### PR TITLE
Add planner-agent dockerfile

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,0 +1,25 @@
+# Builder container
+FROM registry.access.redhat.com/ubi9/go-toolset as builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+USER 0
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o /planner-agent cmd/planner-agent/main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
+
+WORKDIR /app
+
+COPY --from=builder /planner-agent /app/
+
+# Use non-root user
+RUN chown -R 1001:0 /app
+USER 1001
+
+# Run the server
+EXPOSE 3333
+ENTRYPOINT ["/app/planner-agent"]


### PR DESCRIPTION
Use golang 1.21, because that's version used by latest ubi container.