### PR TITLE
feat!: Implements the agent's internal file server

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,7 +59,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 	}(ctx)
 
-	StartREST(a.log, a.config.DataDir)
+	StartServer(a.log, a.config)
 
 	client, err := newPlannerClient(a.config)
 	if err != nil {

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -22,10 +22,10 @@ const (
 	DefaultConfigFile = DefaultConfigDir + "/config.yaml"
 	// DefaultDataDir is the default directory where the agent's data is stored
 	DefaultDataDir = "/var/lib/planner"
+	// DefaultWwwDir is the default directory from which the agent serves static files
+	DefaultWwwDir = "/var/www/planner"
 	// DefaultPlannerEndpoint is the default address of the migration planner server
 	DefaultPlannerEndpoint = "https://localhost:7443"
-	// DefaultCredUIPort is the default port for the credentials UI
-	DefaultCredUIPort = "8443"
 )
 
 type Config struct {
@@ -33,6 +33,8 @@ type Config struct {
 	ConfigDir string `json:"config-dir"`
 	// DataDir is the directory where the agent's data is stored
 	DataDir string `json:"data-dir"`
+	// WwwDir is the directory from which the agent serves static files
+	WwwDir string `json:"www-dir"`
 	// SourceID is the ID of this source in the planner
 	SourceID string `json:"source-id"`
 
@@ -41,8 +43,6 @@ type Config struct {
 
 	// UpdateInterval is the interval between two status updates
 	UpdateInterval util.Duration `json:"update-interval,omitempty"`
-
-	CredUIPort string `json:"cred-ui-port"`
 
 	// LogLevel is the level of logging. can be:  "panic", "fatal", "error", "warn"/"warning",
 	// "info", "debug" or "trace", any other will be treated as "info"
@@ -68,11 +68,11 @@ func NewDefault() *Config {
 	c := &Config{
 		ConfigDir:      DefaultConfigDir,
 		DataDir:        DefaultDataDir,
+		WwwDir:         DefaultWwwDir,
 		PlannerService: PlannerService{Config: *client.NewDefault()},
 		UpdateInterval: util.Duration{Duration: DefaultUpdateInterval},
 		reader:         fileio.NewReader(),
 		LogLevel:       logrus.InfoLevel.String(),
-		CredUIPort:     DefaultCredUIPort,
 	}
 	c.PlannerService.Service.Server = DefaultPlannerEndpoint
 

--- a/internal/agent/fileserver.go
+++ b/internal/agent/fileserver.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"net/http"
+	"path/filepath"
+	"strconv"
+
+	"github.com/go-chi/chi"
+	"github.com/kubev2v/migration-planner/internal/agent/fileio"
+	"github.com/kubev2v/migration-planner/pkg/log"
+)
+
+func RegisterFileServer(router *chi.Mux, log *log.PrefixLogger, wwwDir string) {
+	fs := http.FileServer(http.Dir(wwwDir))
+
+	router.Get("/login", handleGetLogin(log, wwwDir))
+	router.Method("GET", "/*", fs)
+}
+
+func handleGetLogin(log *log.PrefixLogger, wwwDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pathToIndeHtml := filepath.Join(wwwDir, "index.html")
+		file, err := fileio.NewReader().ReadFile(pathToIndeHtml)
+		if err != nil {
+			log.Warnf("Failed reading %s", pathToIndeHtml)
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Length", strconv.Itoa(len(file)))
+		w.Write(file)
+	}
+}

--- a/internal/agent/rest.go
+++ b/internal/agent/rest.go
@@ -33,8 +33,8 @@ func RegisterApi(router *chi.Mux, log *log.PrefixLogger, dataDir string) {
 }
 
 type StatusReply struct {
-	Status     string
-	StatusInfo string
+	Status     string `json:"status"`
+	StatusInfo string `json:"statusInfo"`
 }
 
 func (s StatusReply) Render(w http.ResponseWriter, r *http.Request) error {

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/kubev2v/migration-planner/pkg/log"
+)
+
+func StartServer(log *log.PrefixLogger, config *Config) {
+	router := chi.NewRouter()
+	router.Use(middleware.RequestID)
+	router.Use(middleware.Logger)
+
+	RegisterFileServer(router, log, config.WwwDir)
+	RegisterApi(router, log, config.DataDir)
+
+	server := &http.Server{Addr: "0.0.0.0:3333", Handler: router}
+	serverCtx, serverStopCtx := context.WithCancel(context.Background())
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-sig
+		shutdownCtx, _ := context.WithTimeout(serverCtx, 30*time.Second) // nolint:govet
+
+		go func() {
+			<-shutdownCtx.Done()
+			if shutdownCtx.Err() == context.DeadlineExceeded {
+				log.Fatal("graceful shutdown timed out.. forcing exit.")
+			}
+		}()
+
+		// Trigger graceful shutdown
+		err := server.Shutdown(shutdownCtx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		serverStopCtx()
+	}()
+
+	go func() {
+		// Run the server
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+
+		// Wait for server context to be stopped
+		<-serverCtx.Done()
+	}()
+}


### PR DESCRIPTION
Details:
- Adds an internal file server for serving the UI from within the VM/Agent. The directory holding these files is exposed through the www-dir configuration parameter.
- Prefixes the internal /credentials and /status API endpoints with `/api/v1/...` to differentiate them from the  /login endpoint which is used to display the login form
- Adds an additional field to the Credentials payload: `isDataSharingAllowed` for future use as part of that feature.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
