### PR TITLE
ECOPROJECT-2944 - Add env-var for validation container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GO_FILES := $(shell find ./ -name ".go" -not -path "./bin" -not -path "./packagi
 GO_CACHE := -v $${HOME}/go/migration-planner-go-cache:/opt/app-root/src/go:Z -v $${HOME}/go/migration-planner-go-cache/.cache:/opt/app-root/src/.cache:Z
 TIMEOUT ?= 30m
 VERBOSE ?= false
+VALIDATION_CONTAINER_IMAGE ?= quay.io/kubev2v/forklift-validation:latest
 MIGRATION_PLANNER_AGENT_IMAGE ?= quay.io/kubev2v/migration-planner-agent
 MIGRATION_PLANNER_API_IMAGE ?= quay.io/kubev2v/migration-planner-api
 MIGRATION_PLANNER_IMAGE_TAG ?= latest
@@ -168,6 +169,7 @@ deploy-on-openshift: oc
 	oc process -f deploy/templates/postgres-template.yml | oc apply -f -; \
 	oc process -f deploy/templates/service-template.yml \
        -p DEBUG_MODE=$(DEBUG_MODE) \
+       -p VALIDATION_CONTAINER_IMAGE=$(VALIDATION_CONTAINER_IMAGE) \
        -p MIGRATION_PLANNER_IMAGE=$(MIGRATION_PLANNER_API_IMAGE) \
        -p MIGRATION_PLANNER_AGENT_IMAGE=$(MIGRATION_PLANNER_AGENT_IMAGE) \
        -p MIGRATION_PLANNER_REPLICAS=${MIGRATION_PLANNER_REPLICAS} \
@@ -223,6 +225,7 @@ deploy-on-kind: oc
 	   -p MIGRATION_PLANNER_UI_URL=http://$${inet_ip}:3333 \
 	   -p MIGRATION_PLANNER_IMAGE_URL=http://$${inet_ip}:7443/api/migration-assessment \
 	   -p MIGRATION_PLANNER_API_IMAGE_PULL_POLICY=Never \
+	   -p VALIDATION_CONTAINER_IMAGE=$(VALIDATION_CONTAINER_IMAGE) \
 	   -p MIGRATION_PLANNER_IMAGE=$(MIGRATION_PLANNER_API_IMAGE) \
 	   -p MIGRATION_PLANNER_AGENT_IMAGE=$(MIGRATION_PLANNER_AGENT_IMAGE) \
 	   -p MIGRATION_PLANNER_REPLICAS=$(MIGRATION_PLANNER_REPLICAS) \

--- a/data/ignition.template
+++ b/data/ignition.template
@@ -191,7 +191,7 @@ storage:
 
           [Container]
           ContainerName=opa
-          Image=quay.io/kubev2v/forklift-validation:release-v2.6.4
+          Image={{ .ValidationContainerImage }}
           Entrypoint=/usr/bin/opa
           PublishPort=8181:8181
           Exec=run --server /usr/share/opa/policies

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -82,6 +82,8 @@ parameters:
   - name: ENVOY_IMAGE
     description: Envoy container image
     value: docker.io/envoyproxy/envoy:v1.33.2
+  - name: VALIDATION_CONTAINER_IMAGE
+    description: Full registry path to the validation (OPA) container
 
 objects:
   - kind: ServiceAccount
@@ -428,6 +430,8 @@ objects:
                   value: ${MIGRATION_PLANNER_URL}
                 - name: DEBUG_MODE
                   value: ${DEBUG_MODE}
+                - name: VALIDATION_CONTAINER_IMAGE
+                  value: ${VALIDATION_CONTAINER_IMAGE}
                 - name: PERSISTENT_DISK_DEVICE
                   value: ${PERSISTENT_DISK_DEVICE}
                 - name:  INSECURE_REGISTRY

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -32,16 +32,17 @@ const (
 )
 
 const (
-	defaultAgentImage            = "quay.io/kubev2v/migration-planner-agent"
-	defaultPlannerService        = "http://127.0.0.1:7443"
-	defaultPersistenceDiskDevice = "/dev/sda"
-	defaultConfigServerUI        = "http://localhost:3000/migrate/wizard"
-	defaultTemplate              = "data/ignition.template"
-	defaultPersistentDiskImage   = "data/persistence-disk.vmdk"
-	defaultOvfFile               = "data/MigrationAssessment.ovf"
-	defaultOvfName               = "MigrationAssessment.ovf"
-	defaultIsoImageName          = "MigrationAssessment.iso"
-	defaultRHCOSImage            = "rhcos-live.x86_64.iso"
+	defaultAgentImage               = "quay.io/kubev2v/migration-planner-agent"
+	defaultValidationContainerImage = "quay.io/kubev2v/forklift-validation"
+	defaultPlannerService           = "http://127.0.0.1:7443"
+	defaultPersistenceDiskDevice    = "/dev/sda"
+	defaultConfigServerUI           = "http://localhost:3000/migrate/wizard"
+	defaultTemplate                 = "data/ignition.template"
+	defaultPersistentDiskImage      = "data/persistence-disk.vmdk"
+	defaultOvfFile                  = "data/MigrationAssessment.ovf"
+	defaultOvfName                  = "MigrationAssessment.ovf"
+	defaultIsoImageName             = "MigrationAssessment.iso"
+	defaultRHCOSImage               = "rhcos-live.x86_64.iso"
 )
 
 // IgnitionData defines modifiable fields in ignition config
@@ -58,6 +59,7 @@ type IgnitionData struct {
 	HttpProxyUrl               string
 	HttpsProxyUrl              string
 	NoProxyDomain              string
+	ValidationContainerImage   string
 }
 
 type Proxy struct {
@@ -78,6 +80,7 @@ type ImageBuilder struct {
 	InsecureRegistry           string
 	Token                      string
 	PersistentDiskDevice       string
+	ValidationContainerImage   string
 	PersistentDiskImage        string
 	IsoImageName               string
 	OvfFile                    string
@@ -95,6 +98,7 @@ func NewImageBuilder(sourceID uuid.UUID) *ImageBuilder {
 		PlannerServiceUI:           util.GetEnv("CONFIG_SERVER_UI", defaultConfigServerUI),
 		MigrationPlannerAgentImage: util.GetEnv("MIGRATION_PLANNER_AGENT_IMAGE", defaultAgentImage),
 		PersistentDiskDevice:       util.GetEnv("PERSISTENT_DISK_DEVICE", defaultPersistenceDiskDevice),
+		ValidationContainerImage:   util.GetEnv("VALIDATION_CONTAINER_IMAGE", defaultValidationContainerImage),
 		PersistentDiskImage:        defaultPersistentDiskImage,
 		IsoImageName:               defaultIsoImageName,
 		OvfFile:                    defaultOvfFile,
@@ -192,6 +196,7 @@ func (b *ImageBuilder) generateIgnition() (string, error) {
 		HttpProxyUrl:               b.Proxy.HttpUrl,
 		HttpsProxyUrl:              b.Proxy.HttpsUrl,
 		NoProxyDomain:              b.Proxy.NoProxyDomain,
+		ValidationContainerImage:   b.ValidationContainerImage,
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

## Summary by Sourcery

Add support for configuring the validation (OPA) container image via an environment variable and integrate it throughout the build and deployment process

New Features:
- Introduce VALIDATION_CONTAINER_IMAGE environment variable to specify the validation container image

Enhancements:
- Extend ImageBuilder and IgnitionData to include the validation container image
- Modify service-template.yml to accept and propagate VALIDATION_CONTAINER_IMAGE to pods

Build:
- Add VALIDATION_CONTAINER_IMAGE variable to the Makefile and include it in deploy-on-openshift and deploy-on-kind targets