### PR TITLE
chore: Updates .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/rhcos-live.x86_64.iso
 rhcos-live.x86_64.iso
 examples/config.ign
 examples/config.yaml
+*.local.*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ rhcos-live.x86_64.iso
 examples/config.ign
 examples/config.yaml
 *.local.*
+/tmp/


### PR DESCRIPTION
- Ignores a top-level `/tmp` directory (facilitates many things during local development, e.g. it is used by used with https://github.com/air-verse/air for performing hot reloading)
- Ignores `*.local.*` files to allow having custom config copies that we don't want to commit to VCS