### PR TITLE
store/source: Return source list instead of pointer to list

### DIFF
--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -11,7 +11,7 @@ func (h *ServiceHandler) ListSources(ctx context.Context, request server.ListSou
 	if err != nil {
 		return nil, err
 	}
-	return server.ListSources200JSONResponse(*result), nil
+	return server.ListSources200JSONResponse(result), nil
 }
 
 func (h *ServiceHandler) CreateSource(ctx context.Context, request server.CreateSourceRequestObject) (server.CreateSourceResponseObject, error) {

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Source interface {
-	List(ctx context.Context) (*api.SourceList, error)
+	List(ctx context.Context) (api.SourceList, error)
 	Create(ctx context.Context, sourceCreate api.SourceCreate) (*api.Source, error)
 	DeleteAll(ctx context.Context) error
 	Get(ctx context.Context, id uuid.UUID) (*api.Source, error)
@@ -38,14 +38,13 @@ func (s *SourceStore) InitialMigration(ctx context.Context) error {
 	return s.getDB(ctx).AutoMigrate(&model.Source{})
 }
 
-func (s *SourceStore) List(ctx context.Context) (*api.SourceList, error) {
+func (s *SourceStore) List(ctx context.Context) (api.SourceList, error) {
 	var sources model.SourceList
 	result := s.getDB(ctx).Model(&sources).Order("id").Find(&sources)
 	if result.Error != nil {
 		return nil, result.Error
 	}
-	apiSourceList := sources.ToApiResource()
-	return &apiSourceList, nil
+	return sources.ToApiResource(), nil
 }
 
 func (s *SourceStore) Create(ctx context.Context, sourceCreate api.SourceCreate) (*api.Source, error) {

--- a/internal/store/source_test.go
+++ b/internal/store/source_test.go
@@ -46,13 +46,13 @@ var _ = Describe("source store", Ordered, func() {
 
 			sources, err := s.Source().List(context.TODO())
 			Expect(err).To(BeNil())
-			Expect(*sources).To(HaveLen(2))
+			Expect(sources).To(HaveLen(2))
 		})
 
 		It("list all sources -- no sources", func() {
 			sources, err := s.Source().List(context.TODO())
 			Expect(err).To(BeNil())
-			Expect(*sources).To(HaveLen(0))
+			Expect(sources).To(HaveLen(0))
 		})
 
 		AfterEach(func() {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Store", Ordered, func() {
 			sources, err := store.Source().List(ctx)
 			Expect(err).To(BeNil())
 			Expect(sources).NotTo(BeNil())
-			Expect(*sources).To(HaveLen(1))
+			Expect(sources).To(HaveLen(1))
 
 			// rollback
 			_, cerr := st.Rollback(ctx)


### PR DESCRIPTION
Change the returned value for _List_ method to return a list instead of a pointer to list.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>