### PR TITLE
chore: Updates the planner-db deployment script

### DIFF
--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -1,13 +1,12 @@
 deploy-db:
 	podman rm -f planner-db || true
 	podman volume rm podman_planner-db || true
-	podman volume create --opt device=tmpfs --opt type=tmpfs --opt o=nodev,noexec podman_planner-db
-	cd deploy/podman && podman-compose up -d planner-db
+	podman-compose -f deploy/podman/compose.yaml up -d planner-db
 	test/scripts/wait_for_postgres.sh podman
 	podman exec -it planner-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
 	podman exec -it planner-db createdb admin || true
 
 kill-db:
-	cd deploy/podman && podman-compose down planner-db
+	podman-compose -f deploy/podman/compose.yaml down planner-db
 
 .PHONY: deploy-db kill-db

--- a/deploy/podman/compose.yaml
+++ b/deploy/podman/compose.yaml
@@ -1,5 +1,3 @@
-version: '4.4'
-
 services:
   planner-db:
     container_name: planner-db
@@ -18,8 +16,13 @@ services:
     networks:
       - planner-network
     restart: unless-stopped
-
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 volumes:
   planner-db:
+    driver_opts:
+      type: "tmpfs"  
+      device: "tmpfs" 
+      o: "nodev,noexec"
 networks:
-  planner-network:
+  planner-network:    


### PR DESCRIPTION
Details:
- Removes the top-level version field because it is obsolete (see https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete) and clutters the logs
- Moves the volume definition from the makefile into compose.yaml
- Adds host.docker.internal to /etc/hosts to facilitate debugging the DB

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
