### PR TITLE
Use custom header for agent authentication

### DIFF
--- a/internal/agent/client/client.go
+++ b/internal/agent/client/client.go
@@ -34,8 +34,9 @@ func NewDefault() *Config {
 	return baseclient.NewDefault()
 }
 
-//go:generate moq -out zz_generated_planner.go . Planner
 // Planner is the client interface for migration planning.
+//
+//go:generate moq -out zz_generated_planner.go . Planner
 type Planner interface {
 	UpdateSourceStatus(ctx context.Context, id uuid.UUID, params api.SourceStatusUpdate) error
 	// Health is checking the connectivity with console.redhat.com by making requests to /health endpoint.

--- a/internal/agent/client/planner.go
+++ b/internal/agent/client/planner.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/kubev2v/migration-planner/api/v1alpha1/agent"
 	"github.com/kubev2v/migration-planner/internal/agent/common"
 	client "github.com/kubev2v/migration-planner/internal/api/client/agent"
+	"github.com/kubev2v/migration-planner/internal/auth"
 )
 
 var _ Planner = (*planner)(nil)
@@ -32,7 +33,7 @@ type planner struct {
 func (p *planner) UpdateSourceStatus(ctx context.Context, id uuid.UUID, params api.SourceStatusUpdate) error {
 	resp, err := p.client.UpdateSourceInventoryWithResponse(ctx, id, params, func(ctx context.Context, req *http.Request) error {
 		if jwt, found := p.jwtFromContext(ctx); found {
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+			req.Header.Add(auth.AgentTokenHeader, jwt)
 		}
 		return nil
 	})
@@ -52,7 +53,7 @@ func (p *planner) UpdateSourceStatus(ctx context.Context, id uuid.UUID, params a
 func (p *planner) Health(ctx context.Context) error {
 	resp, err := p.client.HealthWithResponse(ctx, func(ctx context.Context, req *http.Request) error {
 		if jwt, found := p.jwtFromContext(ctx); found {
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+			req.Header.Add(auth.AgentTokenHeader, jwt)
 		}
 		return nil
 	})
@@ -72,7 +73,7 @@ func (p *planner) Health(ctx context.Context) error {
 func (p *planner) UpdateAgentStatus(ctx context.Context, id uuid.UUID, params api.AgentStatusUpdate) error {
 	resp, err := p.client.UpdateAgentStatusWithResponse(ctx, id, params, func(ctx context.Context, req *http.Request) error {
 		if jwt, found := p.jwtFromContext(ctx); found {
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+			req.Header.Add(auth.AgentTokenHeader, jwt)
 		}
 		return nil
 	})

--- a/internal/auth/agent_authenticator.go
+++ b/internal/auth/agent_authenticator.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultExpirationPeriod = 3 * 30 * 24 // 3 months
+	AgentTokenHeader        = "X-Agent-Token"
 )
 
 func GenerateAgentJWTAndKey(source *model.Source) (*model.Key, string, error) {
@@ -115,13 +116,12 @@ func (aa *AgentAuthenticator) Authenticate(token string) (AgentJWT, error) {
 
 func (aa *AgentAuthenticator) Authenticator(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		accessToken := r.Header.Get("Authorization")
-		if accessToken == "" || len(accessToken) < len("Bearer ") {
+		accessToken := r.Header.Get(AgentTokenHeader)
+		if accessToken == "" {
 			http.Error(w, "No token provided", http.StatusUnauthorized)
 			return
 		}
 
-		accessToken = accessToken[len("Bearer "):]
 		agentJwt, err := aa.Authenticate(accessToken)
 		if err != nil {
 			http.Error(w, "authentication failed", http.StatusUnauthorized)

--- a/internal/auth/agent_authenticator_test.go
+++ b/internal/auth/agent_authenticator_test.go
@@ -147,7 +147,7 @@ var _ = Describe("agent authentication", Ordered, func() {
 
 			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
 			Expect(err).To(BeNil())
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+			req.Header.Add(auth.AgentTokenHeader, token)
 
 			resp, rerr := http.DefaultClient.Do(req)
 			Expect(rerr).To(BeNil())

--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -2,10 +2,10 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/kubev2v/migration-planner/internal/api/client"
+	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -42,7 +42,7 @@ func (o *GlobalOptions) Client() (*client.ClientWithResponses, error) {
 			if o.Token == "" {
 				return nil
 			}
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", o.Token))
+			req.Header.Add(auth.AgentTokenHeader, o.Token)
 			return nil
 		}),
 	)


### PR DESCRIPTION
The gateway expects the `Authorization: Bearer` to be validated, we introduce custom header for authentication.