### PR TITLE
agent_handler: Add wrapper to log request and response error

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -85,7 +85,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 	)
 
-	h := service.NewAgentServiceHandler(s.store, s.evWriter)
+	h := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s.store, s.evWriter))
 	server.HandlerFromMux(server.NewStrictHandler(h, nil), router)
 	srv := http.Server{Addr: s.cfg.Service.Address, Handler: router}
 

--- a/internal/service/agent/handler_test.go
+++ b/internal/service/agent/handler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateAgentStatus(ctx, server.UpdateAgentStatusRequestObject{
 				Id: agentID,
 				Body: &apiAgent.UpdateAgentStatusJSONRequestBody{
@@ -114,7 +114,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateAgentStatus(ctx, server.UpdateAgentStatusRequestObject{
 				Id: agentID,
 				Body: &apiAgent.UpdateAgentStatusJSONRequestBody{
@@ -167,7 +167,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateAgentStatus(ctx, server.UpdateAgentStatusRequestObject{
 				Id: agentID,
 				Body: &apiAgent.UpdateAgentStatusJSONRequestBody{
@@ -193,7 +193,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateAgentStatus(ctx, server.UpdateAgentStatusRequestObject{
 				Id: uuid.New(),
 				Body: &apiAgent.UpdateAgentStatusJSONRequestBody{
@@ -230,7 +230,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateSourceInventory(ctx, server.UpdateSourceInventoryRequestObject{
 				Id: sourceID,
 				Body: &apiAgent.SourceStatusUpdate{
@@ -276,7 +276,7 @@ var _ = Describe("agent service", Ordered, func() {
 
 			// first agent request
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateSourceInventory(ctx, server.UpdateSourceInventoryRequestObject{
 				Id: sourceID,
 				Body: &apiAgent.SourceStatusUpdate{
@@ -337,7 +337,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateSourceInventory(ctx, server.UpdateSourceInventoryRequestObject{
 				Id: firstSourceID,
 				Body: &apiAgent.SourceStatusUpdate{
@@ -364,7 +364,7 @@ var _ = Describe("agent service", Ordered, func() {
 			ctx := auth.NewUserContext(context.TODO(), user)
 
 			eventWriter := newTestWriter()
-			srv := service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter))
+			srv := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s, events.NewEventProducer(eventWriter)))
 			resp, err := srv.UpdateSourceInventory(ctx, server.UpdateSourceInventoryRequestObject{
 				Id: firstSourceID,
 				Body: &apiAgent.SourceStatusUpdate{

--- a/internal/service/agent/wrapper.go
+++ b/internal/service/agent/wrapper.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+
+	agentServer "github.com/kubev2v/migration-planner/internal/api/server/agent"
+	"go.uber.org/zap"
+)
+
+type AgentServiceHandlerLogger struct {
+	delegate *AgentServiceHandler
+}
+
+func NewAgentServiceHandlerLogger(delegate *AgentServiceHandler) *AgentServiceHandlerLogger {
+	return &AgentServiceHandlerLogger{delegate: delegate}
+}
+
+func (h *AgentServiceHandlerLogger) UpdateSourceInventory(ctx context.Context, request agentServer.UpdateSourceInventoryRequestObject) (agentServer.UpdateSourceInventoryResponseObject, error) {
+	zap.S().Named("agent_handler").Debugw("update source inventory request",
+		"source_id", request.Id,
+		"agent_id", request.Body.AgentId,
+		"inventory", request.Body.Inventory,
+	)
+
+	resp, err := h.delegate.UpdateSourceInventory(ctx, request)
+	if err != nil {
+		zap.S().Named("agent_handler").Errorf("failed to update source inventory: %s", err)
+	}
+
+	return resp, nil
+}
+
+func (h *AgentServiceHandlerLogger) UpdateAgentStatus(ctx context.Context, request agentServer.UpdateAgentStatusRequestObject) (agentServer.UpdateAgentStatusResponseObject, error) {
+	zap.S().Named("agent_handler").Debugw("update agent status request",
+		"agent_id", request.Id,
+		"source_id", request.Body.SourceId,
+		"credential_url", request.Body.CredentialUrl,
+		"status", request.Body.Status,
+		"version", request.Body.Version,
+	)
+
+	resp, err := h.delegate.UpdateAgentStatus(ctx, request)
+	if err != nil {
+		zap.S().Named("agent_handler").Errorf("failed to update agent status: %s", err)
+	}
+
+	return resp, nil
+}
+
+func (h *AgentServiceHandlerLogger) Health(ctx context.Context, request agentServer.HealthRequestObject) (agentServer.HealthResponseObject, error) {
+	return h.delegate.Health(ctx, request)
+}


### PR DESCRIPTION
This PR adds a simple wrapper around agent handler to log the request and error from the actual handler.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>