### PR TITLE
Change the E2E to work with authentication

### DIFF
--- a/deploy/e2e.mk
+++ b/deploy/e2e.mk
@@ -1,5 +1,7 @@
+E2E_PRIVATE_KEY_FOLDER_PATH ?= /etc/planner/e2e
+
 .PHONY: deploy-e2e-environment
-deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration persistent_disk
+deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt generate_private_key deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration persistent_disk
 
 .PHONY: install_qemu_img
 install_qemu_img:
@@ -30,6 +32,15 @@ setup_libvirt:
 		sudo dnf install -y sshpass libvirt-devel libvirt-daemon libvirt-daemon-config-network; \
 	fi
 	sudo systemctl restart libvirtd
+
+.PHONY: generate_private_key
+generate_private_key:
+	sudo mkdir -p $(E2E_PRIVATE_KEY_FOLDER_PATH) && \
+	sudo chown -R $(shell whoami):$(shell whoami) $(E2E_PRIVATE_KEY_FOLDER_PATH); \
+	if [ ! -f $(E2E_PRIVATE_KEY_FOLDER_PATH)/private-key ]; then \
+		openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $(E2E_PRIVATE_KEY_FOLDER_PATH)/private-key; \
+		openssl rsa -in $(E2E_PRIVATE_KEY_FOLDER_PATH)/private-key -out $(E2E_PRIVATE_KEY_FOLDER_PATH)/private-key -traditional; \
+	fi
 
 .PHONY: deploy_registry
 deploy_registry:

--- a/deploy/templates/pk-secret-template.yml
+++ b/deploy/templates/pk-secret-template.yml
@@ -1,0 +1,17 @@
+---
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: migration-planner-private-key-secret
+parameters:
+  - name: E2E_PRIVATE_KEY_BASE64
+    description: Base64-encoded content of the private key file.
+    displayName: Private Key Base64 Content
+objects:
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: migration-planner-private-key-secret
+    type: Opaque
+    data:
+      private-key: ${E2E_PRIVATE_KEY_BASE64}

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -211,6 +211,12 @@ objects:
                 # Auth Config values
                 - name: MIGRATION_PLANNER_AUTH
                   value: ${MIGRATION_PLANNER_AUTH}
+                - name: MIGRATION_PLANNER_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: migration-planner-private-key-secret
+                      key: private-key
+                      optional: true
                 - name: MIGRATION_PLANNER_JWK_URL
                   value: ${MIGRATION_PLANNER_JWK_URL}
                 # DB Config values

--- a/internal/cli/sso.go
+++ b/internal/cli/sso.go
@@ -43,12 +43,12 @@ func newTokenCmd() *cobra.Command {
 		Use:   "token",
 		Short: "Generate a jwt",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			privateKey, err := parsePrivateKey(o.PrivateKey)
+			privateKey, err := ParsePrivateKey(o.PrivateKey)
 			if err != nil {
 				return err
 			}
 
-			token, err := generateToken(o.Username, o.Organization, privateKey)
+			token, err := GenerateToken(o.Username, o.Organization, privateKey)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func newPrivateKeyCmd() *cobra.Command {
 	}
 }
 
-func parsePrivateKey(content string) (*rsa.PrivateKey, error) {
+func ParsePrivateKey(content string) (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(content))
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
@@ -96,7 +96,7 @@ func parsePrivateKey(content string) (*rsa.PrivateKey, error) {
 	return key, nil
 }
 
-func generateToken(username, organization string, privateKey *rsa.PrivateKey) (string, error) {
+func GenerateToken(username, organization string, privateKey *rsa.PrivateKey) (string, error) {
 	type TokenClaims struct {
 		Username string `json:"preferred_username"`
 		OrgID    string `json:"org_id"`

--- a/test/e2e/e2e_utils_test.go
+++ b/test/e2e/e2e_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/kubev2v/migration-planner/internal/cli"
 	. "github.com/onsi/gomega"
 	"io"
 	"os"
@@ -195,4 +196,23 @@ func RunCommand(ip string, command string) (string, error) {
 	}
 
 	return stdout.String(), nil
+}
+
+func getToken(username string, organization string) (string, error) {
+	privateKeyString, err := os.ReadFile(privateKeyPath)
+	if err != nil {
+		return "", fmt.Errorf("error, unable to read the private key: %v", err)
+	}
+
+	privateKey, err := cli.ParsePrivateKey(string(privateKeyString))
+	if err != nil {
+		return "", fmt.Errorf("error with parsing the private key: %v", err)
+	}
+
+	token, err := cli.GenerateToken(username, organization, privateKey)
+	if err != nil {
+		return "", fmt.Errorf("error, unable to generate token: %v", err)
+	}
+
+	return token, nil
 }


### PR DESCRIPTION
Hi,

This PR updates the migration-planner service, deployed on Kind, to use local authentication (auth: local). As a result, all communication methods with the service now include a JWT token in the request.