### PR TITLE
migrations: Remove unused username and org_id column from agents

### DIFF
--- a/pkg/migrations/sql/20250414125006_remove_org_username_agent.sql
+++ b/pkg/migrations/sql/20250414125006_remove_org_username_agent.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE agents DROP COLUMN IF EXISTS username;
+ALTER TABLE agents DROP COLUMN IF EXISTS org_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- no statement because this migration is done to sync the old schema with the current one.
+-- +goose StatementEnd


### PR DESCRIPTION
This migration removes the `username` and `org_id` from agents table. They are not used anymore. Previously, they were not removed due to the `IF EXISTS` condition.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Chores:
- Create a database migration to drop the unused 'username' and 'org_id' columns from the agents table