### PR TITLE
grafana: fix dashboard title

### DIFF
--- a/dashboards/grafana-assisted-migrations.yaml
+++ b/dashboards/grafana-assisted-migrations.yaml
@@ -1422,7 +1422,7 @@ data:
       },
       "timepicker": {},
       "timezone": "browser",
-      "title": "assisted_migrations_test",
+      "title": "Assisted Migrations",
       "uid": "de9yb0qpl8dmo",
       "version": 6,
       "weekStart": ""


### PR DESCRIPTION
Fixes the dashboard title to "Assisted Migrations"

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>