### PR TITLE
Fix rchos bug

### DIFF
--- a/Containerfile.api-debug
+++ b/Containerfile.api-debug
@@ -18,7 +18,7 @@ FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi-minimal
 
 WORKDIR /app
 
-RUN curl -Lo /app/rhcos-live.x86_64.iso https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+RUN curl -Lo /app/rhcos-live-iso.x86_64.iso https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
 COPY /data /app/data/
 COPY --from=builder /planner-api /app/
 COPY --from=builder /app/dlv /app/

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ GOBIN = $(shell pwd)/bin
 GINKGO ?= $(GOBIN)/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.
 ifeq (, $(shell which ginkgo 2> /dev/null))
-	go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.15.0
+	go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.22.0
 endif
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -107,7 +107,7 @@ run:
 
 image:
 ifeq ($(DOWNLOAD_RHCOS), true)
-	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
 endif
 
 integration-test: ginkgo

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -144,7 +144,7 @@ func newListener(address string) (net.Listener, error) {
 
 func initializeIso(ctx context.Context, cfg *config.Config) error {
 	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live.x86_64.iso")
+	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
 	if _, err := os.Stat(isoPath); err == nil {
 		return nil
 	}

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -14,9 +14,9 @@ parameters:
   - name: IMAGE_TAG
     value: latest
   - name: MIGRATION_PLANNER_ISO_PATH
-    value: /iso/rhcos-live.x86_64.iso
+    value: /iso/rhcos-live-iso.x86_64.iso
   - name: MIGRATION_PLANNER_ISO_URL
-    value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso
+    value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
   - name: MIGRATION_PLANNER_URL
     description: The API URL of the migration assessment
     required: true

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -42,7 +42,7 @@ const (
 	defaultOvfFile                  = "data/MigrationAssessment.ovf"
 	defaultOvfName                  = "MigrationAssessment.ovf"
 	defaultIsoImageName             = "MigrationAssessment.iso"
-	defaultRHCOSImage               = "rhcos-live.x86_64.iso"
+	defaultRHCOSImage               = "rhcos-live-iso.x86_64.iso"
 )
 
 // IgnitionData defines modifiable fields in ignition config

--- a/pkg/iso/http.go
+++ b/pkg/iso/http.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	rhcosUrl string = "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live.x86_64.iso"
+	rhcosUrl string = "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso"
 )
 
 type HttpDownloader struct {


### PR DESCRIPTION
## Summary by Sourcery

Refactor inventory collection to leverage shared apiplanner types, centralize struct definitions, update OpenAPI schemas, bump dependencies, standardize CI pipelines, and rename RHCOS ISO asset

Enhancements:
- Refactor collector and related modules to use apiplanner API types instead of inline structs
- Propagate shared types (Histogram, Network, Host, MigrationIssue) across collector, rvtools, store, and generated API code
- Consolidate and centralize JSON schema definitions in openapi.yaml and types.gen.go
- Simplify inventory output by writing through service.InventoryData
- Streamline network and host processing by returning api.Network and []api.Host

CI:
- Standardize Tekton pipeline YAML formatting and update on-cel-expression conditions
- Bump Tekton task bundle image digests across pipelines

Documentation:
- Enhance OpenAPI spec with explicit Network, Host, and Histogram schemas and update MigrationIssue array types

Chores:
- Update Go module dependencies (fjord/forklift, govmomi, Kubernetes libs, test frameworks)
- Rename RHCOS ISO artifact to rhcos-live-iso.x86_64.iso across Makefile, templates, and code
- Upgrade local test tooling version for ginkgo and gomega