### PR TITLE
cache: return the public keys from store not from cache

### DIFF
--- a/internal/store/cache_key.go
+++ b/internal/store/cache_key.go
@@ -41,16 +41,14 @@ func (p *CachePrivateKeyStore) Delete(ctx context.Context, orgID string) error {
 }
 
 func (p *CachePrivateKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
-	if len(p.publicKeys) != 0 {
-		return p.publicKeys, nil
-	}
+	// if len(p.publicKeys) != 0 {
+	// 	return p.publicKeys, nil
+	// }
 
 	pb, err := p.delegate.GetPublicKeys(ctx)
 	if err != nil {
 		return make(map[string]crypto.PublicKey), err
 	}
-
-	p.publicKeys = pb
 
 	return pb, nil
 }


### PR DESCRIPTION
for now, removes the ability to cache public keys

## Summary by Sourcery

Enhancements:
- Modify GetPublicKeys method to always fetch public keys from the delegate store instead of using a cached version