### PR TITLE
Remove authentication disabled flood from log

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/kubev2v/migration-planner/internal/config"
+	"go.uber.org/zap"
 )
 
 type Authenticator interface {
@@ -16,6 +17,8 @@ const (
 )
 
 func NewAuthenticator(authConfig config.Auth) (Authenticator, error) {
+	zap.S().Named("auth").Infof("authentication: '%s'", authConfig.AuthenticationType)
+
 	switch authConfig.AuthenticationType {
 	case RHSSOAuthentication:
 		return NewRHSSOAuthenticator(authConfig.JwtCertUrl)

--- a/internal/auth/none_authenticator.go
+++ b/internal/auth/none_authenticator.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"net/http"
-
-	"go.uber.org/zap"
 )
 
 type NoneAuthenticator struct{}
@@ -14,7 +12,6 @@ func NewNoneAuthenticator() (*NoneAuthenticator, error) {
 
 func (n *NoneAuthenticator) Authenticator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		zap.S().Named("auth").Info("authentication disabled")
 
 		user := User{
 			Username:     "admin",


### PR DESCRIPTION
Previously `authentication disabled` log entry flood the log like this:

```
2025-02-19T11:09:20+01:00	info	auth	auth/none_authenticator.go:17	authentication disabled
2025-02-19T11:09:20+01:00	info	auth	auth/none_authenticator.go:17	authentication disabled
2025-02-19T11:09:20+01:00	info	auth	auth/none_authenticator.go:17	authentication disabled
2025-02-19T11:09:20+01:00	info	auth	auth/none_authenticator.go:17	authentication disabled
2025-02-19T11:09:20+01:00	info	auth	auth/none_authenticator.go:17	authentication disabled
```

This PR remove this log entry, and add the logging of auth mechanism for each server just once in init stage.