### PR TITLE
update Conterfilefiles to use 'AS' instead of 'as'

### DIFF
--- a/Containerfile.agent
+++ b/Containerfile.agent
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi as ui
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/ubi AS ui
 
 RUN dnf install -y npm wget
 
@@ -13,7 +13,7 @@ RUN cp -r ./node_modules/@patternfly/patternfly/assets css/
 RUN cp -r ./node_modules/@patternfly/patternfly/patternfly.css css/
 
 # Builder container
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/Containerfile.agent-debug
+++ b/Containerfile.agent-debug
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as dlv-builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS dlv-builder
 
 USER 0
 

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -1,5 +1,5 @@
 # Builder container
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS builder
 
 ARG GCFLAGS=""
 

--- a/Containerfile.api-debug
+++ b/Containerfile.api-debug
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset as dlv-builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS dlv-builder
 
 USER 0
 


### PR DESCRIPTION
Eliminates warnings such as:

```
#1 WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

## Summary by Sourcery

Enhancements:
- Replace lowercase 'as' with uppercase 'AS' in all Containerfile.* files to align with 'FROM' casing and satisfy lint rules.