### PR TITLE
Fix "make deploy-db" command to work on macOS

### DIFF
--- a/deploy/podman/compose.yaml
+++ b/deploy/podman/compose.yaml
@@ -16,8 +16,6 @@ services:
     networks:
       - planner-network
     restart: unless-stopped
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 volumes:
   planner-db:
     driver_opts:


### PR DESCRIPTION
The host.docker.internal:host-gateway mapping is causing problems on macOS with podman
I solved this by removing this as it not really needed

## Summary by Sourcery

Bug Fixes:
- Remove extra_hosts entry to resolve Podman networking issues on macOS