### PR TITLE
Fix migration issue in case trying to add column that already exists

### DIFF
--- a/pkg/migrations/sql/20250715111043_add_email_domain_column_source.sql
+++ b/pkg/migrations/sql/20250715111043_add_email_domain_column_source.sql
@@ -1,12 +1,12 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE sources ADD COLUMN email_domain VARCHAR(255);
+ALTER TABLE sources ADD COLUMN IF NOT EXISTS email_domain VARCHAR(255);
 
 -- default all existing sources' org_ids to redhat.com
-UPDATE sources SET email_domain = 'redhat.com' WHERE org_id IN ('11009103', '13872092', '19194072', '18692352', '19006254', '19009423', '19010322', '19012400');
+UPDATE sources SET email_domain = 'redhat.com' WHERE org_id IN ('11009103', '13872092', '19194072', '18692352', '19006254', '19009423', '19010322', '19012400') AND email_domain IS NULL;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-ALTER TABLE sources DROP COLUMN email_domain;
+ALTER TABLE sources DROP COLUMN IF EXISTS email_domain;
 -- +goose StatementEnd


### PR DESCRIPTION
The migration 20250715111043_add_email_domain_column_source.sql is trying to add a column that already exists
The issue is that the migration doesn't use IF NOT EXISTS when adding the column
This means if the migration has been run before it will fail

## Summary by Sourcery

Make the email_domain migration idempotent by adding conditional clauses to avoid errors when re-running it

Bug Fixes:
- Use IF NOT EXISTS when adding the email_domain column to prevent errors if it already exists
- Restrict the UPDATE to only set email_domain on rows where it is null to avoid overwriting existing values
- Use IF EXISTS when dropping the email_domain column in the down migration to prevent errors if the column is missing