### PR TITLE
Use tcpSocket probe for healtcheck

### DIFF
--- a/deploy/k8s/migration-planner.yaml.template
+++ b/deploy/k8s/migration-planner.yaml.template
@@ -28,8 +28,7 @@ spec:
             - containerPort: 7443
             - containerPort: 11443
           livenessProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: 3443
             initialDelaySeconds: 30
           env:

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -105,8 +105,7 @@ objects:
                 - containerPort: 7443
                   name: agent-api-port
               livenessProbe:
-                httpGet:
-                  path: /health
+                tcpSocket:
                   port: 3443
                 initialDelaySeconds: 30
               env:


### PR DESCRIPTION
We need to use tcpSocket because HTTP middleware requires Auth bearer token for RHSSO for /health call