### PR TITLE
agent/run: Show log when config validation failed

### DIFF
--- a/cmd/planner-agent/main.go
+++ b/cmd/planner-agent/main.go
@@ -34,6 +34,12 @@ type agentCmd struct {
 }
 
 func NewAgentCommand() *agentCmd {
+	logger := log.InitLog(zap.NewAtomicLevelAt(zapcore.InfoLevel))
+	defer func() { _ = logger.Sync() }()
+
+	undo := zap.ReplaceGlobals(logger)
+	defer undo()
+
 	a := &agentCmd{
 		config: config.NewDefault(),
 	}


### PR DESCRIPTION
This PR fixes a bug when config validation is not logged on stdout.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>