### PR TITLE
auth: Set username from email claim if available

### DIFF
--- a/internal/auth/rhsso_authenticator.go
+++ b/internal/auth/rhsso_authenticator.go
@@ -79,8 +79,15 @@ func (rh *RHSSOAuthenticator) parseToken(userToken *jwt.Token) (User, error) {
 		return User{}, err
 	}
 
+	username := claims["preferred_username"].(string)
+	if email, ok := claims["email"].(string); ok {
+		if email != "" {
+			username = email
+		}
+	}
+
 	return User{
-		Username:     claims["preferred_username"].(string),
+		Username:     username,
 		Organization: orgID,
 		Token:        userToken,
 	}, nil


### PR DESCRIPTION
This PR updates username from email claim if available in the jwt. defaults to `preffered_username`.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Override the JWT username with the email claim if present, defaulting to the preferred_username.

New Features:
- Use the JWT 'email' claim as the username when available.

Enhancements:
- Modify the token parsing logic to check for an email claim and assign it to the username field.

Tests:
- Extend the generateCustomToken helper to include an email parameter and add a test verifying the email-based username override.