### PR TITLE
update the testVmwareConnection func to return unauthorized both for …

### DIFF
--- a/internal/agent/rest.go
+++ b/internal/agent/rest.go
@@ -171,7 +171,9 @@ func testVmwareConnection(requestCtx context.Context, credentials *config.Creden
 	err = client.Login(ctx, u.User)
 	if err != nil {
 		err = liberr.Wrap(err)
-		if strings.Contains(err.Error(), "Login failure") {
+		// Cover both the different error messages returns from the production and test environments in case of incorrect credentials
+		if strings.Contains(err.Error(), "Login failure") ||
+			strings.Contains(err.Error(), "incorrect") && strings.Contains(err.Error(), "password") {
 			return http.StatusUnauthorized, err
 		}
 		return http.StatusBadRequest, err


### PR DESCRIPTION
Hi,

Just a small fix that now covering both cases as explained in the commit: [update the testVmwareConnection func to return unauthorized both for the test and production environments](https://github.com/kubev2v/migration-planner/pull/121/commits/b12ee4bad9d2e93d1ae88f26da2fd969addba76f)