### PR TITLE
Rearrange golangci-lint Makefile and Github Action actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -86,7 +86,8 @@ jobs:
           sudo apt update
           sudo apt install libvirt-dev
 
+      - name: Install golangci-lint
+        run: make lint-install
+
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.1
-        with:
-          args: --timeout=5m
+        run: make lint


### PR DESCRIPTION
Change all golangci-lint management to be done through the Makefile
This ensures both GithubWorkflow and users run the same command with the same version
Used version v1.64.8 because this was the version previousely used by the workflow

## Summary by Sourcery

Centralize golangci-lint installation and execution in the Makefile and update CI workflow to use the unified commands.

Enhancements:
- Add lint-install and lint targets to Makefile to install and run golangci-lint v1.64.8 locally under bin
- Remove direct golangci-lint download target and integrate lint support entirely through the Makefile

CI:
- Replace golangci-lint-action and libvirt setup in GitHub Actions with make lint-install and make lint steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the linting workflow to use Makefile commands for installing and running the linter, removing reliance on external GitHub Actions and manual package installation.
  * Improved linting process with centralized installation, updated linter version, and increased timeout for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->