### PR TITLE
translate org_id into domain nam

### DIFF
--- a/internal/store/model/inventory_stats_test.go
+++ b/internal/store/model/inventory_stats_test.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestParseDomainName(t *testing.T) {
+	tests := []struct {
+		username   string
+		domainName string
+		wantErr    bool
+	}{
+		{
+			username:   "doejoe@redhat.com",
+			domainName: "redhat.com",
+			wantErr:    false,
+		},
+		{
+			username:   "doejoe@another.redhat.com",
+			domainName: "redhat.com",
+			wantErr:    false,
+		},
+		{
+			username:   "",
+			domainName: "",
+			wantErr:    true,
+		},
+		{
+			username:   "doejoe@com",
+			domainName: "com",
+			wantErr:    false,
+		},
+		{
+			username:   "doejoe",
+			domainName: "",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.username, func(t *testing.T) {
+			got, err := getDomainName(tt.username)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDomainName: error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.domainName {
+				t.Errorf("getDomainName: got = %v, want %v", got, tt.domainName)
+			}
+		})
+	}
+}

--- a/pkg/metrics/inventory_collector.go
+++ b/pkg/metrics/inventory_collector.go
@@ -98,13 +98,13 @@ func (c *inventoryStatsCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.totalVmByOs, prometheus.GaugeValue, float64(total), osType)
 	}
 
-	for orgID, total := range stats.Vms.TotalByCustomer {
-		ch <- prometheus.MustNewConstMetric(c.totalVmByCustomer, prometheus.GaugeValue, float64(total), orgID)
+	for domain, total := range stats.Vms.TotalByCustomer {
+		ch <- prometheus.MustNewConstMetric(c.totalVmByCustomer, prometheus.GaugeValue, float64(total), domain)
 	}
 
 	for _, storage := range stats.Storage {
 		for k, v := range storage.TotalByProvider {
-			ch <- prometheus.MustNewConstMetric(c.totalStorageByCustomer, prometheus.GaugeValue, float64(v), storage.OrgID, k)
+			ch <- prometheus.MustNewConstMetric(c.totalStorageByCustomer, prometheus.GaugeValue, float64(v), storage.Domain, k)
 		}
 	}
 }


### PR DESCRIPTION
This PR get the domain name from username and use it in the inventory stats metrics.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Use email domain as customer identifier in inventory statistics and metrics

New Features:
- Introduce getDomainName function to extract top-level email domain from usernames for inventory stats

Enhancements:
- Replace OrgID with Domain in VM and storage stats computation and in Prometheus metric labels
- Add fallback to original OrgID when domain parsing fails

Tests:
- Add unit tests for getDomainName domain extraction logic