### PR TITLE
fix request_id missing in agent logs

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -72,9 +72,9 @@ func (s *AgentServer) Run(ctx context.Context) error {
 	router.Use(
 		util.GatewayApiRewrite,
 		metricMiddleware.Handler,
+		middleware.RequestID,
 		log.Logger(zap.L(), "router_agent"),
 		auth.NewAgentAuthenticator(s.store).Authenticator,
-		middleware.RequestID,
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 	)


### PR DESCRIPTION
bug fix: request_id is missing in http logs for agent http requests

## Summary by Sourcery

Bug Fixes:
- Ensure request_id is included in agent HTTP request logs by adjusting middleware placement