### PR TITLE
ECOPROJECT-3137: Fix the auth header in the CLI and add an option to pass a proxy address

### DIFF
--- a/internal/cli/global.go
+++ b/internal/cli/global.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/kubev2v/migration-planner/internal/api/client"
-	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -13,6 +15,7 @@ import (
 type GlobalOptions struct {
 	ServerUrl string
 	Token     string
+	ProxyUrl  string
 }
 
 func DefaultGlobalOptions() GlobalOptions {
@@ -24,6 +27,7 @@ func DefaultGlobalOptions() GlobalOptions {
 func (o *GlobalOptions) Bind(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.ServerUrl, "server-url", "u", o.ServerUrl, "Address of the server")
 	fs.StringVarP(&o.Token, "token", "", o.Token, "Token used to authenticate the user")
+	fs.StringVar(&o.ProxyUrl, "proxy", "", "Address of the proxy")
 }
 
 func (o *GlobalOptions) Complete(cmd *cobra.Command, args []string) error {
@@ -35,15 +39,42 @@ func (o *GlobalOptions) Validate(args []string) error {
 }
 
 func (o *GlobalOptions) Client() (*client.ClientWithResponses, error) {
+	httpClient := &http.Client{}
+
+	if o.ProxyUrl != "" {
+		if err := o.WithProxy(httpClient); err != nil {
+			return nil, err
+		}
+	}
+
 	return client.NewClientWithResponses(
 		o.ServerUrl,
-		client.WithHTTPClient(&http.Client{}),
+		client.WithHTTPClient(httpClient),
 		client.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			if o.Token == "" {
 				return nil
 			}
-			req.Header.Add(auth.AgentTokenHeader, o.Token)
+			req.Header.Set("X-Authorization", fmt.Sprintf("Bearer %s", o.Token))
 			return nil
 		}),
 	)
+}
+
+func (o *GlobalOptions) WithProxy(httpClient *http.Client) error {
+	if !strings.HasPrefix(o.ProxyUrl, "http://") && !strings.HasPrefix(o.ProxyUrl, "https://") {
+		o.ProxyUrl = "http://" + o.ProxyUrl
+	}
+
+	proxyUrl, err := url.Parse(o.ProxyUrl)
+	if err != nil {
+		return err
+	}
+
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(proxyUrl),
+	}
+
+	httpClient.Transport = transport
+
+	return nil
 }


### PR DESCRIPTION
This PR was opened to fix the ability to use the `planner-cli` in the stage/production environment.
However, while diving into it, I discovered that the root cause of the issue was the way we were passing the token — it was using the wrong header, which caused an authorization failure. So technically, fixing this would only require replacing one line of code.

That said, this PR also adds support for using a proxy in all commands that rely on the global options (e.g., `get`, `create`, etc.).

@shellymiron Thanks for pointing this out.
When testing, please verify that it’s possible to interact with the stage environment both with and without the proxy.


[ECOPROJECT-3137](https://issues.redhat.com/browse/ECOPROJECT-3137)

## Summary by Sourcery

Enable proxy support in the CLI and correct the authorization header to resolve token-based auth failures

New Features:
- Introduce a --proxy global option to configure an HTTP proxy for CLI commands

Bug Fixes:
- Use the correct 'X-Authorization: Bearer <token>' header to authenticate requests

Enhancements:
- Apply proxy settings to the HTTP client's transport when a proxy URL is provided