### PR TITLE
migrations: Update email-domain column if NULL

### DIFF
--- a/pkg/migrations/sql/20250716073007_update_email_domain_column.sql
+++ b/pkg/migrations/sql/20250716073007_update_email_domain_column.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE sources SET email_domain = 'redhat.com' WHERE email_domain IS NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- No need to have a down migration here because this migration does not change the db schema.
+-- +goose StatementEnd


### PR DESCRIPTION
This migration updates the email_domain column if it is null. This is the case of sources created before the email_domain column was introduced and without any inventory.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Enhancements:
- Introduce SQL migration to set email_domain to 'redhat.com' for records where it is null