### PR TITLE
Improve the end-to-end tests and fix the issue with 'BeforeEach' code block

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Deploy vcsim
         run: |
-          kubectl create deployment vcsim --image=docker.io/vmware/vcsim
+          make deploy-vsphere-simulator
           kubectl wait --for=condition=Ready pods --all --timeout=240s
           kubectl port-forward --address 0.0.0.0 deploy/vcsim 8989:8989 &
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ push-containers: build-containers
 	$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):latest
 	$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG)
 
+deploy-vsphere-simulator:
+	$(KUBECTL) apply -f 'deploy/k8s/vcsim.yaml'
+
 deploy-on-kind:
 	sed "s|@MIGRATION_PLANNER_AGENT_IMAGE@|$(MIGRATION_PLANNER_AGENT_IMAGE)|g; \
              s|@INSECURE_REGISTRY@|$(INSECURE_REGISTRY)|g; \

--- a/deploy/k8s/migration-planner.yaml
+++ b/deploy/k8s/migration-planner.yaml
@@ -46,7 +46,6 @@ spec:
             - name:  INSECURE_REGISTRY
               value: "true"
           volumeMounts:
-          volumeMounts:
             - name: migration-planner-config
               mountPath: "/.migration-planner/config.yaml"
               subPath: config.yaml

--- a/deploy/k8s/vcsim.yaml
+++ b/deploy/k8s/vcsim.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  generation: 1
+  labels:
+    app: vcsim
+  name: vcsim
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: vcsim
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vcsim
+    spec:
+      containers:
+        - name: vcsim
+          image: docker.io/vmware/vcsim
+          imagePullPolicy: Always
+          args: ["-l", "0.0.0.0:8989", "-username", "core", "-password", "123456"]
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/internal/agent/rest.go
+++ b/internal/agent/rest.go
@@ -132,7 +132,7 @@ func testVmwareConnection(requestCtx context.Context, credentials *config.Creden
 	err = client.Login(ctx, u.User)
 	if err != nil {
 		err = liberr.Wrap(err)
-		if strings.Contains(err.Error(), "incorrect") && strings.Contains(err.Error(), "password") {
+		if strings.Contains(err.Error(), "Login failure") {
 			return http.StatusUnauthorized, err
 		}
 		return http.StatusBadRequest, err

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,11 +22,11 @@ var _ = Describe("e2e", func() {
 
 	BeforeEach(func() {
 		svc, err = NewPlannerService(defaultConfigPath)
-		Expect(err).To(BeNil())
+		Expect(err).To(BeNil(), "Failed to create PlannerService")
 		agent, err = NewPlannerAgent(defaultConfigPath, vmName)
-		Expect(err).To(BeNil())
+		Expect(err).To(BeNil(), "Failed to create PlannerAgent")
 		err = agent.Run()
-		Expect(err).To(BeNil())
+		Expect(err).To(BeNil(), "Failed to run PlannerAgent")
 		Eventually(func() string {
 			agentIP, err = agent.GetIp()
 			if err != nil {
@@ -40,7 +40,7 @@ var _ = Describe("e2e", func() {
 		}, "3m", "2s").Should(BeTrue())
 
 		Eventually(func() string {
-			s, err := svc.GetAgent()
+			s, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
 			if err != nil {
 				return ""
 			}
@@ -50,9 +50,19 @@ var _ = Describe("e2e", func() {
 
 			return ""
 		}, "3m", "2s").Should(Equal(fmt.Sprintf("http://%s:3333", agentIP)))
+
+		// Check that planner-agent service is running
+		r := agent.IsServiceRunning(agentIP, "planner-agent")
+		Expect(r).To(BeTrue())
 	})
 
 	AfterEach(func() {
+		s, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
+		if err != nil {
+			s = nil
+		}
+		_ = svc.RemoveAgent(s.Id) // remove the agent created within the 'BeforeEach' block from the DB
+
 		_ = svc.RemoveSources()
 		_ = agent.Remove()
 	})
@@ -61,18 +71,55 @@ var _ = Describe("e2e", func() {
 		agent.DumpLogs(agentIP)
 	})
 
+	Context("Check Vcenter login behavior", func() {
+
+		It("should successfully login with valid credentials", func() {
+
+			res, err := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "core", "123456")
+			Expect(err).To(BeNil())
+			Expect(res.StatusCode).To(Equal(http.StatusNoContent))
+
+		})
+
+		It("Two test combined: should return BadRequest due to an empty username"+
+			" and BadRequest due to an empty password", func() {
+
+			res1, err1 := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "", "pass")
+			Expect(err1).To(BeNil())
+			Expect(res1.StatusCode).To(Equal(http.StatusBadRequest))
+
+			res2, err2 := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "user", "")
+			Expect(err2).To(BeNil())
+			Expect(res2.StatusCode).To(Equal(http.StatusBadRequest))
+
+		})
+
+		It("should return Unauthorized due to invalid credentials", func() {
+
+			res, err := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "invalid", "cred")
+			Expect(err).To(BeNil())
+			Expect(res.StatusCode).To(Equal(http.StatusUnauthorized))
+
+		})
+
+		It("should return badRequest due to an invalid URL", func() {
+
+			res, err := agent.Login(fmt.Sprintf("https://%s", systemIP), "user", "pass") // bad link to Vcenter environment
+			Expect(err).To(BeNil())
+			Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+
+		})
+
+	})
+
 	Context("Flow", func() {
 		It("Up to date", func() {
-			// Check that planner-agent service is running
-			r := agent.IsServiceRunning(agentIP, "planner-agent")
-			Expect(r).To(BeTrue())
-
 			// Put the vCenter credentials and check that source is up to date eventually
-			res, err := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "user", "pass")
+			res, err := agent.Login(fmt.Sprintf("https://%s:8989/sdk", systemIP), "core", "123456")
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusNoContent))
 			Eventually(func() bool {
-				apiAgent, err := svc.GetAgent()
+				apiAgent, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
### Hi,

This PR introduces four additional test cases as part of the end-to-end (e2e) tests to validate login behavior under the following scenarios:

1. Valid credentialsI
2. Invalid credentials
3. Empty username or password
4. Invalid URL

To ensure these tests pass, this PR also addresses the following issues:

### BeforeEach and AfterEach Conflict:
Previously, the afterEach block did not remove agent records from the database, even though the associated VM was deleted. This caused failures in the beforeEach block due to unexpected matches between newly created agents and old database records. This has now been fixed.

### Error Handling in testVmwareConnection:
When an error occurred in the testVmwareConnection method, the expected behavior was to return:
Unauthorized (401) for invalid credentials
BadRequest (400) for other errors
However, this logic was broken due to a if statement that checked wrong substring compare to what returned by the vCenter client. The issue has been resolved.

Additionally, the Vcsim (vSphere simulator) used in the e2e tests is now configured with a core username and password (123456) instead of allowing any non-empty credentials by default.

