### PR TITLE
service/agent: Fix bug when soft-deleted agents are listed

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *ServiceHandler) ListAgents(ctx context.Context, request server.ListAgentsRequestObject) (server.ListAgentsResponseObject, error) {
-	result, err := h.store.Agent().List(ctx, store.NewAgentQueryFilter(), store.NewAgentQueryOptions().WithIncludeSoftDeleted(true))
+	result, err := h.store.Agent().List(ctx, store.NewAgentQueryFilter(), store.NewAgentQueryOptions().WithIncludeSoftDeleted(false))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When list endpoint is called, the soft-deleted agents are present in the response but the soft-deleted agents should be present in the response.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>