### PR TITLE
bug-fix: vcsim pod clbo deploying migration-planner (make target) on real OCP env

### DIFF
--- a/deploy/k8s/vcsim-service.yaml
+++ b/deploy/k8s/vcsim-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vcsim
+  name: vcsim
+spec:
+  ports:
+    - name: vcsim
+      port: 8989
+      protocol: TCP
+      targetPort: 8989
+  selector:
+    app: vcsim

--- a/deploy/k8s/vcsim.yaml
+++ b/deploy/k8s/vcsim.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   annotations:
     deployment.kubernetes.io/revision: "1"
-  generation: 1
   labels:
     app: vcsim
   name: vcsim
@@ -21,7 +20,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: vcsim
     spec:
@@ -30,11 +28,15 @@ spec:
           image: docker.io/vmware/vcsim
           imagePullPolicy: Always
           args: ["-l", "0.0.0.0:8989", "-username", "core", "-password", "123456"]
-          resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: { }
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Hi,

This PR is a fix for the bug introduced in [ECOPROJECT-2575](https://issues.redhat.com/browse/ECOPROJECT-2575).