### PR TITLE
ECOPROJECT-2796: Update postgresql container

### DIFF
--- a/deploy/podman/compose.yaml
+++ b/deploy/podman/compose.yaml
@@ -1,7 +1,7 @@
 services:
   planner-db:
     container_name: planner-db
-    image: ${PGSQL_IMAGE:-quay.io/sclorg/postgresql-12-c8s:latest}
+    image: ${PGSQL_IMAGE:-quay.io/sclorg/postgresql-15-c9s:latest}
     environment:
       - POSTGRESQL_DATABASE=planner
       - POSTGRESQL_USER=demouser

--- a/deploy/templates/postgres-template.yml
+++ b/deploy/templates/postgres-template.yml
@@ -25,9 +25,9 @@ parameters:
     displayName: PostgreSQL Database Name
     value: planner
   - name: POSTGRES_IMAGE
-    description: Postgres image (14 or latest).
+    description: Postgres image (15).
     displayName: Postgres Image
-    value: quay.io/sclorg/postgresql-12-c8s
+    value: quay.io/sclorg/postgresql-15-c9s
   - name: DB_VOLUME_CAPACITY
     description: Volume space available for data, e.g. 512Mi, 2Gi.
     displayName: Volume Capacity


### PR DESCRIPTION
Update postgresql version from to postgresql-15-c9s
postgresql-12-c8s is already obsolete
Notice: this container is used only for development and testing

## Summary by Sourcery

Update the PostgreSQL container image from version 12 to 15 for development and testing environments.

Deployment:
- Update the default PostgreSQL image tag in the Podman compose file.
- Update the default PostgreSQL image tag in the deployment template.