### PR TITLE
store/test: Don't drop table after transaction unit tests

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -27,14 +27,9 @@ var _ = Describe("Store", Ordered, func() {
 
 		store = st.NewStore(db, log.WithField("test", "store"))
 		Expect(store).ToNot(BeNil())
-
-		// migrate
-		err = store.InitialMigration()
-		Expect(err).To(BeNil())
 	})
 
 	AfterAll(func() {
-		gormDB.Exec("DROP TABLE sources;")
 		store.Close()
 	})
 


### PR DESCRIPTION
Fix bug that crashes the unit test because the transaction tests are dropping the tables.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>