### PR TITLE
agent/fileserver: Fix lint errcheck

### DIFF
--- a/internal/agent/fileserver.go
+++ b/internal/agent/fileserver.go
@@ -27,6 +27,8 @@ func handleGetLogin(log *log.PrefixLogger, wwwDir string) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "text/html")
 		w.Header().Set("Content-Length", strconv.Itoa(len(file)))
-		w.Write(file)
+		if _, err := w.Write(file); err != nil {
+			log.Warnf("Failed writing the content of %s", pathToIndeHtml)
+		}
 	}
 }


### PR DESCRIPTION
This PR fix the lint error errcheck when writing the content of the index file into the ResponseWriter is not handled.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>