### PR TITLE
agent: Generate self signed certificate on the fly

### DIFF
--- a/internal/agent/cert_provider.go
+++ b/internal/agent/cert_provider.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+type SelfSignedCertificateProvider struct {
+	ip net.IP
+}
+
+func NewSelfSignedCertificateProvider(credentialAddr *net.TCPAddr) *SelfSignedCertificateProvider {
+	ip := net.IPv4(0, 0, 0, 0)
+	if credentialAddr != nil {
+		ip = credentialAddr.IP
+	}
+
+	return &SelfSignedCertificateProvider{ip: ip}
+}
+
+func (s *SelfSignedCertificateProvider) GetCertificate(expire time.Time) (*x509.Certificate, *rsa.PrivateKey, error) {
+	csr := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().Unix()),
+		Issuer: pkix.Name{
+			Organization: []string{"Red Hat"},
+		},
+		// TODO Verify if these values are OK.
+		Subject: pkix.Name{
+			Country:            []string{"US"},
+			Organization:       []string{"Red Hat"},
+			OrganizationalUnit: []string{"Assisted Migrations"},
+		},
+		IPAddresses:           []net.IP{s.ip},
+		NotBefore:             time.Now(),
+		NotAfter:              expire,
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate rsa private key")
+	}
+
+	certData, err := x509.CreateCertificate(rand.Reader, csr, csr, privateKey.Public(), privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, privateKey, nil
+}

--- a/internal/agent/cert_provider_test.go
+++ b/internal/agent/cert_provider_test.go
@@ -1,0 +1,50 @@
+package agent_test
+
+import (
+	"crypto/x509"
+	"net"
+	"time"
+
+	"github.com/kubev2v/migration-planner/internal/agent"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Certification Provider", func() {
+	Context("self signed certificate", func() {
+		It("generates successfully -- ip 1.2.3.4", func() {
+			certAddr, err := net.ResolveTCPAddr("tcp", "1.2.3.4:3333")
+			Expect(err).To(BeNil())
+
+			cp := agent.NewSelfSignedCertificateProvider(certAddr)
+			cert, key, err := cp.GetCertificate(time.Now().Add(10 * time.Second))
+			Expect(err).To(BeNil())
+			Expect(key).ToNot(BeNil())
+
+			data := x509.MarshalPKCS1PrivateKey(key)
+			Expect(len(data) > 0).To(BeTrue())
+
+			Expect(cert.IPAddresses).To(HaveLen(1))
+			ip := cert.IPAddresses[0]
+			Expect(ip.String()).To(Equal(net.ParseIP("1.2.3.4").String()))
+			Expect(cert.Issuer.Organization).Should(ContainElement("Red Hat"))
+			Expect(cert.Issuer.OrganizationalUnit).Should(ContainElement("Assisted Migrations"))
+		})
+
+		It("generates successfully -- credsURL invalid", func() {
+			cp := agent.NewSelfSignedCertificateProvider(nil)
+			cert, key, err := cp.GetCertificate(time.Now().Add(10 * time.Second))
+			Expect(err).To(BeNil())
+			Expect(key).ToNot(BeNil())
+
+			data := x509.MarshalPKCS1PrivateKey(key)
+			Expect(len(data) > 0).To(BeTrue())
+
+			Expect(cert.IPAddresses).To(HaveLen(1))
+			ip := cert.IPAddresses[0]
+			Expect(ip.String()).To(Equal(net.ParseIP("0.0.0.0").String()))
+			Expect(cert.Issuer.Organization).Should(ContainElement("Red Hat"))
+			Expect(cert.Issuer.OrganizationalUnit).Should(ContainElement("Assisted Migrations"))
+		})
+	})
+})

--- a/test/e2e/e2e_agent_test.go
+++ b/test/e2e/e2e_agent_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -120,7 +121,7 @@ func (p *plannerAgentLibvirt) Version() (string, error) {
 		return "", fmt.Errorf("failed to get agent IP: %w", err)
 	}
 	// Create a new HTTP GET request
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:3333/api/v1/version", agentIP), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s:3333/api/v1/version", agentIP), nil)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create request: %v", err)
 	}
@@ -129,7 +130,11 @@ func (p *plannerAgentLibvirt) Version() (string, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	// Send the request using http.DefaultClient
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("Failed to send request: %v", err)
@@ -165,7 +170,7 @@ func (p *plannerAgentLibvirt) Login(url string, user string, pass string) (*http
 
 	resp, err := http.NewRequest(
 		"PUT",
-		fmt.Sprintf("http://%s:3333/api/v1/credentials", agentIP),
+		fmt.Sprintf("https://%s:3333/api/v1/credentials", agentIP),
 		bytes.NewBuffer(jsonData),
 	)
 	if err != nil {
@@ -173,7 +178,11 @@ func (p *plannerAgentLibvirt) Login(url string, user string, pass string) (*http
 	}
 	resp.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
 	response, err := client.Do(resp)
 	if err != nil {
 		return response, fmt.Errorf("failed to send request: %w", err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,7 +40,7 @@ var _ = Describe("e2e", func() {
 		}, "3m", "2s").Should(BeTrue())
 
 		Eventually(func() string {
-			s, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
+			s, err := svc.GetAgent(fmt.Sprintf("https://%s:3333", agentIP))
 			if err != nil {
 				return ""
 			}
@@ -49,7 +49,7 @@ var _ = Describe("e2e", func() {
 			}
 
 			return ""
-		}, "3m", "2s").Should(Equal(fmt.Sprintf("http://%s:3333", agentIP)))
+		}, "3m", "2s").Should(Equal(fmt.Sprintf("https://%s:3333", agentIP)))
 
 		// Check that planner-agent service is running
 		r := agent.IsServiceRunning(agentIP, "planner-agent")
@@ -57,7 +57,7 @@ var _ = Describe("e2e", func() {
 	})
 
 	AfterEach(func() {
-		s, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
+		s, err := svc.GetAgent(fmt.Sprintf("https://%s:3333", agentIP))
 		if err != nil {
 			s = nil
 		}
@@ -119,7 +119,7 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusNoContent))
 			Eventually(func() bool {
-				apiAgent, err := svc.GetAgent(fmt.Sprintf("http://%s:3333", agentIP))
+				apiAgent, err := svc.GetAgent(fmt.Sprintf("https://%s:3333", agentIP))
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
When agent boots and gets its credential ip, generate a certificate for that ip and use it to setup tls connection for agent's server.

Replaces: #128 

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>