### PR TITLE
Bug-fix : Race condition in systemd units start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ deploy-on-kind:
 	$(KUBECTL) apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f 'deploy/k8s/*-service.yaml'
 	$(KUBECTL) apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f 'deploy/k8s/*-secret.yaml'
 	@config_server=$$(ip addr show ${IFACE}| grep -oP '(?<=inet\s)\d+\.\d+\.\d+\.\d+'); \
-	$(KUBECTL) create secret generic migration-planner-secret -n "${MIGRATION_PLANNER_NAMESPACE}" --from-literal=config_server=http://$$config_server:7443 || true
+	$(KUBECTL) create secret generic migration-planner-secret -n "${MIGRATION_PLANNER_NAMESPACE}" --from-literal=config_server=http://$$config_server:7443 --from-literal=config_server_ui=https://$$config_server_ui/migrate/wizard || true
 	$(KUBECTL) apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f deploy/k8s/
 
 deploy-on-openshift:

--- a/data/ignition.template
+++ b/data/ignition.template
@@ -107,6 +107,7 @@ storage:
           [Unit]
           Description=Planner agent quadlet
           Wants=planner-agent-opa.service
+          After=planner-agent-opa.service
 
           [Container]
           Image={{.MigrationPlannerAgentImage}}


### PR DESCRIPTION
Hi,

Here is a fix for the bug we identified: "Race condition in systemd unit start."

This fix also resolves the failure of the "Deploy assisted-migration" step when running the "run e2e test" workflow, which has been occurring for the past two weeks.

