### PR TITLE
modify logging error messages syntax - change "error" to "failed"

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -176,7 +176,7 @@ func (a *Agent) start(ctx context.Context, plannerClient client.Planner) {
 					a.Stop()
 					break
 				}
-				zap.S().Errorf("unable to update agent status: %s", err)
+				zap.S().Errorf("failed to update agent status: %s", err)
 				continue // skip inventory update if we cannot update agent's state.
 			}
 
@@ -191,7 +191,7 @@ func (a *Agent) initializeCredentialUrl() *net.TCPAddr {
 	// Parse the service URL
 	parsedURL, err := url.Parse(a.config.PlannerService.Service.Server)
 	if err != nil {
-		zap.S().Errorf("error parsing service URL: %v", err)
+		zap.S().Errorf("falied to parse service URL: %v", err)
 		return nil
 	}
 
@@ -204,7 +204,7 @@ func (a *Agent) initializeCredentialUrl() *net.TCPAddr {
 	// Connect to service
 	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%s", parsedURL.Hostname(), port))
 	if err != nil {
-		zap.S().Errorf("failed connecting to migration planner: %v", err)
+		zap.S().Errorf("failed to connect the migration planner: %v", err)
 		return nil
 	}
 	defer conn.Close()

--- a/internal/agent/client/planner.go
+++ b/internal/agent/client/planner.go
@@ -44,7 +44,7 @@ func (p *planner) UpdateSourceStatus(ctx context.Context, id uuid.UUID, params a
 		defer resp.HTTPResponse.Body.Close()
 	}
 	if resp.StatusCode() != http.StatusOK {
-		return fmt.Errorf("update source status failed: %s", resp.Status())
+		return fmt.Errorf("failed to update source status: %s", resp.Status())
 	}
 
 	return nil
@@ -87,7 +87,7 @@ func (p *planner) UpdateAgentStatus(ctx context.Context, id uuid.UUID, params ap
 		return ErrSourceGone
 	}
 	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusCreated {
-		return fmt.Errorf("update agent status failed with status: %s", resp.Status())
+		return fmt.Errorf("failed to update agent status: %s", resp.Status())
 	}
 	return nil
 }

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -135,10 +135,10 @@ func (cfg *Config) Validate() error {
 func (cfg *Config) ParseConfigFile(cfgFile string) error {
 	contents, err := cfg.reader.ReadFile(cfgFile)
 	if err != nil {
-		return fmt.Errorf("reading config file: %w", err)
+		return fmt.Errorf("failed to read config file: %w", err)
 	}
 	if err := yaml.Unmarshal(contents, cfg); err != nil {
-		return fmt.Errorf("unmarshalling config file: %w", err)
+		return fmt.Errorf("failed to unmarshal config file: %w", err)
 	}
 	cfg.PlannerService.Config.SetBaseDir(filepath.Dir(cfgFile))
 	return nil

--- a/internal/agent/fileio/reader.go
+++ b/internal/agent/fileio/reader.go
@@ -45,7 +45,7 @@ func checkPathExists(filePath string) error {
 		return fmt.Errorf("path does not exist: %s", filePath)
 	}
 	if err != nil {
-		return fmt.Errorf("error checking path: %w", err)
+		return fmt.Errorf("failed to check path: %w", err)
 	}
 
 	return nil

--- a/internal/agent/rest.go
+++ b/internal/agent/rest.go
@@ -97,13 +97,13 @@ func getInventory(dataDir string) (*service.InventoryData, error) {
 	filename := filepath.Join(dataDir, config.InventoryFile)
 	contents, err := os.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("error reading inventory file: %v", err)
+		return nil, fmt.Errorf("failed to read inventory file: %v", err)
 	}
 
 	var inventory service.InventoryData
 	err = json.Unmarshal(contents, &inventory)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing inventory file: %v", err)
+		return nil, fmt.Errorf("failed to parse inventory file: %v", err)
 	}
 
 	return &inventory, nil

--- a/internal/agent/service/collector.go
+++ b/internal/agent/service/collector.go
@@ -67,13 +67,13 @@ func (c *Collector) run() {
 
 	credsData, err := os.ReadFile(credentialsFilePath)
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error reading credentials file: %v\n", err)
+		zap.S().Named("collector").Errorf("failed to read credentials file: %v", err)
 		return
 	}
 
 	var creds config.Credentials
 	if err := json.Unmarshal(credsData, &creds); err != nil {
-		zap.S().Named("collector").Errorf("Error parsing credentials JSON: %v\n", err)
+		zap.S().Named("collector").Errorf("failed to parse credentials JSON: %v", err)
 		return
 	}
 	zap.S().Named("collector").Infof("Create Provider")
@@ -84,14 +84,14 @@ func (c *Collector) run() {
 	zap.S().Named("collector").Infof("Create DB")
 	db, err := createDB(provider)
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error creating DB: %s", err)
+		zap.S().Named("collector").Errorf("failed to create DB: %v", err)
 		return
 	}
 
 	zap.S().Named("collector").Infof("vSphere collector")
 	collector, err := createCollector(db, provider, secret)
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error running collector: %s", err)
+		zap.S().Named("collector").Errorf("failed to run the collector: %v", err)
 		return
 	}
 	defer collector.DB().Close(true)
@@ -101,7 +101,7 @@ func (c *Collector) run() {
 	vms := &[]vspheremodel.VM{}
 	err = collector.DB().List(vms, libmodel.FilterOptions{Detail: 1, Predicate: libmodel.Eq("IsTemplate", false)})
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error list database: %s", err)
+		zap.S().Named("collector").Errorf("failed to list database: %v", err)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (c *Collector) run() {
 	hosts := &[]vspheremodel.Host{}
 	err = collector.DB().List(hosts, libmodel.FilterOptions{Detail: 1})
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error list database: %s", err)
+		zap.S().Named("collector").Errorf("failed to list database: %v", err)
 		return
 	}
 
@@ -117,7 +117,7 @@ func (c *Collector) run() {
 	clusters := &[]vspheremodel.Cluster{}
 	err = collector.DB().List(clusters, libmodel.FilterOptions{Detail: 1})
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error list database: %s", err)
+		zap.S().Named("collector").Errorf("failed to list database: %v", err)
 		return
 	}
 
@@ -125,7 +125,7 @@ func (c *Collector) run() {
 	about := &vspheremodel.About{}
 	err = collector.DB().Get(about)
 	if err != nil {
-		zap.S().Named("collector").Errorf("Error list database about table: %s", err)
+		zap.S().Named("collector").Errorf("failed to list database about table: %v", err)
 		return
 	}
 
@@ -139,7 +139,7 @@ func (c *Collector) run() {
 		zap.S().Named("collector").Infof("Run the validation of VMs")
 		vms, err = validation(vms, opaServer)
 		if err != nil {
-			zap.S().Named("collector").Errorf("Error running validation: %s", err)
+			zap.S().Named("collector").Errorf("failed to run validation: %v", err)
 			return
 		}
 	}
@@ -149,7 +149,7 @@ func (c *Collector) run() {
 
 	zap.S().Named("collector").Infof("Write the inventory to output file")
 	if err := createOuput(filepath.Join(c.dataDir, config.InventoryFile), inv); err != nil {
-		zap.S().Named("collector").Errorf("Fill the inventory object with more data: %s", err)
+		zap.S().Named("collector").Errorf("Fill the inventory object with more data: %v", err)
 		return
 	}
 }

--- a/internal/agent/service/health.go
+++ b/internal/agent/service/health.go
@@ -115,7 +115,7 @@ func (h *HealthChecker) do(ctx context.Context) {
 
 	err := h.client.Health(ctx)
 	if err != nil {
-		if _, err := h.logFile.Write([]byte(fmt.Sprintf("[%s] console.redhat.com is unreachable.\n", time.Now().Format(time.RFC3339)))); err != nil {
+		if _, err := h.logFile.Write([]byte(fmt.Sprintf("[%s] console.redhat.com is unreachable\n", time.Now().Format(time.RFC3339)))); err != nil {
 			zap.S().Named("health").Errorf("failed to write to log file %s %w", h.logFilepath, err)
 		}
 		h.lock.Lock()

--- a/internal/agent/service/inventory.go
+++ b/internal/agent/service/inventory.go
@@ -42,7 +42,7 @@ func (u *InventoryUpdater) UpdateServiceWithInventory(ctx context.Context, inven
 
 	newContents, err := json.Marshal(update)
 	if err != nil {
-		zap.S().Named("inventory").Errorf("failed marshalling new status: %v", err)
+		zap.S().Named("inventory").Errorf("failed to marshal new status: %v", err)
 	}
 	if bytes.Equal(u.prevStatus, newContents) {
 		zap.S().Named("inventory").Debug("Local status did not change, skipping service update")
@@ -51,7 +51,7 @@ func (u *InventoryUpdater) UpdateServiceWithInventory(ctx context.Context, inven
 
 	err = u.client.UpdateSourceStatus(ctx, u.sourceID, update)
 	if err != nil {
-		zap.S().Named("inventory").Errorf("failed updating status: %v", err)
+		zap.S().Named("inventory").Errorf("failed to update status: %v", err)
 		return
 	}
 

--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -58,7 +58,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 	zap.S().Named("agent_server").Info("Initializing Agent-side API server")
 	swagger, err := api.GetSwagger()
 	if err != nil {
-		return fmt.Errorf("failed loading swagger spec: %w", err)
+		return fmt.Errorf("failed to load swagger spec: %w", err)
 	}
 	// Skip server name validation
 	swagger.Servers = nil

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -57,7 +57,7 @@ func (s *ImageServer) Run(ctx context.Context) error {
 	zap.S().Named("image_server").Info("Initializing Image-side API server")
 	swagger, err := api.GetSwagger()
 	if err != nil {
-		return fmt.Errorf("failed loading swagger spec: %w", err)
+		return fmt.Errorf("failed to load swagger spec: %w", err)
 	}
 	// Skip server name validation
 	swagger.Servers = nil

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -68,7 +68,7 @@ func (s *Server) Run(ctx context.Context) error {
 	zap.S().Named("api_server").Info("Initializing API server")
 	swagger, err := api.GetSwagger()
 	if err != nil {
-		return fmt.Errorf("failed loading swagger spec: %w", err)
+		return fmt.Errorf("failed to load swagger spec: %w", err)
 	}
 	// Skip server name validation
 	swagger.Servers = nil

--- a/internal/auth/rhsso_authenticator.go
+++ b/internal/auth/rhsso_authenticator.go
@@ -136,5 +136,5 @@ func (rh *RHSSOAuthenticator) getOrgID(claims jwt.MapClaims) (string, error) {
 		return orgID, nil
 	}
 
-	return "", fmt.Errorf("organization id not found in the claims")
+	return "", fmt.Errorf("organization ID not found in claims")
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -52,7 +52,7 @@ func (o *GenerateOptions) Validate(args []string) error {
 	if o.ServiceIP == "" {
 		localIP, err := getLocalIP()
 		if err != nil {
-			return fmt.Errorf("failed to get local ip: %s. Please provide planner api ip", err)
+			return fmt.Errorf("failed to get local ip: %s, Please provide planner api ip", err)
 		}
 		o.ServiceIP = fmt.Sprintf("http://%s:7443", localIP.String())
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -135,14 +135,14 @@ func processReponse(response interface{}, err error, kind string, id *uuid.UUID,
 	case jsonFormat:
 		marshalled, err := json.Marshal(v.FieldByName("JSON200").Interface())
 		if err != nil {
-			return fmt.Errorf("marshalling resource: %w", err)
+			return fmt.Errorf("failed to marshal resource: %w", err)
 		}
 		fmt.Printf("%s\n", string(marshalled))
 		return nil
 	case yamlFormat:
 		marshalled, err := yaml.Marshal(v.FieldByName("JSON200").Interface())
 		if err != nil {
-			return fmt.Errorf("marshalling resource: %w", err)
+			return fmt.Errorf("failed to marshal resource: %w", err)
 		}
 		fmt.Printf("%s\n", string(marshalled))
 		return nil

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -116,7 +116,7 @@ func (b *ImageBuilder) Generate(ctx context.Context, w io.Writer) (int, error) {
 	// Generate ISO data reader with ignition content
 	reader, err := isoeditor.NewRHCOSStreamReader(b.RHCOSImage, &isoeditor.IgnitionContent{Config: []byte(ignitionContent)}, nil, nil)
 	if err != nil {
-		return -1, fmt.Errorf("error reading rhcos iso: %w", err)
+		return -1, fmt.Errorf("failed to read rhcos iso: %w", err)
 	}
 
 	size, err := b.computeSize(reader)
@@ -161,7 +161,7 @@ func (b *ImageBuilder) Validate() error {
 
 	// Generate ISO data reader with ignition content
 	if _, err = isoeditor.NewRHCOSStreamReader(b.RHCOSImage, &isoeditor.IgnitionContent{Config: []byte(ignitionContent)}, nil, nil); err != nil {
-		return fmt.Errorf("error reading rhcos iso: %w", err)
+		return fmt.Errorf("failed to read rhcos iso: %w", err)
 	}
 
 	return nil
@@ -185,15 +185,15 @@ func (b *ImageBuilder) generateIgnition() (string, error) {
 	var buf bytes.Buffer
 	t, err := template.New("ignition.template").ParseFiles(b.Template)
 	if err != nil {
-		return "", fmt.Errorf("error reading the ignition template: %w", err)
+		return "", fmt.Errorf("failed to read the ignition template: %w", err)
 	}
 	if err := t.Execute(&buf, ignData); err != nil {
-		return "", fmt.Errorf("error parsing the ignition template: %w", err)
+		return "", fmt.Errorf("failed to parse the ignition template: %w", err)
 	}
 
 	dataOut, _, err := config.TranslateBytes(buf.Bytes(), common.TranslateBytesOptions{})
 	if err != nil {
-		return "", fmt.Errorf("error translating config: %w", err)
+		return "", fmt.Errorf("failed to translate config: %w", err)
 	}
 
 	return string(dataOut), nil

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -70,8 +70,8 @@ func (h *ServiceHandler) GetImage(ctx context.Context, request server.GetImageRe
 	size, err := imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
-		zap.S().Named("image_service").Errorf("error generating ova at GetImage: %s", err)
-		return server.GetImage500JSONResponse{Message: fmt.Sprintf("error generating image %s", err)}, nil
+		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
+		return server.GetImage500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
 
 	// Set proper headers of the OVA file:

--- a/internal/service/image/handler.go
+++ b/internal/service/image/handler.go
@@ -53,11 +53,11 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 
 	sourceId, err := image.IdFromJWT(req.Token)
 	if err != nil {
-		return nil, fmt.Errorf("error creating the HTTP stream: %v", err)
+		return nil, fmt.Errorf("failed to create the HTTP stream: %v", err)
 	}
 	source, err := h.getSource(ctx, sourceId)
 	if err != nil {
-		return imageServer.GetImageByToken401JSONResponse{Message: "error creating the HTTP stream"}, nil
+		return imageServer.GetImageByToken401JSONResponse{Message: "failed to create the HTTP stream"}, nil
 	}
 
 	imageBuilder := image.NewImageBuilder(source.ID)
@@ -72,8 +72,8 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	size, err := imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
-		zap.S().Named("image_service").Errorf("error generating ova at GetImage: %s", err)
-		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("error generating image %s", err)}, nil
+		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
+		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
 
 	// Set proper headers of the OVA file:

--- a/test/e2e/e2e_utils_test.go
+++ b/test/e2e/e2e_utils_test.go
@@ -90,7 +90,7 @@ func ValidateTar(file *os.File) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("error reading tar header: %w", err)
+			return fmt.Errorf("failed to read tar header: %w", err)
 		}
 
 		switch header.Typeflag {
@@ -102,7 +102,7 @@ func ValidateTar(file *os.File) error {
 				// Validate OVF file
 				ovfContent, err := io.ReadAll(tarReader)
 				if err != nil {
-					return fmt.Errorf("error reading OVF file: %w", err)
+					return fmt.Errorf("failed to read OVF file: %w", err)
 				}
 
 				// Basic validation: check if the content contains essential OVF elements
@@ -139,7 +139,7 @@ func Untar(file *os.File, destFile string, fileName string) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("error reading tar header: %w", err)
+			return fmt.Errorf("failed to read tar header: %w", err)
 		}
 
 		switch header.Typeflag {
@@ -147,12 +147,12 @@ func Untar(file *os.File, destFile string, fileName string) error {
 			if header.Name == fileName {
 				outFile, err := os.Create(destFile)
 				if err != nil {
-					return fmt.Errorf("error creating file: %w", err)
+					return fmt.Errorf("failed to create file: %w", err)
 				}
 				defer outFile.Close()
 
 				if _, err := io.Copy(outFile, tarReader); err != nil {
-					return fmt.Errorf("error writing file: %w", err)
+					return fmt.Errorf("failed to write file: %w", err)
 				}
 				return nil
 			}


### PR DESCRIPTION
As part of the hackathon, one of the goals was to standardize the error message logs with a unified syntax, starting with 'failed' at the beginning of each error.

@nirarg @ravraham