### PR TITLE
ignition: Copy embeded images from archive to container storage

### DIFF
--- a/data/ignition.template
+++ b/data/ignition.template
@@ -100,6 +100,24 @@ storage:
       contents:
         inline: |
           PasswordAuthentication yes
+    - path: /etc/systemd/user-generators/100-skopeo.sh
+      mode: 0775
+      contents:
+        inline: |
+          #!/usr/bin/bash
+          IMAGE_STORAGE=/usr/share/assisted-migrations/images
+          if ! command -v skopeo 2>&1 >/dev/null
+          then
+            echo "skopeo could not be found"
+            exit 0
+          fi
+
+          if [ -f $IMAGE_STORAGE/migration-planner-agent ]; then
+              skopeo copy oci-archive:$IMAGE_STORAGE/migration-planner-agent containers-storage:quay.io/kubev2v/migration-planner-agent:latest
+          fi
+          if [ -f $IMAGE_STORAGE/forklift-validation ]; then
+              skopeo copy oci-archive:$IMAGE_STORAGE/forklift-validation containers-storage:quay.io/kubev2v/forklift-validation:release-v2.6.4
+          fi
     - path: /home/core/.migration-planner/config/config.yaml
       contents:
         inline: |


### PR DESCRIPTION
This PR adds a systemd generator, which copies oci images from the archive to container storage.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>