### PR TITLE
[E2E] Add Multiple-users test case

### DIFF
--- a/test/e2e/e2e_agent/agent_api.go
+++ b/test/e2e/e2e_agent/agent_api.go
@@ -12,31 +12,32 @@ import (
 	"net/http"
 )
 
+// AgentApi provides a client to interact with the Planner Agent API
 type AgentApi struct {
 	baseURL    string
 	httpClient *http.Client
 }
 
+// DefaultAgentApi creates an AgentApi client with a default HTTP client that skips TLS verification
 func DefaultAgentApi(agentApiBaseUrl string) *AgentApi {
-	return &AgentApi{
-		baseURL: agentApiBaseUrl,
-		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
+	return NewAgentApi(agentApiBaseUrl, &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
 			},
 		},
-	}
+	})
 }
 
-func CustomAgentApi(agentApiBaseUrl string, customHttpClient *http.Client) *AgentApi {
+// NewAgentApi creates an AgentApi client with a custom HTTP client, useful for test customization
+func NewAgentApi(agentApiBaseUrl string, customHttpClient *http.Client) *AgentApi {
 	return &AgentApi{
 		baseURL:    agentApiBaseUrl,
 		httpClient: customHttpClient,
 	}
 }
 
+// request is a helper to send an HTTP request to the agent and unmarshal the response into given struct
 func (api *AgentApi) request(method string, path string, body []byte, result any) (*http.Response, error) {
 	var req *http.Request
 	var err error
@@ -79,6 +80,7 @@ func (api *AgentApi) request(method string, path string, body []byte, result any
 	return res, nil
 }
 
+// Version retrieves the agent's version string
 func (api *AgentApi) Version() (string, error) {
 	var result struct {
 		Version string `json:"version"`
@@ -91,6 +93,7 @@ func (api *AgentApi) Version() (string, error) {
 	return result.Version, nil
 }
 
+// Login put the vCenter credentials
 func (api *AgentApi) Login(url string, user string, pass string) (*http.Response, error) {
 	zap.S().Infof("Attempting vCenter login with URL: %s, User: %s", url, user)
 
@@ -113,6 +116,7 @@ func (api *AgentApi) Login(url string, user string, pass string) (*http.Response
 	return res, nil
 }
 
+// Status retrieves the current status of the agent
 func (api *AgentApi) Status() (*coreAgent.StatusReply, error) {
 	result := &coreAgent.StatusReply{}
 	res, err := api.request(http.MethodGet, "status", nil, result)
@@ -124,6 +128,7 @@ func (api *AgentApi) Status() (*coreAgent.StatusReply, error) {
 	return result, nil
 }
 
+// Inventory retrieves the inventory data collected by the agent
 func (api *AgentApi) Inventory() (*v1alpha1.Inventory, error) {
 	var result struct {
 		Inventory v1alpha1.Inventory `json:"inventory"`

--- a/test/e2e/e2e_disconnected_env_test.go
+++ b/test/e2e/e2e_disconnected_env_test.go
@@ -32,14 +32,14 @@ var _ = Describe("e2e-disconnected-environment", func() {
 		TestOptions.DownloadImageByUrl = false
 		TestOptions.DisconnectedEnvironment = true
 
-		svc, err = NewPlannerService()
+		svc, err = DefaultPlannerService()
 		Expect(err).To(BeNil(), "Failed to create PlannerService")
 
 		source, err = svc.CreateSource("source")
 		Expect(err).To(BeNil())
 		Expect(source).NotTo(BeNil())
 
-		agent, err = CreateAgent(DefaultAgentTestID, source.Id, VmName)
+		agent, err = CreateAgent(DefaultAgentTestID, source.Id, VmName, svc)
 		Expect(err).To(BeNil())
 
 		zap.S().Info("Waiting for agent IP...")

--- a/test/e2e/e2e_helpers/test_helpers.go
+++ b/test/e2e/e2e_helpers/test_helpers.go
@@ -1,6 +1,7 @@
 package e2e_helpers
 
 import (
+	"fmt"
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
 	. "github.com/kubev2v/migration-planner/test/e2e/e2e_agent"
@@ -9,9 +10,9 @@ import (
 )
 
 // CreateAgent Create VM with the UUID of the source created
-func CreateAgent(idForTest string, uuid uuid.UUID, vmName string) (PlannerAgent, error) {
+func CreateAgent(idForTest string, uuid uuid.UUID, vmName string, svc PlannerService) (PlannerAgent, error) {
 	zap.S().Info("Creating agent...")
-	agent, err := NewPlannerAgent(uuid, vmName, idForTest)
+	agent, err := NewPlannerAgent(uuid, vmName, idForTest, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -24,29 +25,24 @@ func CreateAgent(idForTest string, uuid uuid.UUID, vmName string) (PlannerAgent,
 }
 
 // AgentIsUpToDate helper function to check that source is up to date eventually
-func AgentIsUpToDate(svc PlannerService, uuid uuid.UUID) bool {
+func AgentIsUpToDate(svc PlannerService, uuid uuid.UUID) (bool, error) {
 	source, err := svc.GetSource(uuid)
 	if err != nil {
-		zap.S().Errorf("Error getting source.")
-		return false
+		return false, fmt.Errorf("error getting source")
 	}
 	zap.S().Infof("agent status is: %s", string(source.Agent.Status))
-	return source.Agent.Status == v1alpha1.AgentStatusUpToDate
+	return source.Agent.Status == v1alpha1.AgentStatusUpToDate, nil
 }
 
 // CredentialURL helper function which return credential url for an Agent by source UUID
-func CredentialURL(svc PlannerService, uuid uuid.UUID) string {
+func CredentialURL(svc PlannerService, uuid uuid.UUID) (string, error) {
 	zap.S().Info("try to retrieve valid credentials url")
 	s, err := svc.GetSource(uuid)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("error getting source")
 	}
 	if s.Agent == nil {
-		return ""
+		return "", fmt.Errorf("source has no agent")
 	}
-	if s.Agent.CredentialUrl != "N/A" && s.Agent.CredentialUrl != "" {
-		return s.Agent.CredentialUrl
-	}
-
-	return ""
+	return s.Agent.CredentialUrl, nil
 }

--- a/test/e2e/e2e_multiple_users_test.go
+++ b/test/e2e/e2e_multiple_users_test.go
@@ -1,0 +1,80 @@
+package e2e_test
+
+import (
+	"fmt"
+	. "github.com/kubev2v/migration-planner/test/e2e"
+	. "github.com/kubev2v/migration-planner/test/e2e/e2e_service"
+	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"strings"
+	"time"
+)
+
+var _ = Describe("e2e-multiple-users", func() {
+	var (
+		users         = []string{"user", "admin", "koko"}
+		organizations = []string{"redhat", "intel", "apple", "microsoft", "nvidia"}
+		svc           PlannerService
+		err           error
+		startTime     time.Time
+	)
+
+	BeforeEach(func() {
+		startTime = time.Now()
+		TestOptions.DownloadImageByUrl = false
+		TestOptions.DisconnectedEnvironment = false
+
+		svc, err = DefaultPlannerService()
+		Expect(err).To(BeNil())
+
+		// Iterate over each organization and user to authenticate and create a unique source per org-user pair
+		for _, org := range organizations {
+			for _, user := range users {
+				err = svc.ChangeCredentials(UserAuth(user, org))
+				Expect(err).To(BeNil())
+				_, err = svc.CreateSource(fmt.Sprintf("%s-%s", org, user))
+				Expect(err).To(BeNil())
+			}
+		}
+
+	})
+
+	AfterEach(func() {
+		zap.S().Info("Cleaning up after test...")
+		for _, org := range organizations {
+			for _, user := range users {
+				err = svc.ChangeCredentials(UserAuth(user, org))
+				Expect(err).To(BeNil())
+				err := svc.RemoveSources()
+				Expect(err).To(BeNil(), "Failed to remove sources from DB")
+			}
+		}
+		testDuration := time.Since(startTime)
+		zap.S().Infof("Test completed in: %s\n", testDuration.String())
+		TestsExecutionTime[CurrentSpecReport().LeafNodeText] = testDuration
+	})
+
+	Context("Multiple Users", func() {
+		It("Users should see only organizational sources", func() {
+			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
+
+			// Verify that each user sees only the sources created by their own organization
+			for _, org := range organizations {
+				for _, user := range users {
+					err = svc.ChangeCredentials(UserAuth(user, org))
+					Expect(err).To(BeNil())
+					visibleSources, err := svc.GetSources()
+					Expect(err).To(BeNil())
+					Expect(*visibleSources).To(HaveLen(len(users)))
+					for _, source := range *visibleSources {
+						Expect(strings.Split(source.Name, "-")[0]).To(Equal(org))
+					}
+				}
+			}
+
+			zap.S().Infof("============Successfully Passed: %s=====", CurrentSpecReport().LeafNodeText)
+		})
+	})
+})

--- a/test/e2e/e2e_service/service.go
+++ b/test/e2e/e2e_service/service.go
@@ -7,35 +7,53 @@ import (
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	internalclient "github.com/kubev2v/migration-planner/internal/api/client"
+	"github.com/kubev2v/migration-planner/internal/auth"
 	. "github.com/kubev2v/migration-planner/test/e2e"
 	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
 	"go.uber.org/zap"
+	"io"
 	"net/http"
+	"os"
 )
 
+// PlannerService defines the interface for interacting with the planner service
 type PlannerService interface {
-	CreateSource(name string) (*api.Source, error)
-	GetSource(id uuid.UUID) (*api.Source, error)
-	RemoveSource(id uuid.UUID) error
+	CreateSource(string) (*api.Source, error)
+	GetImage(*os.File, uuid.UUID) error
+	GetImageUrl(uuid.UUID) (string, error)
+	GetSource(uuid.UUID) (*api.Source, error)
+	GetSources() (*api.SourceList, error)
+	RemoveSource(uuid.UUID) error
 	RemoveSources() error
 	UpdateSource(uuid.UUID, *v1alpha1.Inventory) error
+	ChangeCredentials(user *auth.User) error
 }
 
+// plannerService is the concrete implementation of PlannerService
 type plannerService struct {
-	api *ServiceApi
+	api         *ServiceApi
+	credentials *auth.User
 }
 
-func NewPlannerService() (*plannerService, error) {
+// DefaultPlannerService initializes a planner service using default *auth.User credentials
+func DefaultPlannerService() (*plannerService, error) {
+	return NewPlannerService(DefaultUserAuth())
+}
+
+// NewPlannerService initializes the planner service with custom *auth.User credentials
+func NewPlannerService(cred *auth.User) (*plannerService, error) {
 	zap.S().Info("Initializing PlannerService...")
-	return &plannerService{api: NewServiceApi()}, nil
+	serviceApi, err := NewServiceApi(cred)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize planner service API")
+	}
+	return &plannerService{api: serviceApi, credentials: cred}, nil
 }
 
+// CreateSource sends a request to create a new source with the given name
 func (s *plannerService) CreateSource(name string) (*api.Source, error) {
-	zap.S().Info("Creating source...")
-	user, err := DefaultUserAuth()
-	if err != nil {
-		return nil, err
-	}
+	zap.S().Infof("[PlannerService] Creating source: user: %s, organization: %s",
+		s.credentials.Username, s.credentials.Organization)
 
 	params := &v1alpha1.CreateSourceJSONRequestBody{Name: name}
 
@@ -57,7 +75,7 @@ func (s *plannerService) CreateSource(name string) (*api.Source, error) {
 		return nil, err
 	}
 
-	res, err := s.api.PostRequest("", reqBody, user.Token.Raw)
+	res, err := s.api.PostRequest("", reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +95,62 @@ func (s *plannerService) CreateSource(name string) (*api.Source, error) {
 	return createSourceRes.JSON201, nil
 }
 
-func (s *plannerService) GetSource(id uuid.UUID) (*api.Source, error) {
-	user, err := DefaultUserAuth()
+// GetImage downloads the image of the specified source and writes it to the given file
+func (s *plannerService) GetImage(destFile *os.File, id uuid.UUID) error {
+	zap.S().Infof("[PlannerService] Get image [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	getImagePath := id.String() + "/" + "image"
+	res, err := s.api.GetRequest(getImagePath)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to get source image: %w", err)
 	}
 
-	res, err := s.api.GetRequest(id.String(), user.Token.Raw)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download image: %s", res.Status)
+	}
+
+	if _, err = io.Copy(destFile, res.Body); err != nil {
+		return fmt.Errorf("failed to write to the file: %w", err)
+	}
+
+	return nil
+}
+
+// GetImageUrl retrieves the image URL for a specific source by UUID
+func (s *plannerService) GetImageUrl(id uuid.UUID) (string, error) {
+	zap.S().Infof("[PlannerService] Get image url [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	getImageUrlPath := id.String() + "/" + "image-url"
+	res, err := s.api.GetRequest(getImageUrlPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get source url: %w", err)
+	}
+	defer res.Body.Close()
+
+	var result struct {
+		ExpiresAt string `json:"expires_at"`
+		URL       string `json:"url"`
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("failed to decod JSON: %w", err)
+	}
+
+	return result.URL, nil
+}
+
+// GetSource fetches a single source by UUID
+func (s *plannerService) GetSource(id uuid.UUID) (*api.Source, error) {
+	zap.S().Infof("[PlannerService] Get source [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	res, err := s.api.GetRequest(id.String())
 	if err != nil {
 		return nil, err
 	}
@@ -97,13 +164,29 @@ func (s *plannerService) GetSource(id uuid.UUID) (*api.Source, error) {
 	return getSourceRes.JSON200, nil
 }
 
-func (s *plannerService) RemoveSource(uuid uuid.UUID) error {
-	user, err := DefaultUserAuth()
+// GetSources retrieves a list of all available sources
+func (s *plannerService) GetSources() (*api.SourceList, error) {
+	zap.S().Infof("[PlannerService] Get sources [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	res, err := s.api.GetRequest("")
 	if err != nil {
-		return err
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	getSourceRes, err := internalclient.ParseListSourcesResponse(res)
+	if err != nil || getSourceRes.HTTPResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to list sources. response status code: %d", getSourceRes.HTTPResponse.StatusCode)
 	}
 
-	res, err := s.api.DeleteRequest(uuid.String(), user.Token.Raw)
+	return getSourceRes.JSON200, nil
+}
+
+// RemoveSource deletes a specific source by UUID
+func (s *plannerService) RemoveSource(uuid uuid.UUID) error {
+	zap.S().Infof("[PlannerService] Delete source [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	res, err := s.api.DeleteRequest(uuid.String())
 	if err != nil {
 		return err
 	}
@@ -117,13 +200,11 @@ func (s *plannerService) RemoveSource(uuid uuid.UUID) error {
 	return err
 }
 
+// RemoveSources deletes all existing sources
 func (s *plannerService) RemoveSources() error {
-	user, err := DefaultUserAuth()
-	if err != nil {
-		return err
-	}
-
-	res, err := s.api.DeleteRequest("", user.Token.Raw)
+	zap.S().Infof("[PlannerService] Delete sources [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
+	res, err := s.api.DeleteRequest("")
 	if err != nil {
 		return err
 	}
@@ -136,12 +217,10 @@ func (s *plannerService) RemoveSources() error {
 	return err
 }
 
+// UpdateSource updates the inventory of a specific source
 func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Inventory) error {
-	user, err := DefaultUserAuth()
-	if err != nil {
-		return err
-	}
-
+	zap.S().Infof("[PlannerService] Update source [user: %s, organization: %s]",
+		s.credentials.Username, s.credentials.Organization)
 	update := v1alpha1.UpdateSourceJSONRequestBody{
 		AgentId:   uuid,
 		Inventory: *inventory,
@@ -152,7 +231,7 @@ func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Invent
 		return err
 	}
 
-	res, err := s.api.PutRequest(uuid.String(), reqBody, user.Token.Raw)
+	res, err := s.api.PutRequest(uuid.String(), reqBody)
 	if err != nil {
 		return err
 	}
@@ -164,4 +243,20 @@ func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Invent
 	}
 
 	return err
+}
+
+// ChangeCredentials sets the plannerService's credentials and initializes a new Service API instance
+// if the provided credentials differ from the currently stored ones.
+func (s *plannerService) ChangeCredentials(newCredentials *auth.User) error {
+	if s.credentials.Organization == newCredentials.Organization &&
+		s.credentials.Username == newCredentials.Username {
+		return nil
+	}
+	newApi, err := NewServiceApi(newCredentials)
+	if err != nil {
+		return fmt.Errorf("error creating new Service api instance %s", err)
+	}
+	s.api = newApi
+	s.credentials = newCredentials
+	return nil
 }

--- a/test/e2e/e2e_utils/command.go
+++ b/test/e2e/e2e_utils/command.go
@@ -23,6 +23,9 @@ func RunLocalCommand(command string) (string, error) {
 	return string(output), err
 }
 
+// RunSSHCommand executes a command on a remote machine over SSH using sshpass for authentication.
+// It takes an IP address and a command string as parameters, runs the command on the remote machine,
+// and returns the command's output (stdout) as a string, or an error if the command fails.
 func RunSSHCommand(ip string, command string) (string, error) {
 	sshCmd := exec.Command("sshpass", "-p", "123456", "ssh", "-o", "StrictHostKeyChecking=no", "-o",
 		"UserKnownHostsFile=/dev/null", fmt.Sprintf("core@%s", ip), command)

--- a/test/e2e/e2e_utils/file.go
+++ b/test/e2e/e2e_utils/file.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 )
 
+// ValidateTar validates a tar file by checking if it contains at least one file with the following suffixes:
+// .ovf, .vmdk, and .iso. It also performs basic validation on the .ovf file to ensure it contains essential elements
+// like <Envelope> and <VirtualSystem>. Returns an error if any of these conditions are not met
 func ValidateTar(file *os.File) error {
 	_, _ = file.Seek(0, 0)
 	tarReader := tar.NewReader(file)
@@ -60,6 +63,9 @@ func ValidateTar(file *os.File) error {
 	return nil
 }
 
+// Untar extracts a specific file (identified by 'fileName') from a tar file and writes it to the 'destFile' path.
+// If the specified file is found, it is extracted and written; otherwise, an error is returned indicating that
+// the file was not found in the tar archive.
 func Untar(file *os.File, destFile string, fileName string) error {
 	_, _ = file.Seek(0, 0)
 	tarReader := tar.NewReader(file)

--- a/test/e2e/e2e_utils/log.go
+++ b/test/e2e/e2e_utils/log.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// LogExecutionSummary logs the execution time of all tests stored in the TestsExecutionTime map.
+// It sorts the tests by duration in descending order and logs the test name along with its execution duration.
 func LogExecutionSummary() {
 	zap.S().Infof("============Summarizing execution time============")
 


### PR DESCRIPTION
## Summary by Sourcery

Add multiple-users test case to validate organizational source isolation and authentication

New Features:
- Introduce multi-user authentication support in end-to-end testing framework
- Add ability to create and manage sources across different organizations

Enhancements:
- Extend PlannerService interface to support credential switching
- Add ChangeCredentials method to dynamically change authentication context
- Modify service methods to use per-request authentication

Tests:
- Implement a comprehensive test suite that verifies users can only access sources within their own organization
- Add test to create sources for multiple users and organizations
- Validate source visibility is restricted to the user's organization