### PR TITLE
Gather Operating system from VMware tools and fallback to DB config if not set

### DIFF
--- a/internal/agent/service/collector.go
+++ b/internal/agent/service/collector.go
@@ -210,7 +210,7 @@ func fillInventoryObjectWithMoreData(vms *[]vspheremodel.VM, inv *apiplanner.Inv
 
 		// inventory
 		migratable, hasWarning := migrationReport(vm.Concerns, inv)
-		inv.Vms.Os[vm.GuestName]++
+		inv.Vms.Os[vmGuestName(vm)]++
 		inv.Vms.PowerStates[vm.PowerState]++
 
 		// Update total values
@@ -248,6 +248,13 @@ func fillInventoryObjectWithMoreData(vms *[]vspheremodel.VM, inv *apiplanner.Inv
 	inv.Vms.RamGB.Histogram = histogram(memorySet)
 	inv.Vms.DiskCount.Histogram = histogram(diskCountSet)
 	inv.Vms.DiskGB.Histogram = histogram(diskGBSet)
+}
+
+func vmGuestName(vm vspheremodel.VM) string {
+	if vm.GuestNameFromVmwareTools != "" {
+		return vm.GuestNameFromVmwareTools
+	}
+	return vm.GuestName
 }
 
 func createBasicInventoryObj(vCenterID string, vms *[]vspheremodel.VM, collector *vsphere.Collector, hosts *[]vspheremodel.Host, clusters *[]vspheremodel.Cluster) *apiplanner.Inventory {


### PR DESCRIPTION
After [Nir's PR ](https://github.com/kubev2v/migration-planner/pull/301) merges - I will rebase and omit the changes to the `go.mod` and `so.sun`
Signed-off-by: Aviel Segev <asegev@redhat.com>

## Summary by Sourcery

Gather OS information from VMware Tools with fallback to existing guest name, and update Go version along with module dependencies

Enhancements:
- Prefer VMware Tools guest name for OS inventory with fallback to the original guest name
- Introduce vmGuestName helper function to centralise OS name selection

Build:
- Upgrade Go to 1.23 and configure toolchain to go1.23.8
- Add indirect dependencies for golang/groupcache and openshift/client-go
- Update forklift-controller replace directive to a newer commit version

## Summary by Sourcery

Enhance VM inventory collection to use VMware Tools for OS names with fallbacks and update Go module version and dependencies

Enhancements:
- Prefer OS name from VMware Tools over configured guest name and default to "Unknown" when gathering VM inventory

Build:
- Bump Go version to 1.23 and specify toolchain version
- Add indirect module dependencies (groupcache, openshift/client-go) and update forklift-controller replace path