### PR TITLE
planner-api: Split the main into commands

### DIFF
--- a/Containerfile.api
+++ b/Containerfile.api
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 
 USER 0
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o /planner-api cmd/planner-api/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o /planner-api cmd/planner-api/*.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
@@ -25,4 +25,4 @@ USER 1001
 
 # Run the server
 EXPOSE 3443
-ENTRYPOINT ["/app/planner-api"]
+ENTRYPOINT ["/bin/bash", "-c", "/app/planner-api run"]

--- a/cmd/planner-api/main.go
+++ b/cmd/planner-api/main.go
@@ -1,85 +1,10 @@
 package main
 
-import (
-	"context"
-	"net"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/kubev2v/migration-planner/internal/api_server/agentserver"
-	"github.com/kubev2v/migration-planner/internal/config"
-	"github.com/kubev2v/migration-planner/pkg/log"
-	"github.com/sirupsen/logrus"
-
-	apiserver "github.com/kubev2v/migration-planner/internal/api_server"
-
-	"github.com/kubev2v/migration-planner/internal/store"
-)
+import "os"
 
 func main() {
-	log := log.InitLogs()
-	log.Println("Starting API service")
-	defer log.Println("API service stopped")
-
-	cfg, err := config.LoadOrGenerate(config.ConfigFile())
+	err := rootCmd.Execute()
 	if err != nil {
-		log.Fatalf("reading configuration: %v", err)
+		os.Exit(1)
 	}
-	log.Printf("Using config: %s", cfg)
-
-	logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
-	if err != nil {
-		logLvl = logrus.InfoLevel
-	}
-	log.SetLevel(logLvl)
-
-	log.Println("Initializing data store")
-	db, err := store.InitDB(cfg, log)
-	if err != nil {
-		log.Fatalf("initializing data store: %v", err)
-	}
-
-	store := store.NewStore(db, log.WithField("pkg", "store"))
-	defer store.Close()
-
-	if err := store.InitialMigration(); err != nil {
-		log.Fatalf("running initial migration: %v", err)
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
-	go func() {
-		listener, err := newListener(cfg.Service.Address)
-		if err != nil {
-			log.Fatalf("creating listener: %s", err)
-		}
-
-		server := apiserver.New(log, cfg, store, listener)
-		if err := server.Run(ctx); err != nil {
-			log.Fatalf("Error running server: %s", err)
-		}
-		cancel()
-	}()
-
-	go func() {
-		listener, err := newListener(cfg.Service.AgentEndpointAddress)
-		if err != nil {
-			log.Fatalf("creating listener: %s", err)
-		}
-
-		agentserver := agentserver.New(log, cfg, store, listener)
-		if err := agentserver.Run(ctx); err != nil {
-			log.Fatalf("Error running server: %s", err)
-		}
-		cancel()
-	}()
-
-	<-ctx.Done()
-}
-
-func newListener(address string) (net.Listener, error) {
-	if address == "" {
-		address = "localhost:0"
-	}
-	return net.Listen("tcp", address)
 }

--- a/cmd/planner-api/migrate.go
+++ b/cmd/planner-api/migrate.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/internal/store"
+	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate the db",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := log.InitLogs()
+		log.Println("Starting API service")
+		defer log.Println("Db migrated")
+
+		if configFile == "" {
+			configFile = config.ConfigFile()
+		}
+
+		cfg, err := config.Load(configFile)
+		if err != nil {
+			log.Fatalf("reading configuration: %v", err)
+		}
+		log.Printf("Using config: %s", cfg)
+
+		logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
+		if err != nil {
+			logLvl = logrus.InfoLevel
+		}
+		log.SetLevel(logLvl)
+
+		log.Println("Initializing data store")
+		db, err := store.InitDB(cfg, log)
+		if err != nil {
+			log.Fatalf("initializing data store: %v", err)
+		}
+
+		store := store.NewStore(db, log.WithField("pkg", "store"))
+		defer store.Close()
+
+		if err := store.InitialMigration(); err != nil {
+			log.Fatalf("running initial migration: %v", err)
+		}
+
+		return nil
+	},
+}

--- a/cmd/planner-api/root.go
+++ b/cmd/planner-api/root.go
@@ -1,0 +1,18 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var (
+	configFile string
+)
+
+var rootCmd = &cobra.Command{
+	Use: "planner-api",
+}
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+	rootCmd.AddCommand(runCmd)
+
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Path to configuration file")
+}

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	apiserver "github.com/kubev2v/migration-planner/internal/api_server"
+	"github.com/kubev2v/migration-planner/internal/api_server/agentserver"
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/internal/store"
+	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the planner api",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log := log.InitLogs()
+		log.Println("Starting API service")
+		defer log.Println("API service stopped")
+
+		if configFile == "" {
+			configFile = config.ConfigFile()
+		}
+		cfg, err := config.NewFromFile(configFile)
+		if err != nil {
+			log.Fatalf("reading configuration: %v", err)
+		}
+		log.Printf("Using config: %s", cfg)
+
+		logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
+		if err != nil {
+			logLvl = logrus.InfoLevel
+		}
+		log.SetLevel(logLvl)
+
+		log.Println("Initializing data store")
+		db, err := store.InitDB(cfg, log)
+		if err != nil {
+			log.Fatalf("initializing data store: %v", err)
+		}
+
+		store := store.NewStore(db, log.WithField("pkg", "store"))
+		defer store.Close()
+
+		if err := store.InitialMigration(); err != nil {
+			log.Fatalf("running initial migration: %v", err)
+		}
+
+		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+		go func() {
+			defer cancel()
+			listener, err := newListener(cfg.Service.Address)
+			if err != nil {
+				log.Fatalf("creating listener: %s", err)
+			}
+
+			server := apiserver.New(log, cfg, store, listener)
+			if err := server.Run(ctx); err != nil {
+				log.Fatalf("Error running server: %s", err)
+			}
+		}()
+
+		go func() {
+			defer cancel()
+			listener, err := newListener(cfg.Service.AgentEndpointAddress)
+			if err != nil {
+				log.Fatalf("creating listener: %s", err)
+			}
+
+			agentserver := agentserver.New(log, cfg, store, listener)
+			if err := agentserver.Run(ctx); err != nil {
+				log.Fatalf("Error running server: %s", err)
+			}
+		}()
+
+		<-ctx.Done()
+		return nil
+	},
+}
+
+func newListener(address string) (net.Listener, error) {
+	if address == "" {
+		address = "localhost:0"
+	}
+	return net.Listen("tcp", address)
+}


### PR DESCRIPTION
This PR splits the main file into commands to have another command _migrate_ along with the _run_ command.

The `main.go` functionality was moved into `run` command and a new command `migrate` is added that is only migrating the db. The `migrate` command is needed to migrate db during unit tests.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>