### PR TITLE
Fix lint timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,4 +89,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          args: --timeout=2m
+          args: --timeout=5m


### PR DESCRIPTION
Pipeline fails because the lint timeout of 2min is too short. 

This MR increases the timeout to 5min.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>