### PR TITLE
WIP - ECOPROJECT-3153 - add sidcar opa server to the deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ PODMAN ?= podman
 DOCKER_CONF ?= $(CURDIR)/docker-config
 DOCKER_AUTH_FILE ?= ${DOCKER_CONF}/auth.json
 PKG_MANAGER ?= apt
+OPA_HOST ?= 127.0.0.1
+OPA_PORT ?= 8181
+OPA_SERVER ?= $(OPA_HOST):$(OPA_PORT)
 
 SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
@@ -168,6 +171,9 @@ deploy-on-openshift: oc
 	oc process -f deploy/templates/s3-secret-template.yml | oc apply -f -; \
 	oc process -f deploy/templates/service-template.yml \
        -p DEBUG_MODE=$(DEBUG_MODE) \
+	   -p OPA_HOST=$(OPA_HOST) \
+	   -p OPA_PORT=$(OPA_PORT) \
+	   -p OPA_SERVER=$(OPA_SERVER) \
        -p VALIDATION_CONTAINER_IMAGE=$(VALIDATION_CONTAINER_IMAGE) \
        -p MIGRATION_PLANNER_IMAGE=$(MIGRATION_PLANNER_API_IMAGE) \
        -p MIGRATION_PLANNER_AGENT_IMAGE=$(MIGRATION_PLANNER_AGENT_IMAGE) \

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -102,6 +102,15 @@ parameters:
     value: docker.io/envoyproxy/envoy:v1.33.2
   - name: VALIDATION_CONTAINER_IMAGE
     description: Full registry path to the validation (OPA) container
+  - name: OPA_HOST
+    description: OPA server hostname
+    value: "127.0.0.1"
+  - name: OPA_PORT
+    description: OPA server port
+    value: "8181"
+  - name: OPA_SERVER
+    description: OPA server address (constructed from host:port)
+    value: "${OPA_HOST}:${OPA_PORT}"
 
 objects:
   - kind: ServiceAccount
@@ -153,6 +162,23 @@ objects:
           port: 8080
           protocol: TCP
           targetPort: 8080
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      labels:
+        app: migration-planner
+        port: opa
+      annotations:
+        description: Expose the OPA policy server endpoint
+      name: migration-planner-opa-sidecar
+    spec:
+      selector:
+        app: migration-planner
+      ports:
+        - name: opa
+          port: ${{OPA_PORT}}
+          protocol: TCP
+          targetPort: ${{OPA_PORT}}
   - kind: Service
     apiVersion: v1
     metadata:
@@ -394,6 +420,46 @@ objects:
             app: migration-planner
         spec:
           containers:
+            - name: opa
+              image: ${VALIDATION_CONTAINER_IMAGE}
+              imagePullPolicy: Always
+              command:
+                - /usr/bin/opa
+              args:
+                - run
+                - --server
+                - --addr=0.0.0.0:${OPA_PORT}
+                - --log-level=info
+                - /usr/share/opa/policies
+              ports:
+              - containerPort: ${{OPA_PORT}}
+                name: opa-port
+                protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: ${{OPA_PORT}}
+                initialDelaySeconds: 15
+                timeoutSeconds: 5
+                periodSeconds: 10
+                successThreshold: 1
+                failureThreshold: 3
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: ${{OPA_PORT}}
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+                periodSeconds: 5
+                successThreshold: 1
+                failureThreshold: 3
+              resources:
+                requests:
+                  memory: 256Mi
+                  cpu: 200m
+                limits:
+                  memory: 512Mi
+                  cpu: 500m
             - name: envoy
               image: ${ENVOY_IMAGE}
               imagePullPolicy: Always
@@ -478,6 +544,8 @@ objects:
                   value: ${DEBUG_MODE}
                 - name: VALIDATION_CONTAINER_IMAGE
                   value: ${VALIDATION_CONTAINER_IMAGE}
+                - name: OPA_SERVER
+                  value: ${OPA_SERVER}
                 - name: PERSISTENT_DISK_DEVICE
                   value: ${PERSISTENT_DISK_DEVICE}
                 - name:  INSECURE_REGISTRY


### PR DESCRIPTION
In order to have validations for VMs collected from RVtools excel file we add a sidecar container to the migration-planner pod. for large RVtools file with over 1000 VMs, added timeoutCtx to the transaction


## Summary by Sourcery

Add an OPA sidecar to the migration-planner deployment for in-pod policy validation, introduce a timeout for large RVtools uploads, fix ISO file references, and update Makefile settings.

New Features:
- Deploy an OPA policy server as a sidecar container in the migration-planner pod with its own service and health probes.

Bug Fixes:
- Correct the RHCOS ISO path and download URL to match the updated filename.

Enhancements:
- Enforce a 15-minute timeout context for the RVtools file upload operation.
- Expose and configure the OPA server address via the OPA_SERVER environment variable in deployment templates and Makefile.

Build:
- Pin the Ginkgo test runner version to v2.15.0 in the Makefile.