### PR TITLE
cli/get: Fix table output format and content

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -167,8 +167,12 @@ func printTable(response interface{}, kind string, id *uuid.UUID) error {
 }
 
 func printSourcesTable(w *tabwriter.Writer, sources ...api.Source) {
-	fmt.Fprintln(w, "ID")
+	fmt.Fprintln(w, "ID\tName\tAgent ID\tAgent Status")
 	for _, s := range sources {
-		fmt.Fprintf(w, "%s\n", s.Id)
+		if s.Agent != nil {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Id, s.Name, s.Agent.Id, s.Agent.Status)
+			continue
+		}
+		fmt.Fprintf(w, "%s\t%s\n", s.Id, s.Name)
 	}
 }


### PR DESCRIPTION
The table's output includes agent_id and the agent's status and cred URLs.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>