### PR TITLE
Support remote debugging

### DIFF
--- a/Containerfile.agent-debug
+++ b/Containerfile.agent-debug
@@ -1,0 +1,47 @@
+# UI stage
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi as ui
+
+WORKDIR /app
+RUN mkdir /app/www && \
+     curl -Lo /tmp/agent-latest.tgz https://github.com/kubev2v/migration-planner-ui/releases/download/latest/agent-latest.tgz && \
+     tar xf /tmp/agent-latest.tgz -C /app/www
+
+# Builder stage
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as builder
+
+WORKDIR /app
+
+RUN GOBIN=/app go install github.com/go-delve/delve/cmd/dlv@latest
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+USER 0
+
+# Build binary with debug flags
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false \
+  -gcflags "all=-N -l" \
+  -ldflags "-X github.com/kubev2v/migration-planner/internal/agent.version=${VERSION}" \
+  -o /planner-agent cmd/planner-agent/main.go
+
+# Final image
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal
+
+WORKDIR /app
+
+# Install Delve runtime binary
+COPY --from=builder /app/dlv /app/dlv
+COPY --from=builder /planner-agent /app/planner-agent
+COPY --from=ui /app/www/package/dist /app/www
+
+# Use non-root user
+RUN chown -R 1001:0 /app
+USER 1001
+
+EXPOSE 3333 40001
+ENTRYPOINT ["/app/dlv", "exec", "/app/planner-agent", "--headless", "--listen=:40001", "--api-version=2", "--accept-multiclient", "--continue", "--"]

