### PR TITLE
log: convert unstructured some log entries to structured

### DIFF
--- a/cmd/planner-api/migrate.go
+++ b/cmd/planner-api/migrate.go
@@ -21,21 +21,21 @@ var migrateCmd = &cobra.Command{
 
 		cfg, err := config.New()
 		if err != nil {
-			zap.S().Fatalf("reading configuration: %v", err)
+			zap.S().Fatalw("reading configuration", "error", err)
 		}
-		zap.S().Infof("Using config: %s", cfg)
+		zap.S().Infow("Using config", "configuration", cfg)
 
 		zap.S().Info("Initializing data store")
 		db, err := store.InitDB(cfg)
 		if err != nil {
-			zap.S().Fatalf("initializing data store: %v", err)
+			zap.S().Fatalw("initializing data store", "error", err)
 		}
 
 		store := store.NewStore(db)
 		defer store.Close()
 
 		if err := migrations.MigrateStore(db, cfg.Service.MigrationFolder); err != nil {
-			zap.S().Fatalf("running initial migration: %v", err)
+			zap.S().Fatalw("running initial migration", "error", err)
 		}
 
 		return nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,7 +23,7 @@ const (
 )
 
 func NewAuthenticator(authConfig config.Auth) (Authenticator, error) {
-	zap.S().Named("auth").Infof("authentication: '%s'", authConfig.AuthenticationType)
+	zap.S().Named("auth").Infow("creating authenticator", "type", authConfig.AuthenticationType)
 
 	switch authConfig.AuthenticationType {
 	case RHSSOAuthentication:

--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -33,7 +33,7 @@ func AgentFromContext(ctx context.Context) (AgentJWT, bool) {
 func MustHaveUser(ctx context.Context) User {
 	user, found := UserFromContext(ctx)
 	if !found {
-		zap.S().Named("auth").Panicf("failed to find user in context")
+		zap.S().Named("auth").Panic("failed to find user in context")
 	}
 	return user
 }
@@ -41,7 +41,7 @@ func MustHaveUser(ctx context.Context) User {
 func MustHaveAgent(ctx context.Context) AgentJWT {
 	agentJwt, found := AgentFromContext(ctx)
 	if !found {
-		zap.S().Named("auth").Panicf("failed to find agent jwt in context")
+		zap.S().Named("auth").Panic("failed to find agent jwt in context")
 	}
 	return agentJwt
 }

--- a/internal/service/agent/handler.go
+++ b/internal/service/agent/handler.go
@@ -119,7 +119,7 @@ func (h *AgentServiceHandler) UpdateAgentStatus(ctx context.Context, request age
 func (h *AgentServiceHandler) updateMetrics() {
 	agents, err := h.store.Agent().List(context.TODO(), store.NewAgentQueryFilter(), store.NewAgentQueryOptions())
 	if err != nil {
-		zap.S().Named("agent_handler").Warnf("failed to update agent metrics: %s", err)
+		zap.S().Named("agent_handler").Warnw("failed to update agent metrics", "error", err)
 		return
 	}
 	// holds the total number of agents by state

--- a/internal/service/agent/wrapper.go
+++ b/internal/service/agent/wrapper.go
@@ -24,7 +24,7 @@ func (h *AgentServiceHandlerLogger) UpdateSourceInventory(ctx context.Context, r
 
 	resp, err := h.delegate.UpdateSourceInventory(ctx, request)
 	if err != nil {
-		zap.S().Named("agent_handler").Errorf("failed to update source inventory: %s", err)
+		zap.S().Named("agent_handler").Errorw("failed to update source inventory", "error", err)
 	}
 
 	return resp, nil
@@ -41,7 +41,7 @@ func (h *AgentServiceHandlerLogger) UpdateAgentStatus(ctx context.Context, reque
 
 	resp, err := h.delegate.UpdateAgentStatus(ctx, request)
 	if err != nil {
-		zap.S().Named("agent_handler").Errorf("failed to update agent status: %s", err)
+		zap.S().Named("agent_handler").Errorw("failed to update agent status", "error", err)
 	}
 
 	return resp, nil

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -79,7 +79,7 @@ func (h *ServiceHandler) GetImage(ctx context.Context, request server.GetImageRe
 	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
-		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
+		zap.S().Named("image_service").Errorw("failed to generate ova at GetImage", "error", err)
 		return server.GetImage500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
 
@@ -111,7 +111,7 @@ func (h *ServiceHandler) HeadImage(ctx context.Context, request server.HeadImage
 	}
 
 	if err := imageBuilder.Validate(); err != nil {
-		zap.S().Named("image_service").Errorf("error validating at HeadImage: %s", err)
+		zap.S().Named("image_service").Errorw("error validating at HeadImage", "error", err)
 		return server.HeadImage500Response{}, nil
 	}
 

--- a/internal/service/image/handler.go
+++ b/internal/service/image/handler.go
@@ -78,7 +78,7 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
-		zap.S().Named("image_service").Errorf("failed to generate ova at GetImage: %s", err)
+		zap.S().Named("image_service").Errorw("failed to generate ova at GetImage", "error", err)
 		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Enhancements:
- Replace unstructured logging calls (Fatalf, Infof, Errorf) with structured logging methods (Fatalw, Infow, Errorw) across multiple files