### PR TITLE
Expose agent /url endpoint to get UI URL

### DIFF
--- a/data/ignition.template
+++ b/data/ignition.template
@@ -87,6 +87,7 @@ storage:
           planner-service:
             service:
               server: {{.PlannerService}}
+              ui: {{.PlannerServiceUI}}
       mode: 0644
       user:
         name: core

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -97,7 +97,7 @@ func (a *Agent) start(ctx context.Context, plannerClient client.Planner) {
 	statusUpdater := service.NewStatusUpdater(a.id, version, a.credUrl, a.config, plannerClient)
 
 	// start server
-	a.server = NewServer(defaultAgentPort, a.config.DataDir, a.config.WwwDir)
+	a.server = NewServer(defaultAgentPort, a.config)
 	go a.server.Start(statusUpdater)
 
 	// get the credentials url

--- a/internal/agent/rest.go
+++ b/internal/agent/rest.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func RegisterApi(router *chi.Mux, statusUpdater *service.StatusUpdater, dataDir string) {
+func RegisterApi(router *chi.Mux, statusUpdater *service.StatusUpdater, configuration *config.Config) {
 	router.Get("/api/v1/version", func(w http.ResponseWriter, r *http.Request) {
 		_ = render.Render(w, r, VersionReply{Version: version})
 	})
@@ -31,8 +31,11 @@ func RegisterApi(router *chi.Mux, statusUpdater *service.StatusUpdater, dataDir 
 		status, statusInfo, _ := statusUpdater.CalculateStatus()
 		_ = render.Render(w, r, StatusReply{Status: string(status), StatusInfo: statusInfo})
 	})
+	router.Get("/api/v1/url", func(w http.ResponseWriter, r *http.Request) {
+		_ = render.Render(w, r, ServiceUIReply{URL: configuration.PlannerService.Service.UI})
+	})
 	router.Put("/api/v1/credentials", func(w http.ResponseWriter, r *http.Request) {
-		credentialHandler(dataDir, w, r)
+		credentialHandler(configuration.DataDir, w, r)
 	})
 }
 
@@ -43,6 +46,14 @@ type StatusReply struct {
 
 type VersionReply struct {
 	Version string `json:"version"`
+}
+
+type ServiceUIReply struct {
+	URL string `json:"url"`
+}
+
+func (s ServiceUIReply) Render(w http.ResponseWriter, r *http.Request) error {
+	return nil
 }
 
 func (s StatusReply) Render(w http.ResponseWriter, r *http.Request) error {

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/kubev2v/migration-planner/internal/agent/config"
 	"github.com/kubev2v/migration-planner/internal/agent/service"
 	"go.uber.org/zap"
 )
@@ -19,17 +20,19 @@ Server serves 3 endpoints:
 - /api/v1/status return the status of the agent.
 */
 type Server struct {
-	port       int
-	dataFolder string
-	wwwFolder  string
-	restServer *http.Server
+	port          int
+	dataFolder    string
+	wwwFolder     string
+	configuration *config.Config
+	restServer    *http.Server
 }
 
-func NewServer(port int, dataFolder, wwwFolder string) *Server {
+func NewServer(port int, configuration *config.Config) *Server {
 	return &Server{
-		port:       port,
-		dataFolder: dataFolder,
-		wwwFolder:  wwwFolder,
+		port:          port,
+		dataFolder:    configuration.DataDir,
+		wwwFolder:     configuration.WwwDir,
+		configuration: configuration,
 	}
 }
 
@@ -39,7 +42,7 @@ func (s *Server) Start(statusUpdater *service.StatusUpdater) {
 	router.Use(middleware.Logger)
 
 	RegisterFileServer(router, s.wwwFolder)
-	RegisterApi(router, statusUpdater, s.dataFolder)
+	RegisterApi(router, statusUpdater, s.configuration)
 
 	s.restServer = &http.Server{Addr: fmt.Sprintf("0.0.0.0:%d", s.port), Handler: router}
 

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -39,6 +39,7 @@ type Config struct {
 type Service struct {
 	// Server is the URL of the Planner API server (the part before /api/v1/...).
 	Server string `json:"server"`
+	UI     string `json:"ui"`
 }
 
 func (c *Config) Equal(c2 *Config) bool {

--- a/internal/image/ova.go
+++ b/internal/image/ova.go
@@ -29,6 +29,7 @@ type Ova struct {
 // IgnitionData defines modifiable fields in ignition config
 type IgnitionData struct {
 	SshKey                     string
+	PlannerServiceUI           string
 	PlannerService             string
 	MigrationPlannerAgentImage string
 	InsecureRegistry           string
@@ -141,6 +142,7 @@ func writeOvf(tw *tar.Writer) error {
 func (o *Ova) generateIgnition() (string, error) {
 	ignData := IgnitionData{
 		PlannerService:             util.GetEnv("CONFIG_SERVER", "http://127.0.0.1:7443"),
+		PlannerServiceUI:           util.GetEnv("CONFIG_SERVER_UI", "http://localhost:3000/migrate/wizard"),
 		MigrationPlannerAgentImage: util.GetEnv("MIGRATION_PLANNER_AGENT_IMAGE", "quay.io/kubev2v/migration-planner-agent"),
 	}
 	if o.SshKey != nil {


### PR DESCRIPTION
In order to provide proper UI link in the Agent login page, we need to pass the UI link to the agent same as we do pass the link for the Agent API.

The URL call is used here: https://github.com/kubev2v/migration-planner-ui/pull/53