### PR TITLE
iso: Implement a rolling iso image initializer

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -40,5 +40,11 @@ jobs:
           for pod in $(oc get pods -o name); do
             echo "=== Logs for ${pod} ==="
             oc logs ${pod} || echo "Failed to get logs for ${pod}"
+            
+            # Collect logs for migration-planner-init container if pod starts with migration-planner
+            if [[ ${pod} == *"migration-planner"* ]]; then
+              echo "=== Logs for ${pod} migration-planner-init container ==="
+              oc logs ${pod} -c migration-planner-init || echo "Failed to get logs for migration-planner-init container in ${pod}"
+            fi
             echo "======================="
           done

--- a/cmd/planner-api/init.go
+++ b/cmd/planner-api/init.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/internal/util"
+	"github.com/kubev2v/migration-planner/pkg/iso"
+	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize RHCOS ISO for the migration planner",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		defer zap.S().Info("ISO initialization completed")
+
+		cfg, err := config.New()
+		if err != nil {
+			zap.S().Fatalw("reading configuration", "error", err)
+		}
+
+		logLvl, err := zap.ParseAtomicLevel(cfg.Service.LogLevel)
+		if err != nil {
+			logLvl = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+		}
+
+		logger := log.InitLog(logLvl)
+		defer func() { _ = logger.Sync() }()
+
+		undo := zap.ReplaceGlobals(logger)
+		defer undo()
+
+		zap.S().Info("Starting ISO initialization...")
+
+		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+		defer cancel()
+
+		// Initialize ISOs
+		zap.S().Info("Initializing RHCOS ISO")
+		isoInitializer := newIsoInitializer(cfg)
+		targetIsoFile := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
+		if err := isoInitializer.Initialize(ctx, targetIsoFile, cfg.Service.RhcosImageSha256); err != nil {
+			zap.S().Fatalw("failed to initialize iso", "error", err)
+		}
+		zap.S().Info("RHCOS ISO initialized successfully")
+
+		return nil
+	},
+}
+
+func newIsoInitializer(cfg *config.Config) *iso.IsoInitializer {
+	md := iso.NewDownloaderManager()
+
+	minio, err := iso.NewMinioDownloader(
+		iso.WithEndpoint(cfg.Service.S3.Endpoint),
+		iso.WithBucket(cfg.Service.S3.Bucket),
+		iso.WithAccessKey(cfg.Service.S3.AccessKey),
+		iso.WithSecretKey(cfg.Service.S3.SecretKey),
+		iso.WithImage(cfg.Service.S3.IsoFileName, cfg.Service.RhcosImageSha256),
+	)
+	if err == nil {
+		md.Register(minio)
+	} else {
+		zap.S().Errorw("failed to create minio downloader", "error", err)
+	}
+
+	// register the default downloader of the official RHCOS image.
+	md.Register(iso.NewHttpDownloader(cfg.Service.RhcosImageName, cfg.Service.RhcosImageSha256))
+
+	return iso.NewIsoInitializer(md)
+}

--- a/cmd/planner-api/root.go
+++ b/cmd/planner-api/root.go
@@ -11,6 +11,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(runCmd)
 

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -13,8 +13,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/opa"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
 	"github.com/kubev2v/migration-planner/pkg/migrations"
@@ -68,13 +66,6 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		// Initialize ISOs
-		zap.S().Info("Initializing RHCOS ISO")
-		if err := initializeIso(context.TODO(), cfg); err != nil {
-			zap.S().Fatalw("failed to initilized iso", "error", err)
-		}
-		zap.S().Info("RHCOS ISO initialized")
-
 		// Initialize OPA validator for policy validation
 		var opaValidator *opa.Validator
 
