### PR TITLE
metrics: add prefix to inventory metrics

### DIFF
--- a/pkg/metrics/inventory_collector.go
+++ b/pkg/metrics/inventory_collector.go
@@ -20,7 +20,7 @@ type inventoryStatsCollector struct {
 
 func newInventoryStatsCollector(s store.Store) prometheus.Collector {
 	fqName := func(name string) string {
-		return fmt.Sprintf("inventory_%s", name)
+		return fmt.Sprintf("%s_inventory_%s", assistedMigration, name)
 	}
 
 	return &inventoryStatsCollector{


### PR DESCRIPTION
This PR adds `assisted_migration` prefix for inventory metrics.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>