### PR TITLE
add conditional logging for info/debug log level

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -70,7 +70,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 	router.Use(
 		metricMiddleware.Handler,
 		middleware.RequestID,
-		log.Logger(zap.L(), "router_agent"),
+		log.ConditionalLogger(s.cfg.Service.LogLevel, zap.L(), "router_agent"),
 	)
 
 	zap.S().Infow("agent authentication", "enabled", s.cfg.Service.Auth.AgentAuthenticationEnabled)

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -72,7 +72,7 @@ func (s *ImageServer) Run(ctx context.Context) error {
 	router.Use(
 		metricMiddleware.Handler,
 		middleware.RequestID,
-		log.Logger(zap.L(), "image_server"),
+		log.ConditionalLogger(s.cfg.Service.LogLevel, zap.L(), "image_server"),
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 		apiserver.WithResponseWriter,

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -95,7 +95,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}),
 		authenticator.Authenticator,
 		middleware.RequestID,
-		log.Logger(zap.L(), "router_api"),
+		log.ConditionalLogger(s.cfg.Service.LogLevel, zap.L(), "router_api"),
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 		WithResponseWriter,


### PR DESCRIPTION
http requests are logged both in envoy and in planner service.
This PR is to disable the service logger fro access requests in case envoy exists (stage/prod) and enable in case of local development.
The conditional logger is based on log level:
info - logger is disabled, relying on envoy.
debug - logger is enabled (envoy does not exist)

## Summary by Sourcery

Introduce conditional HTTP request logging middleware that toggles based on the configured log level.

New Features:
- Add ConditionalLogger function to enable HTTP request logging only at debug/trace levels and disable it at info level.

Enhancements:
- Replace Logger middleware with ConditionalLogger in AgentServer, ImageServer, and API Server to defer to Envoy for access logs when running at info level.