### PR TITLE
Fix sending the headers for image download

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -151,7 +151,7 @@ func (o *GenerateOptions) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if _, err := imageBuilder.Generate(ctx, output); err != nil {
+	if err := imageBuilder.Generate(ctx, output); err != nil {
 		return fmt.Errorf("failed to write image: %s", err)
 	}
 

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -65,16 +65,23 @@ func (h *ServiceHandler) GetImage(ctx context.Context, request server.GetImageRe
 		return server.GetImage500JSONResponse{}, nil
 	}
 
-	size, err := imageBuilder.Generate(ctx, writer)
+	// Get image size
+	size, err := imageBuilder.Size()
+	if err != nil {
+		return server.GetImage500JSONResponse{Message: fmt.Sprintf("failed to read image size %s", err)}, nil
+	}
+
+	// Set proper headers of the OVA file:
+	writer.Header().Set("Content-Type", "application/ovf")
+	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", fmt.Sprintf("%s.ova", source.Name)))
+	writer.Header().Set("Content-Length", strconv.Itoa(size))
+
+	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
 		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
 		return server.GetImage500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
-
-	// Set proper headers of the OVA file:
-	writer.Header().Set("Content-Type", "application/ovf")
-	writer.Header().Set("Content-Length", strconv.Itoa(size))
 
 	metrics.IncreaseOvaDownloadsTotalMetric("successful")
 

--- a/internal/service/image/handler.go
+++ b/internal/service/image/handler.go
@@ -67,17 +67,23 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 		return imageServer.GetImageByToken500JSONResponse{}, nil
 	}
 
-	size, err := imageBuilder.Generate(ctx, writer)
+	// Get image size
+	size, err := imageBuilder.Size()
+	if err != nil {
+		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to read image size %s", err)}, nil
+	}
+
+	// Set proper headers of the OVA file:
+	writer.Header().Set("Content-Type", "application/ovf")
+	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", req.Name))
+	writer.Header().Set("Content-Length", strconv.Itoa(size))
+
+	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
 		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
 		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
-
-	// Set proper headers of the OVA file:
-	writer.Header().Set("Content-Type", "application/ovf")
-	writer.Header().Set("Content-Length", strconv.Itoa(size))
-	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", req.Name))
 
 	metrics.IncreaseOvaDownloadsTotalMetric("successful")
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor image generation to separate size calculation from image generation, and improve header handling for image downloads

Bug Fixes:
- Fix content length header setting by separating size calculation from image generation
- Ensure correct headers are set before image generation

Enhancements:
- Split image generation into two separate methods: one for calculating size and another for generating the image
- Improve error handling and method signatures in image generation process