### PR TITLE
Fix the rchos iso filename

### DIFF
--- a/Containerfile.api-debug
+++ b/Containerfile.api-debug
@@ -18,7 +18,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal
 
 WORKDIR /app
 
-RUN curl -Lo /app/rhcos-live.x86_64.iso https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+RUN curl -Lo /app/rhcos-live-iso.x86_64.iso https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
 COPY /data /app/data/
 COPY --from=builder /planner-api /app/
 COPY --from=builder /app/dlv /app/

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ GOBIN = $(shell pwd)/bin
 GINKGO ?= $(GOBIN)/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
 ifeq (, $(shell which ginkgo 2> /dev/null))
-	go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+	go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.22.0
 endif
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -107,7 +107,7 @@ run:
 
 image:
 ifeq ($(DOWNLOAD_RHCOS), true)
-	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
 endif
 
 integration-test: ginkgo

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -144,7 +144,7 @@ func newListener(address string) (net.Listener, error) {
 
 func initializeIso(ctx context.Context, cfg *config.Config) error {
 	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live.x86_64.iso")
+	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
 	if _, err := os.Stat(isoPath); err == nil {
 		return nil
 	}

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -14,9 +14,9 @@ parameters:
   - name: IMAGE_TAG
     value: latest
   - name: MIGRATION_PLANNER_ISO_PATH
-    value: /iso/rhcos-live.x86_64.iso
+    value: /iso/rhcos-live-iso.x86_64.iso
   - name: MIGRATION_PLANNER_ISO_URL
-    value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+    value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
   - name: MIGRATION_PLANNER_URL
     description: The API URL of the migration assessment
     required: true

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -42,7 +42,7 @@ const (
 	defaultOvfFile                  = "data/MigrationAssessment.ovf"
 	defaultOvfName                  = "MigrationAssessment.ovf"
 	defaultIsoImageName             = "MigrationAssessment.iso"
-	defaultRHCOSImage               = "rhcos-live.x86_64.iso"
+	defaultRHCOSImage               = "rhcos-live-iso.x86_64.iso"
 )
 
 // IgnitionData defines modifiable fields in ignition config

--- a/pkg/iso/http.go
+++ b/pkg/iso/http.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	rhcosUrl string = "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso"
+	rhcosUrl string = "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso"
 )
 
 type HttpDownloader struct {


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

## Summary by Sourcery

Update the RHCOS ISO filename to include the "-iso" suffix across configuration, build scripts, and code to match the actual file naming convention.

Bug Fixes:
- Fix the default ISO filename in service templates and environment paths
- Correct the download URL in Makefile to use the updated ISO name
- Update code defaults and constants to reference the new ISO filename