### PR TITLE
cli: Remove the need of config file to define server url

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
-	"github.com/kubev2v/migration-planner/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -53,7 +52,7 @@ func (o *CreateOptions) Bind(fs *pflag.FlagSet) {
 }
 
 func (o *CreateOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.Client()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kubev2v/migration-planner/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -65,7 +64,7 @@ func (o *DeleteOptions) Validate(args []string) error {
 }
 
 func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.Client()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/kubev2v/migration-planner/internal/client"
 	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -99,7 +98,7 @@ func (o *GenerateOptions) Bind(fs *pflag.FlagSet) {
 }
 
 func (o *GenerateOptions) Run(ctx context.Context, args []string) error {
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.Client()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	apiclient "github.com/kubev2v/migration-planner/internal/api/client"
-	"github.com/kubev2v/migration-planner/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/thoas/go-funk"
@@ -94,7 +93,7 @@ func (o *GetOptions) Validate(args []string) error {
 }
 
 func (o *GetOptions) Run(ctx context.Context, args []string) error { // nolint: gocyclo
-	c, err := client.NewFromConfigFile(o.ConfigFilePath)
+	c, err := o.Client()
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}


### PR DESCRIPTION
This PR removes the need to have a config file that sets the server url. It adds a simple flag `--server-url` which defaults to `localhost:3443`.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>