### PR TITLE
sources: Add email domain to source model

### DIFF
--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -53,6 +53,7 @@ func NewTokenContext(ctx context.Context, t any) context.Context {
 type User struct {
 	Username     string
 	Organization string
+	EmailDomain  string
 	Token        *jwt.Token
 }
 

--- a/internal/cli/sso.go
+++ b/internal/cli/sso.go
@@ -98,7 +98,7 @@ func ParsePrivateKey(content string) (*rsa.PrivateKey, error) {
 
 func GenerateToken(username, organization string, privateKey *rsa.PrivateKey) (string, error) {
 	type TokenClaims struct {
-		Username string `json:"preferred_username"`
+		Username string `json:"username"`
 		OrgID    string `json:"org_id"`
 		jwt.RegisteredClaims
 	}

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -62,6 +62,7 @@ func (s *ServiceHandler) CreateSource(ctx context.Context, request apiServer.Cre
 	sourceCreateForm := mappers.SourceFormApi(form)
 	sourceCreateForm.Username = user.Username
 	sourceCreateForm.OrgID = user.Organization
+	sourceCreateForm.EmailDomain = user.EmailDomain
 
 	source, err := s.sourceSrv.CreateSource(ctx, sourceCreateForm)
 	if err != nil {

--- a/internal/handlers/v1alpha1/source_test.go
+++ b/internal/handlers/v1alpha1/source_test.go
@@ -85,6 +85,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -111,6 +112,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -137,6 +139,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -155,12 +158,18 @@ var _ = Describe("source handler", Ordered, func() {
 			tx := gormdb.Raw("SELECT COUNT(*) FROM image_infras;").Scan(&count)
 			Expect(tx.Error).To(BeNil())
 			Expect(count).To(Equal(1))
+
+			emailDomain := ""
+			tx = gormdb.Raw("SELECT email_domain FROM sources LIMIT 1;").Scan(&emailDomain)
+			Expect(tx.Error).To(BeNil())
+			Expect(emailDomain).To(Equal("admin.example.com"))
 		})
 
 		It("successfully creates a source -- with proxy paramters defined", func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -194,6 +203,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -226,6 +236,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -255,6 +266,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -303,6 +315,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -337,6 +350,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -399,6 +413,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "joker",
 				Organization: "joker",
+				EmailDomain:  "joker.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -452,6 +467,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -481,6 +497,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "user",
 				Organization: "user",
+				EmailDomain:  "user.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -505,6 +522,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -548,6 +566,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
@@ -598,6 +617,7 @@ var _ = Describe("source handler", Ordered, func() {
 			user := auth.User{
 				Username:     "admin",
 				Organization: "admin",
+				EmailDomain:  "admin.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 

--- a/internal/service/mappers/inbound.go
+++ b/internal/service/mappers/inbound.go
@@ -16,6 +16,7 @@ type SourceCreateForm struct {
 	SshPublicKey     string
 	Username         string
 	OrgID            string
+	EmailDomain      string
 	Labels           map[string]string
 }
 
@@ -43,6 +44,11 @@ func (s SourceCreateForm) ToSource() model.Source {
 	for k, v := range s.Labels {
 		source.Labels = append(source.Labels, model.Label{Key: k, Value: v, SourceID: source.ID.String()})
 	}
+
+	if s.EmailDomain != "" {
+		source.EmailDomain = &s.EmailDomain
+	}
+
 	return source
 }
 

--- a/internal/store/model/source.go
+++ b/internal/store/model/source.go
@@ -16,16 +16,17 @@ type Label struct {
 
 type Source struct {
 	gorm.Model
-	ID         uuid.UUID `gorm:"primaryKey; not null"`
-	Name       string    `gorm:"uniqueIndex:name_org_id;not null"`
-	VCenterID  string
-	Username   string
-	OrgID      string                    `gorm:"uniqueIndex:name_org_id;not null"`
-	Inventory  *JSONField[api.Inventory] `gorm:"type:jsonb"`
-	OnPremises bool
-	Agents     []Agent    `gorm:"constraint:OnDelete:CASCADE;"`
-	ImageInfra ImageInfra `gorm:"constraint:OnDelete:CASCADE;"`
-	Labels     []Label
+	ID          uuid.UUID `gorm:"primaryKey; not null"`
+	Name        string    `gorm:"uniqueIndex:name_org_id;not null"`
+	VCenterID   string
+	Username    string
+	OrgID       string                    `gorm:"uniqueIndex:name_org_id;not null"`
+	Inventory   *JSONField[api.Inventory] `gorm:"type:jsonb"`
+	OnPremises  bool
+	Agents      []Agent    `gorm:"constraint:OnDelete:CASCADE;"`
+	ImageInfra  ImageInfra `gorm:"constraint:OnDelete:CASCADE;"`
+	Labels      []Label
+	EmailDomain *string
 }
 
 type SourceList []Source

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,7 +81,8 @@ func (s *DataStore) Seed() error {
 	}
 
 	if err := tx.tx.Clauses(clause.OnConflict{
-		UpdateAll: true,
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"inventory"}),
 	}).Create(&source).Error; err != nil {
 		_ = tx.Rollback()
 	}

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -30,10 +30,10 @@ var _ = Describe("migrations", Ordered, func() {
 
 		gormdb.Exec("DROP TABLE IF EXISTS agents;")
 		gormdb.Exec("DROP TABLE IF EXISTS image_infras;")
-		gormdb.Exec("DROP TABLE IF EXISTS sources;")
 		gormdb.Exec("DROP TABLE IF EXISTS keys;")
-		gormdb.Exec("DROP TABLE IF EXISTS goose_db_version;")
 		gormdb.Exec("DROP TABLE IF EXISTS labels;")
+		gormdb.Exec("DROP TABLE IF EXISTS sources;")
+		gormdb.Exec("DROP TABLE IF EXISTS goose_db_version;")
 	})
 
 	AfterAll(func() {

--- a/pkg/migrations/sql/20250715111043_add_email_domain_column_source.sql
+++ b/pkg/migrations/sql/20250715111043_add_email_domain_column_source.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE sources ADD COLUMN email_domain VARCHAR(255);
+
+-- default all existing sources' org_ids to redhat.com
+UPDATE sources SET email_domain = 'redhat.com' WHERE org_id IN ('11009103', '13872092', '19194072', '18692352', '19006254', '19009423', '19010322', '19012400');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sources DROP COLUMN email_domain;
+-- +goose StatementEnd

--- a/test/e2e/e2e_global_vars.go
+++ b/test/e2e/e2e_global_vars.go
@@ -14,6 +14,7 @@ var TestOptions = struct {
 const (
 	DefaultOrganization string = "admin"
 	DefaultUsername     string = "admin"
+	DefaultEmailDomain  string = "example.com"
 	VmName              string = "coreos-vm"
 	Vsphere1Port        string = "8989"
 	Vsphere2Port        string = "8990"

--- a/test/e2e/e2e_multiple_users_test.go
+++ b/test/e2e/e2e_multiple_users_test.go
@@ -32,7 +32,7 @@ var _ = Describe("e2e-multiple-users", func() {
 		// Iterate over each organization and user to authenticate and create a unique source per org-user pair
 		for _, org := range organizations {
 			for _, user := range users {
-				err = svc.ChangeCredentials(UserAuth(user, org))
+				err = svc.ChangeCredentials(UserAuth(user, org, DefaultEmailDomain))
 				Expect(err).To(BeNil())
 				_, err = svc.CreateSource(fmt.Sprintf("%s-%s", org, user))
 				Expect(err).To(BeNil())
@@ -45,7 +45,7 @@ var _ = Describe("e2e-multiple-users", func() {
 		zap.S().Info("Cleaning up after test...")
 		for _, org := range organizations {
 			for _, user := range users {
-				err = svc.ChangeCredentials(UserAuth(user, org))
+				err = svc.ChangeCredentials(UserAuth(user, org, DefaultEmailDomain))
 				Expect(err).To(BeNil())
 				err := svc.RemoveSources()
 				Expect(err).To(BeNil(), "Failed to remove sources from DB")
@@ -63,7 +63,7 @@ var _ = Describe("e2e-multiple-users", func() {
 			// Verify that each user sees only the sources created by their own organization
 			for _, org := range organizations {
 				for _, user := range users {
-					err = svc.ChangeCredentials(UserAuth(user, org))
+					err = svc.ChangeCredentials(UserAuth(user, org, DefaultEmailDomain))
 					Expect(err).To(BeNil())
 					visibleSources, err := svc.GetSources()
 					Expect(err).To(BeNil())

--- a/test/e2e/e2e_utils/auth.go
+++ b/test/e2e/e2e_utils/auth.go
@@ -2,10 +2,11 @@ package e2e_utils
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/cli"
 	. "github.com/kubev2v/migration-planner/test/e2e"
-	"os"
 )
 
 // GetToken retrieves the private key from the specified path, parses it, and then generates a token
@@ -32,14 +33,15 @@ func GetToken(credentials *auth.User) (string, error) {
 }
 
 // UserAuth returns an auth.User object with the provided username and organization.
-func UserAuth(user string, org string) *auth.User {
+func UserAuth(user string, org string, emailDomain string) *auth.User {
 	return &auth.User{
 		Username:     user,
 		Organization: org,
+		EmailDomain:  emailDomain,
 	}
 }
 
 // DefaultUserAuth returns an auth.User object with the default username and organization.
 func DefaultUserAuth() *auth.User {
-	return UserAuth(DefaultUsername, DefaultOrganization)
+	return UserAuth(DefaultUsername, DefaultOrganization, DefaultEmailDomain)
 }


### PR DESCRIPTION
This PR adds the email domain to the source model and retrieves it from the user token's "email" claim.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Add support for parsing and storing email domain from the JWT email claim throughout the authentication and source management flows

New Features:
- Extract email domain from JWT token’s email claim into the auth.User object
- Add an optional email_domain column to the Source model and back it with a database migration
- Propagate email domain through source creation and retrieval in mappers, service layer, and HTTP handlers

Tests:
- Expand authentication and source handler tests to cover scenarios with and without email domain