### PR TITLE
migrations: Cleanup db after each migration test

### DIFF
--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -28,12 +28,6 @@ var _ = Describe("migrations", Ordered, func() {
 		s = store.NewStore(db)
 		gormdb = db
 
-		gormdb.Exec("DROP TABLE IF EXISTS agents;")
-		gormdb.Exec("DROP TABLE IF EXISTS image_infras;")
-		gormdb.Exec("DROP TABLE IF EXISTS keys;")
-		gormdb.Exec("DROP TABLE IF EXISTS labels;")
-		gormdb.Exec("DROP TABLE IF EXISTS sources;")
-		gormdb.Exec("DROP TABLE IF EXISTS goose_db_version;")
 	})
 
 	AfterAll(func() {
@@ -67,5 +61,13 @@ var _ = Describe("migrations", Ordered, func() {
 			}
 		})
 
+		AfterEach(func() {
+			gormdb.Exec("DROP TABLE IF EXISTS agents;")
+			gormdb.Exec("DROP TABLE IF EXISTS image_infras;")
+			gormdb.Exec("DROP TABLE IF EXISTS keys;")
+			gormdb.Exec("DROP TABLE IF EXISTS labels;")
+			gormdb.Exec("DROP TABLE IF EXISTS sources;")
+			gormdb.Exec("DROP TABLE IF EXISTS goose_db_version;")
+		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Migrate database cleanup in migrations tests to run after each test instead of only at setup, ensuring a clean state between tests

Enhancements:
- Remove redundant table drop statements from the initial test setup

Tests:
- Add AfterEach hook to drop migration-related tables after each test