### PR TITLE
Use host network for podman containers

### DIFF
--- a/data/ignition.template
+++ b/data/ignition.template
@@ -72,14 +72,6 @@ storage:
         name: core
       group:
         name: core
-    - path: /home/core/.config/containers/systemd/agent.network
-      contents:
-        inline: |
-          [Network]
-      user:
-        name: core
-      group:
-        name: core
     - path: /home/core/.config/containers/systemd/planner-agent.container
       mode: 0644
       contents:
@@ -95,8 +87,8 @@ storage:
           Exec= -config /agent/config/config.yaml
           PublishPort=3333:3333
           Volume=/home/core/.migration-planner:/agent:Z
-          Environment=OPA_SERVER=opa:8181
-          Network=agent.network
+          Environment=OPA_SERVER=127.0.0.1:8181
+          Network=host
           UserNS=keep-id:uid=1001
 
           [Install]
@@ -115,7 +107,7 @@ storage:
           Entrypoint=/usr/bin/opa
           PublishPort=8181:8181
           Exec=run --server /usr/share/opa/policies
-          Network=agent.network
+          Network=host
 
           [Install]
           WantedBy=multi-user.target default.target

--- a/internal/agent/inventory.go
+++ b/internal/agent/inventory.go
@@ -84,6 +84,7 @@ func (u *InventoryUpdater) initializeCredentialUrl() {
 
 	localAddr := conn.LocalAddr().(*net.TCPAddr)
 	u.credUrl = fmt.Sprintf("http://%s:%d", localAddr.IP.String(), agentPort)
+	u.log.Infof("Discovered Agent IP address: %s", u.credUrl)
 }
 
 func calculateStatus(dataDir string) (api.SourceStatus, string, *api.Inventory) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,6 +41,18 @@ var _ = Describe("e2e", func() {
 		Eventually(func() bool {
 			return agent.IsServiceRunning(agentIP, "planner-agent")
 		}, "3m", "2s").Should(BeTrue())
+
+		Eventually(func() string {
+			s, err := svc.GetSource()
+			if err != nil {
+				return ""
+			}
+			if s.CredentialUrl != nil {
+				return *s.CredentialUrl
+			}
+
+			return ""
+		}, "3m", "2s").Should(Equal(fmt.Sprintf("http://%s:3333", agentIP)))
 	})
 
 	AfterEach(func() {
@@ -54,8 +66,11 @@ var _ = Describe("e2e", func() {
 
 	Context("Flow", func() {
 		It("Up to date", func() {
+			// Check that planner-agent service is running
 			r := agent.IsServiceRunning(agentIP, "planner-agent")
 			Expect(r).To(BeTrue())
+
+			// Put the vCenter credentials and check that source is up to date eventually
 			err = agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "user", "pass")
 			Expect(err).To(BeNil())
 			Eventually(func() bool {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ECOPROJECT-2316

This PR changes the network of the containers to be host network, because of the mechanis we report the credenetials URL. In order to get the real host IP instead of the container IP.