### PR TITLE
Makefile: Organize test targets and add Emojis to Makefile Targets

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,20 @@ on:  # yamllint disable-line rule:truthy
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup libvirt
+        run: |
+          sudo apt update
+          sudo apt install libvirt-dev
+
+      - name: Run golangci-lint
+        run: make lint
+
   check-generate:
     runs-on: ubuntu-latest
     steps:
@@ -33,18 +47,13 @@ jobs:
         uses: actions/setup-go@v5
 
       - name: Check that formatting does not introduce changes
-        run: |
-          make check-format
+        run: make check-format
 
-  test:
+  unit-test:
     runs-on: ubuntu-latest
-    env:
-      PGHOST: localhost
-      PGDATABASE: planner
-      PGUSERNAME: admin
-      PGPASSWORD: adminpass
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out code
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -54,60 +63,10 @@ jobs:
         sudo apt update
         sudo apt install libvirt-dev
 
-    - name: Add PostgreSQL binaries to PATH
-      shell: bash
+    - name: Setup Podman
       run: |
-        echo "$(pg_config --bindir)" >> $GITHUB_PATH
-    - name: Start preinstalled PostgreSQL
-      shell: bash
-      run: |
-        echo "Initializing database cluster..."
-        # Convert backslashes to forward slashes in RUNNER_TEMP for Windows Git Bash
-        export PGHOST="${RUNNER_TEMP//\\//}/postgres"
-        export PGDATA="$PGHOST/pgdata"
-        mkdir -p "$PGDATA"
-        
-        # initdb requires file for password in non-interactive mode
-        export PWFILE="$RUNNER_TEMP/pwfile"
-        echo "postgres" > "$PWFILE"
-        initdb --pgdata="$PGDATA" --username="postgres" --pwfile="$PWFILE"
+        sudo apt update
+        sudo apt install -y podman podman-compose
 
-        echo "Starting PostgreSQL..."
-        echo "unix_socket_directories = '$PGHOST'" >> "$PGDATA/postgresql.conf"
-        pg_ctl start
-
-        echo "Creating user..."
-        psql --host "$PGHOST" --username="postgres" --dbname="postgres" --command="CREATE USER $PGUSERNAME PASSWORD '$PGPASSWORD'" --command="\du"
-
-        echo "Creating database..."
-        createdb --owner="$PGUSERNAME" --username="postgres" "$PGDATABASE"
-
-    - name: Prepare
-      run: |
-        # FIXME: Move to Makefile!
-        go install github.com/matryer/moq@latest
-        export PATH=$PATH:$(go env GOPATH)/bin
-        DOWNLOAD_RHCOS=false make build
-
-    - name: Migrate the db
-      run: |
-        MIGRATION_PLANNER_MIGRATIONS_FOLDER=${{ github.workspace }}/pkg/migrations/sql make migrate
-
-    - name: Test
-      run: |
-        MIGRATION_PLANNER_MIGRATIONS_FOLDER=${{ github.workspace }}/pkg/migrations/sql make test
-
-  Lint:
-    name: Lint code
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Setup libvirt
-        run: |
-          sudo apt update
-          sudo apt install libvirt-dev
-
-      - name: Run golangci-lint
-        run: make lint
+    - name: Run the tests
+      run: make unit-test

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -1,14 +1,18 @@
 COMPOSE_FILE := $(realpath deploy/podman/compose.yaml)
 
 deploy-db:
+	@echo "🚀 Deploy DB on podman..."
 	podman rm -f planner-db || true
 	podman volume rm podman_planner-db || true
 	podman-compose -f $(COMPOSE_FILE) up -d planner-db
 	test/scripts/wait_for_postgres.sh podman
 	podman exec -it planner-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
 	podman exec -it planner-db createdb admin || true
+	@echo "✅ DB was deployed successfully on podman."
 
 kill-db:
+	@echo "🗑️ Remove DB instance from podman..."
 	podman-compose -f $(COMPOSE_FILE) down planner-db
+	@echo "✅ DB instance was removed successfully from podman."
 
 .PHONY: deploy-db kill-db


### PR DESCRIPTION
## Summary by Sourcery

Restructure Makefile by consolidating and labeling test targets, embed emojis for feedback with a legend, introduce new composite targets for builds and tests, and update GitHub Actions workflows to leverage the revamped Makefile targets.

New Features:
- Add build-no-rhcos Make target to build without downloading external RHCOS image
- Introduce composite unit-test Make target that runs build, database setup, migrations, unit tests, and cleanup

Enhancements:
- Reorganize Makefile test-related targets into a dedicated tests support section
- Add emojis to Makefile task outputs and include an Emoji Legend for target types
- Enhance deploy-db and kill-db targets with emoji-based logging

CI:
- Add a separate lint job in GitHub Actions and rename test job to unit-test
- Streamline CI test job to invoke Makefile unit-test target

Documentation:
- Add an Emoji Legend in Makefile to document target emoji usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow by separating linting and unit testing into distinct jobs, simplifying configuration, and removing redundant steps.
  * Enhanced Makefile with clearer, modular test and build targets, added emoji-based status messages, and included a legend for emoji meanings.
  * Improved user feedback in database deployment scripts with additional informational messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->