### PR TITLE
agent-server: Add flag to enable or disable agent auth

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -77,6 +77,9 @@ parameters:
     description: Define the backend authentication mechanism
   - name: MIGRATION_PLANNER_JWK_URL
     description: URL of the x.509 certificate chain that was used to verify the digital signature of the JWT
+  - name: MIGRATION_PLANNER_AGENT_AUTH_ENABLED
+    description: Enable agent authentication for agent-server
+    value: "true"
   - name: MIGRATION_PLANNER_MIGRATIONS_FOLDER
     description: Path to the migration folder containing the sql files used to migrate the db
     value: "/app/migrations"
@@ -539,6 +542,8 @@ objects:
                       optional: true
                 - name: MIGRATION_PLANNER_JWK_URL
                   value: ${MIGRATION_PLANNER_JWK_URL}
+                - name: MIGRATION_PLANNER_AGENT_AUTH_ENABLED
+                  value: ${MIGRATION_PLANNER_AGENT_AUTH_ENABLED}
                 # DB Config values
                 - name: DB_HOST
                   valueFrom:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,9 +44,10 @@ type kafkaConfig struct {
 }
 
 type Auth struct {
-	AuthenticationType string `envconfig:"MIGRATION_PLANNER_AUTH" default:""`
-	JwkCertURL         string `envconfig:"MIGRATION_PLANNER_JWK_URL" default:""`
-	LocalPrivateKey    string `envconfig:"MIGRATION_PLANNER_PRIVATE_KEY" default:""`
+	AuthenticationType         string `envconfig:"MIGRATION_PLANNER_AUTH" default:""`
+	JwkCertURL                 string `envconfig:"MIGRATION_PLANNER_JWK_URL" default:""`
+	LocalPrivateKey            string `envconfig:"MIGRATION_PLANNER_PRIVATE_KEY" default:""`
+	AgentAuthenticationEnabled bool   `envconfig:"MIGRATION_PLANNER_AGENT_AUTH_ENABLED" default:"true"`
 }
 
 func New() (*Config, error) {


### PR DESCRIPTION
For local dev, it's useful to disable agent authentication. This commit adds a configuration option to disable or enable the agent authentication.
By default, the agent authentication is enabled.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Add a configuration option to enable or disable agent authentication in the agent server

New Features:
- Introduce a configuration flag to control agent authentication, allowing it to be disabled for local development

Enhancements:
- Modify the agent server authentication middleware to be conditionally applied based on configuration

Chores:
- Update service template to include new agent authentication configuration parameter