@@ -92,8 +83,9 @@ var runCmd = &cobra.Command{
 		}
 
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
+		defer cancel()
+
 		go func() {
-			defer cancel()
 			listener, err := newListener(cfg.Service.Address)
 			if err != nil {
 				zap.S().Fatalw("creating listener", "error", err)
@@ -109,7 +101,6 @@ var runCmd = &cobra.Command{
 		metrics.RegisterMetrics(store)
 
 		go func() {
-			defer cancel()
 			listener, err := newListener(cfg.Service.AgentEndpointAddress)
 			if err != nil {
 				zap.S().Fatalw("creating listener", "error", err)
@@ -122,7 +113,6 @@ var runCmd = &cobra.Command{
 		}()
 
 		go func() {
-			defer cancel()
 			listener, err := newListener(cfg.Service.ImageEndpointAddress)
 			if err != nil {
 				zap.S().Fatalw("creating listener", "error", err)
@@ -135,7 +125,6 @@ var runCmd = &cobra.Command{
 		}()
 
 		go func() {
-			defer cancel()
 			listener, err := newListener("0.0.0.0:8080")
 			if err != nil {
 				zap.S().Named("metrics_server").Fatalw("creating listener", "error", err)
@@ -157,44 +146,4 @@ func newListener(address string) (net.Listener, error) {
 		address = "localhost:0"
 	}
 	return net.Listen("tcp", address)
-}
-
-func initializeIso(ctx context.Context, cfg *config.Config) error {
-	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
-	if _, err := os.Stat(isoPath); err == nil {
-		return nil
-	}
-
-	out, err := os.Create(isoPath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	md := iso.NewDownloaderManager()
-
-	minio, err := iso.NewMinioDownloader(
-		iso.WithEndpoint(cfg.Service.S3.Endpoint),
-		iso.WithBucket(cfg.Service.S3.Bucket),
-		iso.WithAccessKey(cfg.Service.S3.AccessKey),
-		iso.WithSecretKey(cfg.Service.S3.SecretKey),
-		iso.WithImage(cfg.Service.S3.IsoFileName, cfg.Service.RhcosImageSha256),
-	)
-	if err == nil {
-		md.Register(minio)
-	} else {
-		zap.S().Errorw("failed to create minio downloader", "error", err)
-	}
-
-	// register the default downloader of the official RHCOS image.
-	md.Register(iso.NewHttpDownloader(cfg.Service.RhcosImageName, cfg.Service.RhcosImageSha256))
-
-	if err := md.Download(ctx, out); err != nil {
-		// Remove the file from disk to allow the planner to retry the image download after restart.
-		_ = os.Remove(isoPath)
-		return err
-	}
-
-	return nil
 }

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -112,6 +112,18 @@ objects:
     apiVersion: v1
     metadata:
       name: migration-planner
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: migration-planner-iso-storage
+      labels:
+        app: migration-planner
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
   - kind: Service
     apiVersion: v1
     metadata:
@@ -397,6 +409,46 @@ objects:
           labels:
             app: migration-planner
         spec:
+          initContainers:
+            - name: migration-planner-init
+              image: ${MIGRATION_PLANNER_IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: ${MIGRATION_PLANNER_API_IMAGE_PULL_POLICY}
+              command: ["/app/planner-api", "init"]
+              env:
+                - name: MIGRATION_PLANNER_ISO_PATH
+                  value: ${MIGRATION_PLANNER_ISO_PATH}
+                - name: MIGRATION_PLANNER_ISO_URL
+                  value: ${MIGRATION_PLANNER_ISO_URL}
+                - name: MIGRATION_PLANNER_ISO_SHA256
+                  value: ${MIGRATION_PLANNER_ISO_SHA256}
+                - name: MIGRATION_PLANNER_LOG_LEVEL
+                  value: ${MIGRATION_PLANNER_LOG_LEVEL}
+                - name: MIGRATION_PLANNER_S3_ENDPOINT
+                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
+                - name: MIGRATION_PLANNER_S3_BUCKET
+                  value: ${MIGRATION_PLANNER_S3_BUCKET}
+                - name: MIGRATION_PLANNER_S3_ISO_FILENAME
+                  value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
+                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: access_key
+                - name: MIGRATION_PLANNER_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: secret_key
+              volumeMounts:
+                - name: iso-storage
+                  mountPath: /iso
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
           containers:
             - name: envoy
               image: ${ENVOY_IMAGE}
@@ -574,7 +626,8 @@ objects:
           serviceAccountName: migration-planner
           volumes:
             - name: iso-storage
-              emptyDir: {}
+              persistentVolumeClaim:
+                claimName: migration-planner-iso-storage
             - name: migration-planner-dir
               emptyDir:
                 sizeLimit: 500Mi

--- a/pkg/iso/initializer.go
+++ b/pkg/iso/initializer.go
@@ -1,0 +1,179 @@
+package iso
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+const (
+	sentinelFile string = "planner-iso-download"
+)
+
+type waitResult struct {
+	Err error
+}
+
+type IsoDownloader interface {
+	Download(context.Context, io.WriteSeeker) error
+}
+
+type IsoInitializer struct {
+	downloader IsoDownloader
+}
+
+func NewIsoInitializer(downloader IsoDownloader) *IsoInitializer {
+	return &IsoInitializer{downloader: downloader}
+}
+
+// Initialize ensures the target ISO file is available and valid by checking its SHA256 hash.
+// If the file exists and its SHA256 matches the expected value, no action is taken.
+// If the file is missing or has an incorrect hash, it downloads the new image to a temporary file,
+// then atomically replaces the existing file using intermediate naming to prevent corruption.
+// The method includes rollback logic and cleanup of temporary files to maintain system integrity.
+
+// The planner is typically deployed in Kubernetes with multiple replicas (usually 3+).
+// Using a persistent volume for ISO storage can create race conditions
+// when multiple pods attempt to download the same ISO file simultaneously.
+//
+// A simple solution is to retry downloads or fail until one pod succeeds.
+// However, repeated crashes may trigger false-positive monitoring alerts.
+// Therefore, a more elegant solution is to serialize pod dowload ops.
+// For that, each instance is looking for sentinelFile.
+// It waits until the sentinelFile is removed by the owner and start the process again.
+// If the another instance succeeded in downloading the iso return. If not start the process again.
+func (i *IsoInitializer) Initialize(ctx context.Context, targetIsoFile string, targetIsoSha256 string) error {
+	workingFolder := path.Dir(targetIsoFile)
+
+	waitCh := make(chan waitResult)
+	go func(ctx context.Context, c chan waitResult) {
+		for {
+			_, err := os.Stat(path.Join(workingFolder, sentinelFile))
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					c <- waitResult{}
+					return
+				}
+				c <- waitResult{Err: err}
+				return
+			}
+
+			// the sentinelFile is present on disk
+			// wait for the another instance to finish or for context to be canceled
+
+			t := time.NewTicker(2 * time.Second)
+			defer t.Stop()
+
+			zap.S().Debug("waiting for another instance to download iso")
+
+			select {
+			case <-ctx.Done():
+				c <- waitResult{Err: ctx.Err()}
+				return
+			case <-t.C:
+			}
+		}
+	}(ctx, waitCh)
+
+	result := <-waitCh
+	if result.Err != nil {
+		return result.Err
+	}
+
+	statErr := i.verifyIso(targetIsoFile, targetIsoSha256)
+	if statErr == nil {
+		return nil
+	}
+
+	// touch the sentinelFile
+	sf, err := os.Create(path.Join(workingFolder, sentinelFile))
+	if err != nil {
+		return fmt.Errorf("failed to create sentinel file: %w", err)
+	}
+	sf.Close()
+	defer func() {
+		_ = os.Remove(path.Join(workingFolder, sentinelFile))
+	}()
+
+	zap.S().Debugw("failed to verify the integrity of the existing image", "error", statErr, "target iso", targetIsoFile, "target sha256", targetIsoSha256)
+
+	// first try to download the new image to temporary file
+	tempIsoFile, err := os.CreateTemp(path.Dir(targetIsoFile), "iso-image")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary iso file: %w", err)
+	}
+
+	defer func() {
+		_ = os.Remove(tempIsoFile.Name())
+	}()
+
+	if err := i.downloader.Download(ctx, tempIsoFile); err != nil {
+		tempIsoFile.Close()
+		return fmt.Errorf("failed to write the image to the temporary iso file: %w", err)
+	}
+	tempIsoFile.Close()
+
+	// if targetIsoFile does not exists, just move the new the targetIsoFile
+	if errors.Is(statErr, os.ErrNotExist) {
+		return os.Rename(tempIsoFile.Name(), targetIsoFile)
+	}
+
+	intermediateFilename := i.createIntermediateFilename(targetIsoFile)
+
+	if err := os.Rename(targetIsoFile, intermediateFilename); err != nil {
+		return fmt.Errorf("failed to rename the old image iso: %w", err)
+	}
+
+	if err := os.Rename(tempIsoFile.Name(), targetIsoFile); err != nil {
+		// try to rollback the old image
+		return os.Rename(intermediateFilename, targetIsoFile)
+	}
+
+	// safe to remove the oldfile
+	if err := os.Remove(intermediateFilename); err != nil {
+		zap.S().Warnw("failed to remove the old iso image from storage", "error", err)
+	}
+
+	return nil
+}
+
+func (i *IsoInitializer) verifyIso(targetIsoFile, targetIsoSha256 string) error {
+	if _, err := os.Stat(targetIsoFile); err != nil {
+		return err
+	}
+
+	// compute sha256
+	reader, err := os.Open(targetIsoFile)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, reader); err != nil {
+		return err
+	}
+
+	computedSha256 := fmt.Sprintf("%x", hasher.Sum(nil))
+
+	if targetIsoSha256 != computedSha256 {
+		return fmt.Errorf("sha256 sums dont't match. computed %s wanted %s", computedSha256, targetIsoSha256)
+	}
+
+	return nil
+}
+
+func (i *IsoInitializer) createIntermediateFilename(targetIsoFile string) string {
+	baseName := strings.TrimSuffix(path.Base(targetIsoFile), path.Ext(targetIsoFile))
+	ext := path.Ext(targetIsoFile)
+	return path.Join(path.Dir(targetIsoFile), fmt.Sprintf("%s%x%s", baseName, uuid.NewString()[:6], ext))
+}

--- a/pkg/iso/initializer_test.go
+++ b/pkg/iso/initializer_test.go
@@ -1,0 +1,294 @@
+package iso_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kubev2v/migration-planner/pkg/iso"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("iso initializer", func() {
+	var (
+		tempDir         string
+		targetIsoFile   string
+		targetIsoSha256 string
+		testData        []byte
+		initializer     *iso.IsoInitializer
+		testDownloader  *testIsoDownloader
+	)
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "iso-initializer-test")
+		Expect(err).To(BeNil())
+
+		targetIsoFile = filepath.Join(tempDir, "test.iso")
+		testData = []byte("test iso content for validation")
+
+		hasher := sha256.New()
+		hasher.Write(testData)
+		targetIsoSha256 = fmt.Sprintf("%x", hasher.Sum(nil))
+
+		testDownloader = &testIsoDownloader{
+			dataToWrite: testData,
+		}
+		initializer = iso.NewIsoInitializer(testDownloader)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	Context("when target file does not exist", func() {
+		It("should download the file", func() {
+			err := initializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+			Expect(err).To(BeNil())
+			Expect(testDownloader.hasBeenCalled).To(BeTrue())
+
+			// Verify file was created with correct content
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(testData))
+		})
+	})
+
+	Context("when target file exists with correct SHA256", func() {
+		BeforeEach(func() {
+			err := os.WriteFile(targetIsoFile, testData, 0644)
+			Expect(err).To(BeNil())
+		})
+
+		It("should not download anything and preserve the original file", func() {
+			err := initializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+			Expect(err).To(BeNil())
+			Expect(testDownloader.hasBeenCalled).To(BeFalse())
+
+			// Verify the original file still exists and contains the correct data
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(testData))
+
+			// Verify file hasn't been modified
+			fileInfo, err := os.Stat(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(fileInfo.Size()).To(Equal(int64(len(testData))))
+		})
+	})
+
+	Context("when target file exists with incorrect SHA256", func() {
+		BeforeEach(func() {
+			wrongData := []byte("wrong content")
+			err := os.WriteFile(targetIsoFile, wrongData, 0644)
+			Expect(err).To(BeNil())
+		})
+
+		It("should download and replace the file", func() {
+			err := initializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+			Expect(err).To(BeNil())
+			Expect(testDownloader.hasBeenCalled).To(BeTrue())
+
+			// Verify file was replaced with correct content
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(testData))
+
+			// Verify temporary file is cleaned up - directory should contain only the target file
+			entries, err := os.ReadDir(tempDir)
+			Expect(err).To(BeNil())
+			Expect(entries).To(HaveLen(1))
+			Expect(entries[0].Name()).To(Equal("test.iso"))
+			Expect(entries[0].IsDir()).To(BeFalse())
+		})
+	})
+
+	Context("when download fails", func() {
+		var originalData []byte
+
+		BeforeEach(func() {
+			// Create an existing file with wrong content to trigger download
+			originalData = []byte("original wrong content")
+			err := os.WriteFile(targetIsoFile, originalData, 0644)
+			Expect(err).To(BeNil())
+
+			testDownloader.shouldReturnError = true
+		})
+
+		It("should return the download error and preserve the original file", func() {
+			err := initializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to write the image to the temporary iso file"))
+			Expect(testDownloader.hasBeenCalled).To(BeTrue())
+
+			// Verify the original file still exists and contains the original data
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(originalData))
+
+			// Verify file hasn't been corrupted
+			fileInfo, err := os.Stat(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(fileInfo.Size()).To(Equal(int64(len(originalData))))
+		})
+	})
+
+	Context("when context is cancelled", func() {
+		var originalData []byte
+
+		BeforeEach(func() {
+			// Create an existing file with wrong content to trigger download
+			originalData = []byte("original content before cancellation")
+			err := os.WriteFile(targetIsoFile, originalData, 0644)
+			Expect(err).To(BeNil())
+		})
+
+		It("should handle cancellation gracefully and preserve the original file", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // Cancel immediately
+
+			testDownloader.shouldRespectContext = true
+			err := initializer.Initialize(ctx, targetIsoFile, targetIsoSha256)
+			Expect(err).To(HaveOccurred())
+
+			// Verify the original file still exists and contains the original data
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(originalData))
+
+			// Verify file hasn't been corrupted
+			fileInfo, err := os.Stat(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(fileInfo.Size()).To(Equal(int64(len(originalData))))
+
+			// Verify no temporary files are left behind
+			entries, err := os.ReadDir(tempDir)
+			Expect(err).To(BeNil())
+			Expect(entries).To(HaveLen(1))
+			Expect(entries[0].Name()).To(Equal("test.iso"))
+		})
+	})
+
+	Context("when multiple intializer are executed", func() {
+		It("the first initializer should download the iso", func() {
+			testDownloader1 := &testIsoDownloader{
+				dataToWrite: testData,
+			}
+			firstInitializer := iso.NewIsoInitializer(testDownloader1)
+			testDownloader2 := &testIsoDownloader{
+				dataToWrite: testData,
+			}
+			secondInitializer := iso.NewIsoInitializer(testDownloader2)
+
+			var wait sync.WaitGroup
+			wait.Add(2)
+			go func() {
+				err := firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+				Expect(err).To(BeNil())
+				wait.Done()
+			}()
+
+			// the second should not start the download
+			go func() {
+				<-time.After(1 * time.Second)
+				err := secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+				Expect(err).To(BeNil())
+				wait.Done()
+			}()
+			wait.Wait()
+
+			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
+			Expect(testDownloader2.hasBeenCalled).To(BeFalse())
+			// Verify file was created with correct content
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(testData))
+
+			// in download folder, we should have only the iso.
+			entries, err := os.ReadDir(tempDir)
+			Expect(err).To(BeNil())
+			Expect(entries).To(HaveLen(1))
+		})
+
+		It("the first initializer fails but the second downloads the iso", func() {
+			testDownloader1 := &testIsoDownloader{
+				dataToWrite:       testData,
+				shouldReturnError: true,
+			}
+			firstInitializer := iso.NewIsoInitializer(testDownloader1)
+			testDownloader2 := &testIsoDownloader{
+				dataToWrite: testData,
+			}
+			secondInitializer := iso.NewIsoInitializer(testDownloader2)
+
+			var wait sync.WaitGroup
+			wait.Add(2)
+
+			var firstErr error
+			go func() {
+				firstErr = firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoFile)
+				wait.Done()
+			}()
+
+			var secondErr error
+			go func() {
+				<-time.After(1 * time.Second)
+				secondErr = secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
+				wait.Done()
+			}()
+			wait.Wait()
+
+			Expect(secondErr).To(BeNil())
+			Expect(firstErr).NotTo(BeNil())
+
+			// Both initializers should be called
+			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
+			Expect(testDownloader2.hasBeenCalled).To(BeTrue())
+
+			// Verify file was created with correct content
+			data, err := os.ReadFile(targetIsoFile)
+			Expect(err).To(BeNil())
+			Expect(data).To(Equal(testData))
+
+			// in download folder, we should have only the iso.
+			entries, err := os.ReadDir(tempDir)
+			Expect(err).To(BeNil())
+			Expect(entries).To(HaveLen(1))
+		})
+	})
+})
+
+// testIsoDownloader is a simple implementation of IsoDownloader for testing
+type testIsoDownloader struct {
+	dataToWrite          []byte
+	shouldReturnError    bool
+	shouldRespectContext bool
+	hasBeenCalled        bool
+	calledTime           time.Time
+}
+
+func (t *testIsoDownloader) Download(ctx context.Context, dst io.WriteSeeker) error {
+	t.hasBeenCalled = true
+	t.calledTime = time.Now()
+
+	if t.shouldRespectContext {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+
+	if t.shouldReturnError {
+		return fmt.Errorf("test download error")
+	}
+
+	_, err := dst.Write(t.dataToWrite)
+	return err
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2,12 +2,13 @@ package e2e_test
 
 import (
 	"fmt"
+	"testing"
+
 	. "github.com/kubev2v/migration-planner/test/e2e"
 	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION
The initializer tries to minimize risk to leave the planner without an iso image by rolling images: existing and the freshly downloaded.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Introduce a robust ISO image initializer that verifies checksums, downloads updates when needed, and performs atomic replacements with rollback and cleanup to minimize risk of leaving the planner without a valid ISO

New Features:
- Introduce IsoInitializer with IsoDownloader to verify ISO checksum and fetch missing or outdated images
- Implement atomic rolling updates of ISO files using temporary downloads and safe renames with rollback support

Enhancements:
- Ensure cleanup of temporary files and remaining intermediates after initialization
- Generate unique intermediate filenames to avoid conflicts during atomic replacement

Tests:
- Add comprehensive unit tests for IsoInitializer covering non-existent, valid, invalid ISO, download errors, and context cancellations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a CLI command to initialize the Red Hat CoreOS (RHCOS) ISO, with support for multiple download sources and checksum verification.
  * Added an init container to the deployment for ISO initialization, ensuring persistent ISO storage across pod restarts.
  * Enhanced Makefile with new targets for ISO initialization, migration, and running the application.

* **Bug Fixes**
  * Improved ISO download logic to prevent race conditions during concurrent initialization in multi-replica environments.

* **Tests**
  * Added comprehensive unit tests for ISO initialization, including error handling and concurrent scenarios.

* **Chores**
  * Improved CI workflow to collect logs from the ISO init container for better troubleshooting.
  * Updated deployment to use a persistent volume for ISO storage.
  * Removed ISO initialization logic from the main run command to streamline startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->