### PR TITLE
Fix the local e2e cli command

### DIFF
--- a/deploy/e2e.mk
+++ b/deploy/e2e.mk
@@ -82,8 +82,6 @@ deploy_assisted_migration: oc
 	oc wait --for=condition=Ready pods --all --timeout=240s
 	sleep 30
 	oc port-forward --address 0.0.0.0 service/migration-planner-agent 7443:7443 > /dev/null 2>&1 &
-	oc port-forward --address 0.0.0.0 service/migration-planner 3443:3443 > /dev/null 2>&1 &
-	oc port-forward --address 0.0.0.0 service/migration-planner-image 11443:11443 > /dev/null 2>&1 &
 
 .PHONY: undeploy-e2e-environment
 undeploy-e2e-environment:


### PR DESCRIPTION
After the 

Signed-off-by: Aviel Segev <asegev@redhat.com>

## Summary by Sourcery

Simplify the local E2E CLI by removing manual port-forwarding logic and unused defaults, and adjust the E2E deploy Makefile accordingly

Enhancements:
- Remove the ensureFullConnectivity and portForwardCommand implementations from the E2E CLI
- Eliminate unused time import and redundant default port and service constants
- Remove duplicate oc port-forward lines from the deploy/e2e.mk script