### PR TITLE
Don't log GET request in api-server

### DIFF
--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -13,12 +13,12 @@ import (
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/api/server"
 	"github.com/kubev2v/migration-planner/internal/auth"
+	"github.com/kubev2v/migration-planner/internal/chilogger"
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/events"
 	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/leosunmo/zapchi"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
 	chiprometheus "github.com/toshi0607/chi-prometheus"
 	"go.uber.org/zap"
@@ -91,7 +91,7 @@ func (s *Server) Run(ctx context.Context) error {
 		metricMiddleware.Handler,
 		authenticator.Authenticator,
 		middleware.RequestID,
-		zapchi.Logger(zap.S(), "router_api"),
+		chilogger.Logger(zap.S(), "router_api"),
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 		WithResponseWriter,

--- a/internal/chilogger/chilogger.go
+++ b/internal/chilogger/chilogger.go
@@ -1,0 +1,64 @@
+package chilogger
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+)
+
+var (
+	sugaredLogFormat = `[%s] "%s %s %s" from %s - %s %dB in %s`
+)
+
+func Logger(l interface{}, name string) func(next http.Handler) http.Handler {
+	switch logger := l.(type) {
+
+	case *zap.SugaredLogger:
+		logger = zap.New(logger.Desugar().Core(), zap.AddCallerSkip(1)).Sugar().Named(name)
+		return func(next http.Handler) http.Handler {
+			fn := func(w http.ResponseWriter, r *http.Request) {
+				ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+				t1 := time.Now()
+				defer func() {
+					if r.Method != http.MethodGet {
+						logger.Infof(sugaredLogFormat,
+							middleware.GetReqID(r.Context()),
+							r.Method,
+							r.URL.Path,
+							r.Proto,
+							r.RemoteAddr,
+							statusLabel(ww.Status()),
+							ww.BytesWritten(),
+							time.Since(t1),
+						)
+					}
+
+				}()
+				next.ServeHTTP(ww, r)
+			}
+			return http.HandlerFunc(fn)
+		}
+	default:
+		log.Fatalf("Unknown logger passed in. Please provide *Zap.Logger or *Zap.SugaredLogger")
+	}
+	return nil
+}
+
+func statusLabel(status int) string {
+	switch {
+	case status >= 100 && status < 300:
+		return fmt.Sprintf("%d OK", status)
+	case status >= 300 && status < 400:
+		return fmt.Sprintf("%d Redirect", status)
+	case status >= 400 && status < 500:
+		return fmt.Sprintf("%d Client Error", status)
+	case status >= 500:
+		return fmt.Sprintf("%d Server Error", status)
+	default:
+		return fmt.Sprintf("%d Unknown", status)
+	}
+}


### PR DESCRIPTION
api-server is flooded by GET requests when UI is running, create custom logger that don't log GET requests.