### PR TITLE
cache: proper initialize cache key map

### DIFF
--- a/internal/store/cache_key.go
+++ b/internal/store/cache_key.go
@@ -3,52 +3,63 @@ package store
 import (
 	"context"
 	"crypto"
+	"sync"
 
 	"github.com/kubev2v/migration-planner/internal/store/model"
 )
 
-// CachePrivateKeyStore is wrapper around PrivateKeyStore which provide basic caching of the public keys.
-type CachePrivateKeyStore struct {
+// CacheKeyStore is wrapper around PrivateKeyStore which provide basic caching of the public keys.
+type CacheKeyStore struct {
 	delegate   PrivateKey
 	publicKeys map[string]crypto.PublicKey
+	mu         sync.Mutex
 }
 
-func NewCachePrivateKeyStore(delegate PrivateKey) PrivateKey {
-	return &CachePrivateKeyStore{
+func NewCacheKeyStore(delegate PrivateKey) PrivateKey {
+	return &CacheKeyStore{
 		delegate:   delegate,
 		publicKeys: make(map[string]crypto.PublicKey),
 	}
 }
 
-func (p *CachePrivateKeyStore) Create(ctx context.Context, privateKey model.Key) (*model.Key, error) {
+func (p *CacheKeyStore) Create(ctx context.Context, privateKey model.Key) (*model.Key, error) {
 	r, err := p.delegate.Create(ctx, privateKey)
 	if err != nil {
 		return r, err
 	}
 
 	// invalidate cache
+	p.mu.Lock()
 	p.publicKeys = make(map[string]crypto.PublicKey)
+	p.mu.Unlock()
 
 	return r, nil
 }
 
-func (p *CachePrivateKeyStore) Get(ctx context.Context, orgID string) (*model.Key, error) {
+func (p *CacheKeyStore) Get(ctx context.Context, orgID string) (*model.Key, error) {
 	return p.delegate.Get(ctx, orgID)
 }
 
-func (p *CachePrivateKeyStore) Delete(ctx context.Context, orgID string) error {
+func (p *CacheKeyStore) Delete(ctx context.Context, orgID string) error {
 	return p.delegate.Delete(ctx, orgID)
 }
 
-func (p *CachePrivateKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
-	// if len(p.publicKeys) != 0 {
-	// 	return p.publicKeys, nil
-	// }
+func (p *CacheKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.publicKeys) != 0 {
+		return p.publicKeys, nil
+	}
 
 	pb, err := p.delegate.GetPublicKeys(ctx)
 	if err != nil {
 		return make(map[string]crypto.PublicKey), err
 	}
 
-	return pb, nil
+	for k, v := range pb {
+		p.publicKeys[k] = v
+	}
+
+	return p.publicKeys, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,7 +33,7 @@ func NewStore(db *gorm.DB) Store {
 		agent:      NewAgentSource(db),
 		source:     NewSource(db),
 		imageInfra: NewImageInfraStore(db),
-		privateKey: NewCachePrivateKeyStore(NewPrivateKey(db)),
+		privateKey: NewCacheKeyStore(NewPrivateKey(db)),
 		db:         db,
 	}
 }


### PR DESCRIPTION
This PR properly initializes the new cache map. Also, the name is changed to reflect the actual function of the cache store.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Improve cache initialization and naming for the private key store

Enhancements:
- Properly initialize the cache map for public keys by populating the internal cache during GetPublicKeys method

Chores:
- Rename CachePrivateKeyStore to CacheKeyStore to better reflect its function