### PR TITLE
bug-fix: agent crash in disconnected environment

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -120,7 +120,11 @@ func (a *Agent) start(ctx context.Context, plannerClient client.Planner) {
 	if a.server.tlsConfig != nil {
 		protocol = "https"
 	}
-	a.credUrl = fmt.Sprintf("%s://%s:%d", protocol, credUrl.IP.String(), defaultAgentPort)
+
+	a.credUrl = "N/A"
+	if credUrl != nil {
+		a.credUrl = fmt.Sprintf("%s://%s:%d", protocol, credUrl.IP.String(), defaultAgentPort)
+	}
 	zap.S().Infof("Discovered Agent IP address: %s", a.credUrl)
 
 	// start the health check


### PR DESCRIPTION
The issue occurs when the service is unreachable. In agent.go, the function initializeCredentialUrl() returns nil:

`credUrl := a.initializeCredentialUrl()`

Later, when composing the string, a nil reference error occurs when calling to credUrl.IP.String():

`a.credUrl = fmt.Sprintf("%s://%s:%d", protocol, credUrl.IP.String(), defaultAgentPort)`

This PR introduce simple solution for the above bug.