### PR TITLE
store/source: Create unique index between name and org_id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/go-chi/chi v1.5.5
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-chi/render v1.0.3
+	github.com/go-openapi/strfmt v0.23.0
+	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/uuid v1.6.0
 	github.com/konveyor/forklift-controller v0.0.0-20221102112227-e73b65a01cda
@@ -23,6 +25,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.32.0
 	github.com/openshift/assisted-image-service v0.0.0-20240827125623-ad5c4b36a817
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
@@ -78,7 +81,6 @@ require (
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -86,8 +88,6 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -135,7 +135,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/xattr v0.4.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/goccy/go-json v0.10.4/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -21,9 +21,8 @@ import (
 
 const (
 	insertAgentStm              = "INSERT INTO agents (id, status, status_info, cred_url,source_id, version) VALUES ('%s', '%s', '%s', '%s', '%s', 'version_1');"
-	insertSourceStm             = "INSERT INTO sources (id, name) VALUES ('%s', '%s');"
 	insertSourceWithUsernameStm = "INSERT INTO sources (id, name, username, org_id) VALUES ('%s', 'source_name', '%s', '%s');"
-	insertSourceOnPremisesStm   = "INSERT INTO sources (id, name, username, org_id, on_premises) VALUES ('%s', 'source_name', '%s', '%s', TRUE);"
+	insertSourceOnPremisesStm   = "INSERT INTO sources (id, name, username, org_id, on_premises) VALUES ('%s', '%s', '%s', '%s', TRUE);"
 )
 
 var _ = Describe("source handler", Ordered, func() {
@@ -78,13 +77,13 @@ var _ = Describe("source handler", Ordered, func() {
 
 		It("successfully list all the sources -- on premises", func() {
 			sourceID := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceOnPremisesStm, sourceID, "admin", "admin"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceOnPremisesStm, sourceID, "source1", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", sourceID))
 			Expect(tx.Error).To(BeNil())
 
 			sourceID = uuid.NewString()
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceOnPremisesStm, sourceID, "admin", "admin"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceOnPremisesStm, sourceID, "source2", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", sourceID))
 			Expect(tx.Error).To(BeNil())

--- a/internal/store/agent_test.go
+++ b/internal/store/agent_test.go
@@ -42,14 +42,14 @@ var _ = Describe("agent store", Ordered, func() {
 	Context("list", func() {
 		It("successfuly list all the agents -- without filter and options", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			agentID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", source1))
 			Expect(tx.Error).To(BeNil())
 
 			source2 := uuid.NewString()
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			agent2ID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agent2ID, "not-connected", "status-info-2", "cred_url-2", source2))
@@ -74,14 +74,14 @@ var _ = Describe("agent store", Ordered, func() {
 
 		It("successfuly list all the agents -- with options order by id", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			agentID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", source1))
 			Expect(tx.Error).To(BeNil())
 
 			source2 := uuid.NewString()
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			agent2ID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agent2ID, "not-connected", "status-info-2", "cred_url-2", source2))
@@ -94,7 +94,7 @@ var _ = Describe("agent store", Ordered, func() {
 
 		It("successfuly list all the agents -- with options order by update_id", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			// 24h from now
 			agentID := uuid.New()
@@ -103,7 +103,7 @@ var _ = Describe("agent store", Ordered, func() {
 
 			// this one should be the first
 			source2 := uuid.NewString()
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			agent1ID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentWithUpdateAtStm, agent1ID, "not-connected", "status-info-2", "cred_url-2", time.Now().Format(time.RFC3339), source2))
@@ -118,10 +118,10 @@ var _ = Describe("agent store", Ordered, func() {
 
 		It("successfuly list the agents -- with filter by source-id", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			source2 := uuid.NewString()
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, source2, "source-2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			agent1ID := uuid.New()
@@ -147,7 +147,7 @@ var _ = Describe("agent store", Ordered, func() {
 	Context("create", func() {
 		It("successfuly creates an agent", func() {
 			sourceID, _ := uuid.NewUUID()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			agentID, _ := uuid.NewUUID()
@@ -187,7 +187,7 @@ var _ = Describe("agent store", Ordered, func() {
 
 		It("successfuly return the agent", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			agentID := uuid.New()
@@ -215,7 +215,7 @@ var _ = Describe("agent store", Ordered, func() {
 			source1 := uuid.NewString()
 			agentID := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", source1))
 			Expect(tx.Error).To(BeNil())
@@ -240,7 +240,7 @@ var _ = Describe("agent store", Ordered, func() {
 		It("successfuly updates an agent -- status-info field", func() {
 			source1 := uuid.NewString()
 			agentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source-1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", source1))
 			Expect(tx.Error).To(BeNil())
@@ -264,7 +264,7 @@ var _ = Describe("agent store", Ordered, func() {
 
 		It("fails updates an agent -- agent is missing", func() {
 			source1 := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, source1))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, source1, "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, "agent-1", "not-connected", "status-info-1", "cred_url-1", source1))
 			Expect(tx.Error).To(BeNil())

--- a/internal/store/model/source.go
+++ b/internal/store/model/source.go
@@ -11,10 +11,10 @@ import (
 type Source struct {
 	gorm.Model
 	ID            uuid.UUID `gorm:"primaryKey; not null"`
-	Name          string    `gorm:"not null"`
+	Name          string    `gorm:"uniqueIndex:name_org_id;not null"`
 	VCenterID     string
 	Username      string
-	OrgID         string
+	OrgID         string                    `gorm:"uniqueIndex:name_org_id;not null"`
 	Inventory     *JSONField[api.Inventory] `gorm:"type:jsonb"`
 	OnPremises    bool
 	SshPublicKey  *string

--- a/internal/store/source_test.go
+++ b/internal/store/source_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	insertSourceStm             = "INSERT INTO sources (id, name) VALUES ('%s', '%s');"
-	insertSourceWithUsernameStm = "INSERT INTO sources (id, name, username, org_id) VALUES ('%s', '%s', '%s', '%s');"
-	insertSourceOnPremisesStm   = "INSERT INTO sources (id, name, username, org_id, on_premises) VALUES ('%s','%s', '%s', '%s', TRUE);"
+	insertSourceStm           = "INSERT INTO sources (id, name, username, org_id) VALUES ('%s', '%s', '%s', '%s');"
+	insertSourceOnPremisesStm = "INSERT INTO sources (id, name, username, org_id, on_premises) VALUES ('%s','%s', '%s', '%s', TRUE);"
 )
 
 var _ = Describe("source store", Ordered, func() {
@@ -41,9 +40,9 @@ var _ = Describe("source store", Ordered, func() {
 
 	Context("list", func() {
 		It("successfully list all the sources", func() {
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1", "user2", "org_id_2"))
 			Expect(tx.Error).To(BeNil())
 
 			sources, err := s.Source().List(context.TODO(), store.NewSourceQueryFilter())
@@ -55,7 +54,7 @@ var _ = Describe("source store", Ordered, func() {
 			sourceID := uuid.NewString()
 			agentID := uuid.NewString()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", sourceID))
@@ -72,7 +71,7 @@ var _ = Describe("source store", Ordered, func() {
 			sourceID := uuid.NewString()
 			agentID := uuid.NewString()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, sourceID, "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", sourceID))
@@ -94,9 +93,9 @@ var _ = Describe("source store", Ordered, func() {
 		})
 
 		It("successfully list the user's sources", func() {
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, uuid.NewString(), "source1", "admin", "admin"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, uuid.NewString(), "source2", "user", "user"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "user", "user"))
 			Expect(tx.Error).To(BeNil())
 
 			sources, err := s.Source().List(context.TODO(), store.NewSourceQueryFilter().ByUsername("admin"))
@@ -106,9 +105,9 @@ var _ = Describe("source store", Ordered, func() {
 		})
 
 		It("successfully list the source on prem", func() {
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, uuid.NewString(), "source1", "admin", "admin"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, uuid.NewString(), "source2", "admin", "admin"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 			tx = gormdb.Exec(fmt.Sprintf(insertSourceOnPremisesStm, uuid.NewString(), "source3", "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
@@ -132,14 +131,14 @@ var _ = Describe("source store", Ordered, func() {
 		It("successfully get a source", func() {
 			id := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			agentID := uuid.New()
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", id.String()))
 			Expect(tx.Error).To(BeNil())
 
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			source, err := s.Source().Get(context.TODO(), id)
@@ -151,9 +150,9 @@ var _ = Describe("source store", Ordered, func() {
 
 		It("failed get a source -- source does not exists", func() {
 			id := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2"))
+			tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "user1", "org_id_1"))
 			Expect(tx.Error).To(BeNil())
 
 			source, err := s.Source().Get(context.TODO(), id)
@@ -185,6 +184,31 @@ var _ = Describe("source store", Ordered, func() {
 				Expect(count).To(Equal(1))
 			})
 
+			It("failed to create source with the same name in org namespace", func() {
+				sourceID := uuid.New()
+				m := model.Source{
+					ID:       sourceID,
+					Username: "admin",
+					OrgID:    "org",
+				}
+				source, err := s.Source().Create(context.TODO(), m)
+				Expect(err).To(BeNil())
+				Expect(source).NotTo(BeNil())
+
+				var count int
+				tx := gormdb.Raw("SELECT COUNT(*) FROM sources;").Scan(&count)
+				Expect(tx.Error).To(BeNil())
+				Expect(count).To(Equal(1))
+
+				m = model.Source{
+					ID:       uuid.New(),
+					Username: "admin",
+					OrgID:    "org",
+				}
+				_, err = s.Source().Create(context.TODO(), m)
+				Expect(err).ToNot(BeNil())
+			})
+
 			AfterEach(func() {
 				gormdb.Exec("DELETE from agents;")
 				gormdb.Exec("DELETE from sources;")
@@ -194,9 +218,9 @@ var _ = Describe("source store", Ordered, func() {
 		Context("delete", func() {
 			It("successfully delete a source", func() {
 				id := uuid.New()
-				tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1"))
+				tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1", "user1", "org_id_1"))
 				Expect(tx.Error).To(BeNil())
-				tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1"))
+				tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "user1", "org_id_1"))
 				Expect(tx.Error).To(BeNil())
 
 				err := s.Source().Delete(context.TODO(), id)
@@ -211,12 +235,12 @@ var _ = Describe("source store", Ordered, func() {
 			It("successfully delete all sources", func() {
 				id := uuid.New()
 				agentID := uuid.New()
-				tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1"))
+				tx := gormdb.Exec(fmt.Sprintf(insertSourceStm, id, "source1", "user1", "org_id_1"))
 				Expect(tx.Error).To(BeNil())
 				tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", id))
 
 				Expect(tx.Error).To(BeNil())
-				tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source1"))
+				tx = gormdb.Exec(fmt.Sprintf(insertSourceStm, uuid.NewString(), "source2", "user1", "org_id_1"))
 				Expect(tx.Error).To(BeNil())
 
 				err := s.Source().DeleteAll(context.TODO())


### PR DESCRIPTION
This PR adds a unique index in the source model to make the name of the source unique in the namespace of the organization.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>