--- a/Containerfile.api-debug
+++ b/Containerfile.api-debug
@@ -1,0 +1,34 @@
+# Builder container
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+USER 0
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -o /planner-api cmd/planner-api/*.go
+
+# Install Delve
+RUN GOBIN=/app go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal
+
+WORKDIR /app
+
+RUN curl -Lo /app/rhcos-live.x86_64.iso https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+COPY /data /app/data/
+COPY --from=builder /planner-api /app/
+COPY --from=builder /app/dlv /app/
+
+# Use non-root user
+RUN chown -R 1001:0 /app
+USER 1001
+
+# Expose ports
+EXPOSE 3443 40000
+
+# Run the server with Delve
+ENTRYPOINT ["/app/dlv", "--continue", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/app/planner-api", "run"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ VERBOSE ?= false
 MIGRATION_PLANNER_AGENT_IMAGE ?= quay.io/kubev2v/migration-planner-agent
 MIGRATION_PLANNER_API_IMAGE ?= quay.io/kubev2v/migration-planner-api
 MIGRATION_PLANNER_IMAGE_TAG ?= latest
+MIGRATION_PLANNER_IMAGE_TAG := $(MIGRATION_PLANNER_IMAGE_TAG)$(if $(DEBUG_MODE),-debug)
 MIGRATION_PLANNER_API_IMAGE_PULL_POLICY ?= Always
 MIGRATION_PLANNER_UI_IMAGE ?= quay.io/kubev2v/migration-planner-ui
 MIGRATION_PLANNER_UI_IMAGE_TAG ?= latest
@@ -16,7 +17,6 @@ MIGRATION_PLANNER_NAMESPACE ?= assisted-migration
 MIGRATION_PLANNER_REPLICAS ?= 1
 PERSISTENT_DISK_DEVICE ?= /dev/sda
 INSECURE_REGISTRY ?= "true"
-REGISTRY_TAG ?= latest
 DOWNLOAD_RHCOS ?= true
 KUBECTL ?= kubectl
 IFACE ?= eth0
@@ -123,10 +123,10 @@ build-cli: bin
 
 # rebuild container only on source changes
 bin/.migration-planner-agent-container: bin Containerfile.agent go.mod go.sum $(GO_FILES)
-	$(PODMAN) build . --build-arg VERSION=$(SOURCE_GIT_TAG) -f Containerfile.agent $(if $(LABEL),--label "$(LABEL)") -t $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG)
+	$(PODMAN) build . --build-arg VERSION=$(SOURCE_GIT_TAG) -f $(if $(DEBUG_MODE),Containerfile.agent-debug,Containerfile.agent) $(if $(LABEL),--label "$(LABEL)") -t $(MIGRATION_PLANNER_AGENT_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG)
 
 bin/.migration-planner-api-container: bin Containerfile.api go.mod go.sum $(GO_FILES)
-	$(PODMAN) build . -f Containerfile.api $(if $(LABEL),--label "$(LABEL)") -t $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG)
+	$(PODMAN) build . -f $(if $(DEBUG_MODE),Containerfile.api-debug,Containerfile.api) $(if $(LABEL),--label "$(LABEL)") -t $(MIGRATION_PLANNER_API_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG)
 
 migration-planner-api-container: bin/.migration-planner-api-container
 migration-planner-agent-container: bin/.migration-planner-agent-container
@@ -144,16 +144,16 @@ quay-login:
 
 push-api-container: migration-planner-api-container quay-login
 	if [ -f $(DOCKER_AUTH_FILE) ]; then \
-		$(PODMAN) push --authfile $(DOCKER_AUTH_FILE) $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG); \
+		$(PODMAN) push --authfile $(DOCKER_AUTH_FILE) $(MIGRATION_PLANNER_API_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG); \
 	else \
-		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):$(REGISTRY_TAG); \
+		$(PODMAN) push $(MIGRATION_PLANNER_API_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG); \
 	fi;
 
 push-agent-container: migration-planner-agent-container quay-login
 	if [ -f $(DOCKER_AUTH_FILE) ]; then \
-		$(PODMAN) push --authfile=$(DOCKER_AUTH_FILE) $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG); \
+		$(PODMAN) push --authfile=$(DOCKER_AUTH_FILE) $(MIGRATION_PLANNER_AGENT_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG); \
 	else \
-		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(REGISTRY_TAG); \
+		$(PODMAN) push $(MIGRATION_PLANNER_AGENT_IMAGE):$(MIGRATION_PLANNER_IMAGE_TAG); \
 	fi;
 
 push-containers: push-api-container push-agent-container
@@ -164,6 +164,7 @@ deploy-on-openshift: oc
 	echo "*** Deploy Migration Planner on Openshift. Project: $${openshift_project}, Base URL: $${openshift_base_url} ***";\
 	oc process -f deploy/templates/postgres-template.yml | oc apply -f -; \
 	oc process -f deploy/templates/service-template.yml \
+       -p DEBUG_MODE=$(DEBUG_MODE) \
        -p MIGRATION_PLANNER_IMAGE=$(MIGRATION_PLANNER_API_IMAGE) \
        -p MIGRATION_PLANNER_AGENT_IMAGE=$(MIGRATION_PLANNER_AGENT_IMAGE) \
        -p MIGRATION_PLANNER_REPLICAS=${MIGRATION_PLANNER_REPLICAS} \

--- a/data/ignition.template
+++ b/data/ignition.template
@@ -156,6 +156,9 @@ storage:
           AutoUpdate=registry
           Exec= -config /agent/config/config.yaml
           PublishPort=3333:3333
+          {{ if .DebugMode }}
+          PublishPort=40001:40001
+          {{ end }}
           Volume=/home/core/.migration-planner:/agent:Z
           Volume=/var/lib/data:/agent/persistent-data:Z
           Environment=OPA_SERVER=127.0.0.1:8181

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -4,6 +4,9 @@ apiVersion: template.openshift.io/v1
 metadata:
   name: assisted-migration-service
 parameters:
+  - name: DEBUG_MODE
+    description: If set the debug port 400001 will be opened on Agent VM
+    value: ""
   - name: MIGRATION_PLANNER_IMAGE
     required: true
   - name: MIGRATION_PLANNER_API_IMAGE_PULL_POLICY
@@ -180,6 +183,8 @@ objects:
                   value: ${MIGRATION_PLANNER_AGENT_IMAGE}:${IMAGE_TAG}
                 - name: BASE_AGENT_ENDPOINT_URL
                   value: ${MIGRATION_PLANNER_URL}
+                - name: DEBUG_MODE
+                  value: ${DEBUG_MODE}
                 - name: PERSISTENT_DISK_DEVICE
                   value: ${PERSISTENT_DISK_DEVICE}
                 - name:  INSECURE_REGISTRY

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -45,6 +45,7 @@ const (
 
 // IgnitionData defines modifiable fields in ignition config
 type IgnitionData struct {
+	DebugMode                  string
 	SshKey                     string
 	PlannerServiceUI           string
 	PlannerService             string
@@ -69,6 +70,7 @@ type ImageBuilder struct {
 	SshKey                     string
 	Proxy                      Proxy
 	CertificateChain           string
+	DebugMode                  string
 	PlannerServiceUI           string
 	PlannerService             string
 	MigrationPlannerAgentImage string
@@ -87,6 +89,7 @@ type ImageBuilder struct {
 func NewImageBuilder(sourceID uuid.UUID) *ImageBuilder {
 	imageBuilder := &ImageBuilder{
 		SourceID:                   sourceID.String(),
+		DebugMode:                  util.GetEnv("DEBUG_MODE", ""),
 		PlannerService:             util.GetEnv("CONFIG_SERVER", defaultPlannerService),
 		PlannerServiceUI:           util.GetEnv("CONFIG_SERVER_UI", defaultConfigServerUI),
 		MigrationPlannerAgentImage: util.GetEnv("MIGRATION_PLANNER_AGENT_IMAGE", defaultAgentImage),
@@ -169,6 +172,7 @@ func (b *ImageBuilder) Validate() error {
 
 func (b *ImageBuilder) generateIgnition() (string, error) {
 	ignData := IgnitionData{
+		DebugMode:                  b.DebugMode,
 		SourceID:                   b.SourceID,
 		SshKey:                     b.SshKey,
 		PlannerServiceUI:           b.PlannerServiceUI,


### PR DESCRIPTION
This PR add support for remote debugging.
We add two new container files:

 - Containerfile.agent-debug
 - Containerfile.api-debug

The makefile has support to build the application in debug mode using
the `DEBUG_MODE` env variable.

So in order to build container in debug mode please run:

 `DEBUG_MODE=true make push-containers`

Then to debug the code please follow the guide in `doc/debugdeployment.md`

Signed-off-by: Aviel Segev <asegev@redhat.com>
Signed-off-by: borod108 <boris.od@gmail.com>
Signed-off-by: Ondra Machacek <omachace@redhat.com>