### PR TITLE
metrics: create own router metric middleware to support slo buckets

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kubev2v/migration-planner/pkg/log"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/kubev2v/migration-planner/pkg/metrics"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -20,7 +22,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/util"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
-	chiprometheus "github.com/toshi0607/chi-prometheus"
 	"go.uber.org/zap"
 )
 
@@ -69,7 +70,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 
 	router := chi.NewRouter()
 
-	metricMiddleware := chiprometheus.New("agent_server")
+	metricMiddleware := metrics.NewMiddleware("agent_server")
 	metricMiddleware.MustRegisterDefault()
 
 	router.Use(

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/kubev2v/migration-planner/pkg/metrics"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -21,7 +22,6 @@ import (
 	service "github.com/kubev2v/migration-planner/internal/service/image"
 	"github.com/kubev2v/migration-planner/internal/store"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
-	chiprometheus "github.com/toshi0607/chi-prometheus"
 	"go.uber.org/zap"
 )
 
@@ -70,7 +70,7 @@ func (s *ImageServer) Run(ctx context.Context) error {
 
 	router := chi.NewRouter()
 
-	metricMiddleware := chiprometheus.New("image_server")
+	metricMiddleware := metrics.NewMiddleware("image_server")
 	metricMiddleware.MustRegisterDefault()
 
 	router.Use(

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -20,8 +20,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/kubev2v/migration-planner/pkg/metrics"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
-	chiprometheus "github.com/toshi0607/chi-prometheus"
 	"go.uber.org/zap"
 )
 
@@ -85,7 +85,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	router := chi.NewRouter()
 
-	metricMiddleware := chiprometheus.New("api_server")
+	metricMiddleware := metrics.NewMiddleware("api_server")
 	metricMiddleware.MustRegisterDefault()
 
 	router.Use(

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	bucketsConfig = []float64{300, 500, 1000, 5000}
+)
+
+const (
+	// EnvChiPrometheusLatencyBuckets represents an environment variable, which is formatted like "100,200,300,400" as string
+	EnvChiPrometheusLatencyBuckets = "CHI_PROMETHEUS_LATENCY_BUCKETS"
+	RequestsCollectorName          = "chi_requests_total"
+	LatencyCollectorName           = "chi_request_duration_milliseconds"
+)
+
+// Middleware is a handler that exposes prometheus metrics for the number of requests,
+// the latency, and the response size partitioned by status code, method, and HTTP path.
+type Middleware struct {
+	requests *prometheus.CounterVec
+	latency  *prometheus.HistogramVec
+}
+
+func setBucket() {
+	var buckets []float64
+	conf, ok := os.LookupEnv(EnvChiPrometheusLatencyBuckets)
+	if ok {
+		for _, v := range strings.Split(conf, ",") {
+			f64v, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				panic(err)
+			}
+			buckets = append(buckets, f64v)
+		}
+		bucketsConfig = buckets
+	}
+}
+
+// New returns a new prometheus middleware for the provided service name.
+func NewMiddleware(name string) *Middleware {
+	setBucket()
+
+	var m Middleware
+	m.requests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        RequestsCollectorName,
+			Help:        "Number of HTTP requests partitioned by status code, method and HTTP path.",
+			ConstLabels: prometheus.Labels{"service": name},
+		}, []string{"code", "method", "path"})
+
+	m.latency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        LatencyCollectorName,
+		Help:        "Time spent on the request partitioned by status code, method and HTTP path.",
+		ConstLabels: prometheus.Labels{"service": name},
+		Buckets:     bucketsConfig,
+	}, []string{"code", "method", "path"})
+
+	return &m
+}
+
+// Handler returns a handler for the middleware pattern.
+func (m Middleware) Handler(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		next.ServeHTTP(ww, r)
+
+		if rctx := chi.RouteContext(r.Context()); rctx != nil {
+			rp := rctx.RoutePattern()
+			since := float64(time.Since(start).Milliseconds())
+			m.requests.WithLabelValues(strconv.Itoa(ww.Status()), r.Method, rp).Inc()
+			m.latency.WithLabelValues(strconv.Itoa(ww.Status()), r.Method, rp).Observe(since)
+		}
+	}
+	return http.HandlerFunc(fn)
+}
+
+// Collectors returns collector for your own collector registry.
+func (m Middleware) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{m.requests, m.latency}
+}
+
+// MustRegisterDefault registers collectors to DefaultRegisterer. If you don't initialize the collector registry,
+// this method should be called before calling promhttp.Handler().
+func (m Middleware) MustRegisterDefault() {
+	if m.requests == nil || m.latency == nil {
+		panic("collectors must be set")
+	}
+	prometheus.MustRegister(m.requests)
+	prometheus.MustRegister(m.latency)
+}


### PR DESCRIPTION
To use the same sli levels as the other services in app-interface, the buckets must be redefined to: 300ms, 500ms, and 1s.
To support that, a new custom metric middleware has been added to the metrics package.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>