### PR TITLE
makefile and doc: add s3 secret template to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ deploy-on-openshift: oc
 	openshift_project=$$(oc project -q); \
 	echo "*** Deploy Migration Planner on Openshift. Project: $${openshift_project}, Base URL: $${openshift_base_url} ***";\
 	oc process -f deploy/templates/postgres-template.yml | oc apply -f -; \
+	oc process -f deploy/templates/s3-secret-template.yml | oc apply -f -; \
 	oc process -f deploy/templates/service-template.yml \
        -p DEBUG_MODE=$(DEBUG_MODE) \
        -p VALIDATION_CONTAINER_IMAGE=$(VALIDATION_CONTAINER_IMAGE) \
@@ -210,6 +211,7 @@ delete-from-openshift: oc
        -p MIGRATION_PLANNER_IMAGE_URL=http://planner-image-$${openshift_project}.apps.$${openshift_base_url} \
 	   | oc delete -f -; \
 	oc process -f deploy/templates/postgres-template.yml | oc delete -f -; \
+	oc process -f deploy/templates/s3-secret-template.yml | oc delete -f -; \
 	oc delete route planner-agent planner-ui planner-image; \
 	echo "*** Migration Planner has been deleted successfully from Openshift ***"
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -32,6 +32,17 @@ export MIGRATION_PLANNER_UI_IMAGE_TAG=<ui_image_tag>            # Default: lates
 export MIGRATION_PLANNER_REPLICAS=<replica_count>               # Default: 1  
 ```
 
+
+To use custom rhcos image stored in S3 bucket, you must supply s3 credentials in the secret created by the `s3-secret-template.yml` template.
+The s3 endpoint and bucket are set via env variables:
+```sh
+export MIGRATION_PLANNER_S3_ENDPOINT=<s3_endpoint>
+export MIGRATION_PLANNER_S3_BUCKET=<s3_bucket>
+export MIGRATION_PLANNER_S3_ISO_FILENAME=<iso_filename>
+```
+
+> MIGRATION_PLANNER_S3_ISO_FILENAME defaults to `custom-rhcos-live-iso.x86_64.iso`
+
 ### 3. Deploy to OpenShift
 Run the following command to deploy the Assisted Migration Service and its dependencies (including the UI and database):
 ```sh


### PR DESCRIPTION
This PR adds s3 creds template to `deploy-on-openshift` and `delete-from-openshift` targets and adds doc about it.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Enable custom RHCOS image deployment by applying an S3 secret template in Makefile targets and document the required environment variables and defaults for S3-based ISO retrieval

New Features:
- Add support for custom RHCOS images hosted in S3 via a dedicated secret template

Enhancements:
- Integrate `s3-secret-template.yml` into the Makefile’s deploy-on-openshift and delete-from-openshift targets

Documentation:
- Update deployment guide with instructions for S3 credentials and environment variables for custom ISO usage