### PR TITLE
Add new iso file name to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/AgentVM.ova
 examples/AgentVM-1.iso
 examples/rhcos-live.x86_64.iso
 rhcos-live.x86_64.iso
+rhcos-live-iso.x86_64.iso
 examples/config.ign
 examples/config.yaml
 *.local.*


### PR DESCRIPTION
rhcos file name changed to rhcos-live-iso.x86_64.iso

## Summary by Sourcery

Chores:
- Add 'rhcos-live-iso.x86_64.iso' to .gitignore