### PR TITLE
Remove the deprecated os count

### DIFF
--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -241,7 +241,6 @@ func FillInventoryObjectWithMoreData(vms *[]vspheremodel.VM, inv *apiplanner.Inv
 		migratable, hasWarning := migrationReport(vm.Concerns, inv)
 
 		guestName := vmGuestName(vm)
-		inv.Vms.Os[guestName]++ // deprecated
 
 		osInfoMap := *inv.Vms.OsInfo
 		osInfo, found := osInfoMap[guestName]


### PR DESCRIPTION
This PR is a followup task for: https://github.com/kubev2v/migration-planner/pull/335

With this change the inventory shows:
```
"os": {},
      "osInfo": {
        "Amazon Linux 2 (64-bit)": {
          "count": 1,
          "supported": true
        },
        "Amazon Linux 3 (64-bit)": {
          "count": 1,
          "supported": true
        },
...
```

Signed-off-by: Aviel Segev <asegev@redhat.com>
