### PR TITLE
ECOPROJECT-2844: Fix Envoy Route/Response timeout in "ingress-backend-image" listener

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -387,6 +387,7 @@ objects:
                             prefix: /api/v1/image
                           route:
                             cluster: backend-image
+                            timeout: 0s
                         - match: 
                             prefix: /health
                           route:


### PR DESCRIPTION
Disable this - envoy shoudn't wait for the response to complete and allow any duration

## Summary by Sourcery

Enhancements:
- Extend the response timeout for the backend image API route to allow longer-running requests