### PR TITLE
event-streamer: Don't write the event on stdout

### DIFF
--- a/internal/events/writer_stdout.go
+++ b/internal/events/writer_stdout.go
@@ -4,14 +4,13 @@ import (
 	"context"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"go.uber.org/zap"
 )
 
 // event writer used in dev
 type StdoutWriter struct{}
 
 func (s *StdoutWriter) Write(ctx context.Context, topic string, e cloudevents.Event) error {
-	zap.S().Named("stout_writer").Infow("event wrote", "event", e, "topic", topic)
+	//	zap.S().Named("stout_writer").Infow("event wrote", "event", e, "topic", topic)
 	return nil
 }
 


### PR DESCRIPTION
Since we don't use event-streamer anymore, this PR disables the logging of events.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>