### PR TITLE
store: Add metrics interceptor for pg driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,12 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.7.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/konveyor/forklift-controller v0.0.0-20221102112227-e73b65a01cda
 	github.com/libvirt/libvirt-go v7.4.0+incompatible
 	github.com/lthibault/jitterbug v2.0.0+incompatible
+	github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79
 	github.com/oapi-codegen/nethttp-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/onsi/ginkgo/v2 v2.15.0
@@ -95,7 +97,6 @@ require (
 	github.com/invopop/yaml v0.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.1 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79 h1:Dmx8g2747UTVPzSkmohk84S3g/uWqd6+f4SSLPhLcfA=
+github.com/ngrok/sqlmw v0.0.0-20220520173518-97c9c04efc79/go.mod h1:E26fwEtRNigBfFfHDWsklmo0T7Ixbg0XXgck+Hq4O9k=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/store/metric.go
+++ b/internal/store/metric.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"context"
+	"database/sql/driver"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ngrok/sqlmw"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	opRegex     = regexp.MustCompile(`^(\w)+`)
+	pgOpLatency *prometheus.HistogramVec
+	pgOpTotal   *prometheus.CounterVec
+)
+
+type metricInterceptor struct {
+	sqlmw.NullInterceptor
+}
+
+func init() {
+	pgOpLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "pg_op_duration_milliseconds",
+		Help:      "Time spent on a postgres operation",
+		Subsystem: "assisted_migrations",
+		Buckets:   []float64{100, 300, 500, 1000, 5000},
+	},
+		[]string{"op", "method"},
+	)
+	pgOpTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "pg_op_total",
+		Help:      "Number of postgres operations",
+		Subsystem: "assisted_migrations",
+	},
+		[]string{"op"},
+	)
+
+	prometheus.MustRegister(pgOpLatency)
+	prometheus.MustRegister(pgOpTotal)
+}
+
+func (mi *metricInterceptor) ConnBeginTx(ctx context.Context, conn driver.ConnBeginTx, opts driver.TxOptions) (context.Context, driver.Tx, error) {
+	start := time.Now()
+	defer mi.measure("conn-begin-tx", "conn-begin-tx", start)
+
+	tx, err := conn.BeginTx(ctx, opts)
+	return ctx, tx, err
+}
+
+func (mi *metricInterceptor) ConnPrepareContext(ctx context.Context, conn driver.ConnPrepareContext, query string) (context.Context, driver.Stmt, error) {
+	start := time.Now()
+	defer mi.measure("conn-prepare-context", "conn-prepare-context", start)
+
+	stmt, err := conn.PrepareContext(ctx, query)
+	return ctx, stmt, err
+}
+
+func (mi *metricInterceptor) ConnPing(ctx context.Context, conn driver.Pinger) error {
+	start := time.Now()
+	defer mi.measure("conn-ping", "conn-ping", start)
+
+	return conn.Ping(ctx)
+}
+
+func (mi *metricInterceptor) ConnExecContext(ctx context.Context, conn driver.ExecerContext, query string, args []driver.NamedValue) (driver.Result, error) {
+	start := time.Now()
+	matches := opRegex.FindSubmatch([]byte(query))
+	method := "conn-exec-context"
+	if len(matches) > 0 {
+		method = string(matches[0])
+	}
+	defer mi.measure("conn-exec-context", strings.ToLower(method), start)
+
+	return conn.ExecContext(ctx, query, args)
+}
+
+func (mi *metricInterceptor) ConnQueryContext(ctx context.Context, conn driver.QueryerContext, query string, args []driver.NamedValue) (context.Context, driver.Rows, error) {
+	start := time.Now()
+	method := "conn-query-context"
+	matches := opRegex.FindSubmatch([]byte(query))
+	if len(matches) > 0 {
+		method = string(matches[0])
+	}
+	defer mi.measure("conn-exec-context", strings.ToLower(method), start)
+
+	rows, err := conn.QueryContext(ctx, query, args)
+	return ctx, rows, err
+}
+
+// Connector interceptors
+func (mi *metricInterceptor) ConnectorConnect(ctx context.Context, conn driver.Connector) (driver.Conn, error) {
+	start := time.Now()
+	defer mi.measure("connector-connect", "connector-connect", start)
+	return conn.Connect(ctx)
+}
+
+// Rows interceptors
+func (mi *metricInterceptor) RowsNext(ctx context.Context, conn driver.Rows, dest []driver.Value) error {
+	start := time.Now()
+	defer mi.measure("rows-next", "rows-next", start)
+	return conn.Next(dest)
+}
+
+// Stmt interceptors
+func (mi *metricInterceptor) StmtExecContext(ctx context.Context, conn driver.StmtExecContext, _ string, args []driver.NamedValue) (driver.Result, error) {
+	start := time.Now()
+	defer mi.measure("stmt-exec-context", "stmt-exec-context", start)
+	return conn.ExecContext(ctx, args)
+}
+
+func (mi *metricInterceptor) StmtQueryContext(ctx context.Context, conn driver.StmtQueryContext, _ string, args []driver.NamedValue) (context.Context, driver.Rows, error) {
+	start := time.Now()
+	defer mi.measure("stmt-query-context", "stmt-query-context", start)
+
+	rows, err := conn.QueryContext(ctx, args)
+	return ctx, rows, err
+}
+
+func (mi *metricInterceptor) StmtClose(ctx context.Context, conn driver.Stmt) error {
+	start := time.Now()
+	defer mi.measure("stmt-close", "stmt-close", start)
+	return conn.Close()
+}
+
+// Tx interceptors
+func (mi *metricInterceptor) TxCommit(ctx context.Context, conn driver.Tx) error {
+	start := time.Now()
+	defer mi.measure("tx-commit", "tx-commit", start)
+	return conn.Commit()
+}
+
+func (mi *metricInterceptor) TxRollback(ctx context.Context, conn driver.Tx) error {
+	start := time.Now()
+	defer mi.measure("tx-rollback", "tx-rollback", start)
+	return conn.Rollback()
+}
+
+func (mi *metricInterceptor) measure(op, method string, start time.Time) {
+	labels := prometheus.Labels{
+		"op": op,
+	}
+	pgOpTotal.With(labels).Inc()
+
+	since := float64(time.Since(start).Milliseconds())
+	labels = prometheus.Labels{
+		"op":     op,
+		"method": method,
+	}
+	pgOpLatency.With(labels).Observe(since)
+}


### PR DESCRIPTION
This PR adds an interceptor for the pg driver to collect latency metrics for all postgres operations.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Add a metrics interceptor for PostgreSQL database operations to collect latency and operation count metrics

New Features:
- Implement a Prometheus metrics interceptor for PostgreSQL database operations

Enhancements:
- Modify database connection setup to use a metrics-enabled driver
- Add detailed metrics tracking for various database operations