### PR TITLE
Generate default config file on run when missing

### DIFF
--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -27,11 +27,10 @@ var runCmd = &cobra.Command{
 		if configFile == "" {
 			configFile = config.ConfigFile()
 		}
-		cfg, err := config.NewFromFile(configFile)
+		cfg, err := config.LoadOrGenerate(configFile)
 		if err != nil {
 			log.Fatalf("reading configuration: %v", err)
 		}
-		log.Printf("Using config: %s", cfg)
 
 		logLvl, err := logrus.ParseLevel(cfg.Service.LogLevel)
 		if err != nil {


### PR DESCRIPTION
Seems we lost the autogeneration of the config file during latest refactoring. Adding it back.