### PR TITLE
Change configuration to use envconfig

### DIFF
--- a/cmd/planner-api/migrate.go
+++ b/cmd/planner-api/migrate.go
@@ -18,18 +18,14 @@ var migrateCmd = &cobra.Command{
 		undo := zap.ReplaceGlobals(logger)
 		defer undo()
 
-		if configFile == "" {
-			configFile = config.ConfigFile()
-		}
-
-		cfg, err := config.Load(configFile)
+		envConfig, err := config.New()
 		if err != nil {
 			zap.S().Fatalf("reading configuration: %v", err)
 		}
-		zap.S().Infof("Using config: %s", cfg)
+		zap.S().Infof("Using config: %s", envConfig)
 
 		zap.S().Info("Initializing data store")
-		db, err := store.InitDB(cfg)
+		db, err := store.InitDB(&envConfig.DB)
 		if err != nil {
 			zap.S().Fatalf("initializing data store: %v", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/uuid v1.6.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/konveyor/forklift-controller v0.0.0-20221102112227-e73b65a01cda
 	github.com/kubev2v/migration-event-streamer v0.0.0-20241125102656-9cdf9e64a16b
 	github.com/leosunmo/zapchi v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=

--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -28,7 +28,8 @@ const (
 )
 
 type AgentServer struct {
-	cfg      *config.Config
+	svcCfg   *config.SvcConfig
+	authCfg  auth.Config
 	store    store.Store
 	listener net.Listener
 	evWriter *events.EventProducer
@@ -36,13 +37,15 @@ type AgentServer struct {
 
 // New returns a new instance of a migration-planner server.
 func New(
-	cfg *config.Config,
+	svcCfg *config.SvcConfig,
+	authCfg auth.Config,
 	store store.Store,
 	ew *events.EventProducer,
 	listener net.Listener,
 ) *AgentServer {
 	return &AgentServer{
-		cfg:      cfg,
+		svcCfg:   svcCfg,
+		authCfg:  authCfg,
 		store:    store,
 		evWriter: ew,
 		listener: listener,
@@ -66,7 +69,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 		ErrorHandler: oapiErrorHandler,
 	}
 
-	authenticator, err := auth.NewAuthenticator(s.cfg.Service.Auth)
+	authenticator, err := auth.NewAuthenticator(s.authCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create authenticator: %w", err)
 	}
@@ -87,7 +90,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 
 	h := service.NewAgentServiceHandlerLogger(service.NewAgentServiceHandler(s.store, s.evWriter))
 	server.HandlerFromMux(server.NewStrictHandler(h, nil), router)
-	srv := http.Server{Addr: s.cfg.Service.Address, Handler: router}
+	srv := http.Server{Addr: s.svcCfg.Address, Handler: router}
 
 	go func() {
 		<-ctx.Done()

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -28,7 +28,7 @@ const (
 )
 
 type ImageServer struct {
-	cfg      *config.Config
+	svcCfg   *config.SvcConfig
 	store    store.Store
 	listener net.Listener
 	evWriter *events.EventProducer
@@ -36,13 +36,13 @@ type ImageServer struct {
 
 // New returns a new instance of a migration-planner server.
 func New(
-	cfg *config.Config,
+	svcCfg *config.SvcConfig,
 	store store.Store,
 	ew *events.EventProducer,
 	listener net.Listener,
 ) *ImageServer {
 	return &ImageServer{
-		cfg:      cfg,
+		svcCfg:   svcCfg,
 		store:    store,
 		evWriter: ew,
 		listener: listener,
@@ -80,9 +80,9 @@ func (s *ImageServer) Run(ctx context.Context) error {
 		apiserver.WithResponseWriter,
 	)
 
-	h := service.NewImageHandler(s.store, s.evWriter, s.cfg)
+	h := service.NewImageHandler(s.store, s.evWriter)
 	server.HandlerFromMux(server.NewStrictHandler(h, nil), router)
-	srv := http.Server{Addr: s.cfg.Service.Address, Handler: router}
+	srv := http.Server{Addr: s.svcCfg.Address, Handler: router}
 
 	go func() {
 		<-ctx.Done()

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,27 +1,33 @@
 package auth
 
 import (
-	"net/http"
-
-	"github.com/kubev2v/migration-planner/internal/config"
 	"go.uber.org/zap"
+	"net/http"
 )
+
+type AuthType string
+
+const (
+	AuthTypeEmpty AuthType = ""
+	AuthTypeRHSSO AuthType = "rhsso"
+	AuthTypeNone  AuthType = "none"
+)
+
+type Config struct {
+	AuthType   AuthType `envconfig:"MIGRATION_PLANNER_AUTH" default:""`
+	JwtCertUrl string   `envconfig:"MIGRATION_PLANNER_JWK_URL" default:""`
+}
 
 type Authenticator interface {
 	Authenticator(next http.Handler) http.Handler
 }
 
-const (
-	RHSSOAuthentication string = "rhsso"
-	NoneAuthentication  string = "none"
-)
+func NewAuthenticator(cfg Config) (Authenticator, error) {
+	zap.S().Named("auth").Infof("authentication: '%s'", cfg.AuthType)
 
-func NewAuthenticator(authConfig config.Auth) (Authenticator, error) {
-	zap.S().Named("auth").Infof("authentication: '%s'", authConfig.AuthenticationType)
-
-	switch authConfig.AuthenticationType {
-	case RHSSOAuthentication:
-		return NewRHSSOAuthenticator(authConfig.JwkCertURL)
+	switch cfg.AuthType {
+	case AuthTypeRHSSO:
+		return NewRHSSOAuthenticator(cfg.JwtCertUrl)
 	default:
 		return NewNoneAuthenticator()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,161 +1,51 @@
 package config
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/IBM/sarama"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"sigs.k8s.io/yaml"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/kubev2v/migration-planner/internal/auth"
+	"github.com/kubev2v/migration-planner/internal/store"
 )
 
 const (
-	appName = "migration-planner"
+	appName         = "migration-planner"
+	EnvConfigPrefix = "MIGRATION_PLANNER"
 )
 
+var singleConfig *Config = nil
+
 type Config struct {
-	Database *dbConfig  `json:"database,omitempty"`
-	Service  *svcConfig `json:"service,omitempty"`
+	Auth  auth.Config
+	DB    store.Config
+	Svc   SvcConfig
+	Kafka KafkaConfig
 }
 
-type dbConfig struct {
-	Type     string `json:"type,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	Port     uint   `json:"port,omitempty"`
-	Name     string `json:"name,omitempty"`
-	User     string `json:"user,omitempty"`
-	Password string `json:"password,omitempty"`
+type SvcConfig struct {
+	Address              string `envconfig:"MIGRATION_PLANNER_ADDRESS" default:":3443"`
+	AgentEndpointAddress string `envconfig:"MIGRATION_PLANNER_AGENT_ENDPOINT_ADDRESS" default:":7443"`
+	ImageEndpointAddress string `envconfig:"MIGRATION_PLANNER_IMAGE_ENDPOINT_ADDRESS" default:":11443"`
+	BaseUrl              string `envconfig:"MIGRATION_PLANNER_BASE_URL" default:"https://localhost:3443"`
+	BaseAgentEndpointUrl string `envconfig:"MIGRATION_PLANNER_BASE_AGENT_ENDPOINT_URL" default:"https://localhost:7443"`
+	BaseImageEndpointUrl string `envconfig:"MIGRATION_PLANNER_BASE_IMAGE_ENDPOINT_URL" default:"https://localhost:11443"`
+	LogLevel             string `envconfig:"MIGRATION_PLANNER_LOG_LEVEL" default:"info"`
 }
 
-type svcConfig struct {
-	Address              string      `json:"address,omitempty"`
-	AgentEndpointAddress string      `json:"agentEndpointAddress,omitempty"`
-	ImageEndpointAddress string      `json:"imageEndpointAddress,omitempty"`
-	BaseUrl              string      `json:"baseUrl,omitempty"`
-	BaseAgentEndpointUrl string      `json:"baseAgentEndpointUrl,omitempty"`
-	BaseImageEndpointUrl string      `json:"baseImageEndpointUrl,omitempty"`
-	LogLevel             string      `json:"logLevel,omitempty"`
-	Kafka                kafkaConfig `json:"kafka,omitempty"`
-	Auth                 Auth        `json:"auth"`
-}
-
-type kafkaConfig struct {
-	Brokers  []string            `yaml:"brokers"`
-	Topic    string              `yaml:"topic"`
-	Version  sarama.KafkaVersion `yaml:"-"`
-	ClientID string              `yaml:"clientID"`
+type KafkaConfig struct {
+	Brokers  []string            `envconfig:"MIGRATION_PLANNER_KAFKA_BROKERS" default:""`
+	Topic    string              `envconfig:"MIGRATION_PLANNER_KAFKA_TOPIC" default:""`
+	Version  sarama.KafkaVersion `envconfig:"MIGRATION_PLANNER_KAFKA_VERSION" default:""`
+	ClientID string              `envconfig:"MIGRATION_PLANNER_KAFKA_CLIENT_ID" default:""`
 
 	SaramaConfig *sarama.Config
 }
 
-type Auth struct {
-	AuthenticationType string `json:"type"`
-	JwkCertURL         string `json:"jwk_cert_url"`
-}
-
-func ConfigDir() string {
-	return filepath.Join(util.MustString(os.UserHomeDir), "."+appName)
-}
-
-func ConfigFile() string {
-	return filepath.Join(ConfigDir(), "config.yaml")
-}
-
-func ClientConfigFile() string {
-	return filepath.Join(ConfigDir(), "client.yaml")
-}
-
-func NewDefault() (*Config, error) {
-	port, err := util.GetIntEnv("DB_PORT", 5432)
-	if err != nil {
-		return nil, err
-	}
-	c := &Config{
-		Database: &dbConfig{
-			Type:     "pgsql",
-			Hostname: util.GetEnv("DB_HOST", "localhost"),
-			Port:     port,
-			Name:     util.GetEnv("DB_NAME", "planner"),
-			User:     util.GetEnv("DB_USER", "admin"),
-			Password: util.GetEnv("DB_PASS", "adminpass"),
-		},
-		Service: &svcConfig{
-			Address:              ":3443",
-			AgentEndpointAddress: ":7443",
-			ImageEndpointAddress: ":11443",
-			BaseUrl:              "https://localhost:3443",
-			BaseAgentEndpointUrl: "https://localhost:7443",
-			BaseImageEndpointUrl: "https://localhost:11443",
-			LogLevel:             "info",
-			Auth: Auth{
-				AuthenticationType: util.GetEnv("MIGRATION_PLANNER_AUTH", "none"),
-				JwkCertURL:         util.GetEnv("MIGRATION_PLANNER_JWK_URL", ""),
-			},
-		},
-	}
-	return c, nil
-}
-
-func NewFromFile(cfgFile string) (*Config, error) {
-	cfg, err := Load(cfgFile)
-	if err != nil {
-		return nil, err
-	}
-	if err := Validate(cfg); err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-func LoadOrGenerate(cfgFile string) (*Config, error) {
-	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(cfgFile), os.FileMode(0755)); err != nil {
-			return nil, fmt.Errorf("creating directory for config file: %v", err)
-		}
-		cfg, err := NewDefault()
-		if err != nil {
-			return nil, err
-		}
-		if err := Save(cfg, cfgFile); err != nil {
+func New() (*Config, error) {
+	if singleConfig == nil {
+		singleConfig = new(Config)
+		if err := envconfig.Process(EnvConfigPrefix, singleConfig); err != nil {
 			return nil, err
 		}
 	}
-	return NewFromFile(cfgFile)
-}
-
-func Load(cfgFile string) (*Config, error) {
-	contents, err := os.ReadFile(cfgFile)
-	if err != nil {
-		return nil, fmt.Errorf("reading config file: %v", err)
-	}
-	c := &Config{}
-	if err := yaml.Unmarshal(contents, c); err != nil {
-		return nil, fmt.Errorf("decoding config: %v", err)
-	}
-	return c, nil
-}
-
-func Save(cfg *Config, cfgFile string) error {
-	contents, err := yaml.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("encoding config: %v", err)
-	}
-	if err := os.WriteFile(cfgFile, contents, 0600); err != nil {
-		return fmt.Errorf("writing config file: %v", err)
-	}
-	return nil
-}
-
-func Validate(cfg *Config) error {
-	return nil
-}
-
-func (cfg *Config) String() string {
-	contents, err := json.Marshal(cfg) // nolint: staticcheck
-	if err != nil {
-		return "<error>"
-	}
-	return string(contents)
+	return singleConfig, nil
 }

--- a/internal/service/agent/handler_test.go
+++ b/internal/service/agent/handler_test.go
@@ -35,9 +35,9 @@ var _ = Describe("agent service", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		cfg, err := config.NewDefault()
+		cfg, err := config.New()
 		Expect(err).To(BeNil())
-		db, err := store.InitDB(cfg)
+		db, err := store.InitDB(&cfg.DB)
 		Expect(err).To(BeNil())
 
 		s = store.NewStore(db)

--- a/internal/service/image/handler.go
+++ b/internal/service/image/handler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	imageServer "github.com/kubev2v/migration-planner/internal/api/server/image"
-	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/events"
 	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/kubev2v/migration-planner/internal/store"
@@ -22,17 +21,15 @@ import (
 type ImageHandler struct {
 	store       store.Store
 	eventWriter *events.EventProducer
-	cfg         *config.Config
 }
 
 // Make sure we conform to servers Service interface
 var _ imageServer.Service = (*ImageHandler)(nil)
 
-func NewImageHandler(store store.Store, ew *events.EventProducer, cfg *config.Config) *ImageHandler {
+func NewImageHandler(store store.Store, ew *events.EventProducer) *ImageHandler {
 	return &ImageHandler{
 		store:       store,
 		eventWriter: ew,
-		cfg:         cfg,
 	}
 }
 

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -32,9 +32,9 @@ var _ = Describe("source handler", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		cfg, err := config.NewDefault()
+		cfg, err := config.New()
 		Expect(err).To(BeNil())
-		db, err := store.InitDB(cfg)
+		db, err := store.InitDB(&cfg.DB)
 		Expect(err).To(BeNil())
 
 		s = store.NewStore(db)

--- a/internal/store/agent_test.go
+++ b/internal/store/agent_test.go
@@ -26,9 +26,9 @@ var _ = Describe("agent store", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		cfg, err := config.NewDefault()
+		cfg, err := config.New()
 		Expect(err).To(BeNil())
-		db, err := store.InitDB(cfg)
+		db, err := store.InitDB(&cfg.DB)
 		Expect(err).To(BeNil())
 
 		s = store.NewStore(db)

--- a/internal/store/source_test.go
+++ b/internal/store/source_test.go
@@ -25,9 +25,9 @@ var _ = Describe("source store", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		cfg, err := config.NewDefault()
+		cfg, err := config.New()
 		Expect(err).To(BeNil())
-		db, err := store.InitDB(cfg)
+		db, err := store.InitDB(&cfg.DB)
 		Expect(err).To(BeNil())
 
 		s = store.NewStore(db)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -19,9 +19,9 @@ var _ = Describe("Store", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		cfg, err := config.NewDefault()
+		cfg, err := config.New()
 		Expect(err).To(BeNil())
-		db, err := st.InitDB(cfg)
+		db, err := st.InitDB(&cfg.DB)
 		Expect(err).To(BeNil())
 		gormDB = db
 


### PR DESCRIPTION
Change the way configuration values are provided during the service creation
Use envconfig library to read environment variables, instead of creating and reading the configuration file itself