### PR TITLE
ECOPROJECT-2524: Add scripts to be triggered by AppSRE jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/config.yaml
 *.local.*
 /tmp/
 cover.out
+/docker-config/

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ DOWNLOAD_RHCOS ?= true
 KUBECTL ?= kubectl
 IFACE ?= eth0
 PODMAN ?= podman
+DOCKER_CONF ?= $(CURDIR)/docker-config
+DOCKER_AUTH_FILE ?= "${DOCKER_CONF}/auth.json"
 
 SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
@@ -108,11 +110,31 @@ build-containers: migration-planner-api-container migration-planner-agent-contai
 
 .PHONY: build-containers
 
-push-containers: build-containers
-	$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):latest
-	$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG)
-	$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):latest
-	$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG)
+quay-login:
+	if [ ! -f "$(DOCKER_AUTH_FILE)" ] && [ -n "$(QUAY_USER)" ] && [ -n "$(QUAY_TOKEN)" ]; then \
+		mkdir -p "$(DOCKER_CONF)"; \
+		$(PODMAN) login --authfile "$(DOCKER_AUTH_FILE)" -u="$(QUAY_USER)" -p="$(QUAY_TOKEN)" quay.io; \
+	fi;
+
+push-api-container: migration-planner-api-container quay-login
+	if [ -f "$(DOCKER_AUTH_FILE)" ]; then \
+		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):latest --authfile $(DOCKER_AUTH_FILE); \
+		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG) --authfile $(DOCKER_AUTH_FILE); \
+	else \
+		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):latest; \
+		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG); \
+	fi;
+
+push-agent-container: migration-planner-agent-container quay-login
+	if [ -f "$(DOCKER_AUTH_FILE)" ]; then \
+		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):latest --authfile=$(DOCKER_AUTH_FILE); \
+		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG) --authfile=$(DOCKER_AUTH_FILE); \
+	else \
+		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):latest; \
+		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG); \
+	fi;
+
+push-containers: push-api-container push-agent-container
 
 deploy-vsphere-simulator:
 	$(KUBECTL) apply -f 'deploy/k8s/vcsim.yaml'

--- a/ci/build-deploy.sh
+++ b/ci/build-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PARENT_DIR"
+
+export MIGRATION_PLANNER_API_IMAGE="${MIGRATION_PLANNER_API_IMAGE:-quay.io/app-sre/migration-planner-api}"
+export MIGRATION_PLANNER_AGENT_IMAGE="${MIGRATION_PLANNER_AGENT_IMAGE:-quay.io/app-sre/migration-planner-agent}"
+export REGISTRY_TAG="${REGISTRY_TAG:-$(git rev-parse --short=7 HEAD)}"
+
+make push-containers

--- a/ci/pr-check.sh
+++ b/ci/pr-check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PARENT_DIR"
+
+export MIGRATION_PLANNER_API_IMAGE="${MIGRATION_PLANNER_API_IMAGE:-quay.io/app-sre/migration-planner-api}"
+export MIGRATION_PLANNER_AGENT_IMAGE="${MIGRATION_PLANNER_AGENT_IMAGE:-quay.io/app-sre/migration-planner-agent}"
+export REGISTRY_TAG="${REGISTRY_TAG:-pr-test}"
+
+make build-containers


### PR DESCRIPTION
This is done as part of onboarding the service to AppSRE Step: Continuous Integration (https://service.pages.redhat.com/dev-guidelines/docs/appsre/onboarding/continuous-integration) Add two kinds of scripts for the migration-planner-service and migration-discovery-agent:
* Build and deploy containers from main branch
* Verify container build before merge PR This change require changing the Makefile and allow using quay.io creds when pushing image to registry Related PR for AppSRE: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/130293