### PR TITLE
templates: add template var for pvc access mode

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -106,6 +106,9 @@ parameters:
     description: Full registry path to the validation (OPA) container
   - name: RHCOS_PASSWORD
     description: "Password to be set for the default RHCOS user"
+  - name: ISO_PV_ACCESS_MODE
+    description: "Access type for ISO PV"
+    value: ReadWriteOnce
 
 objects:
   - kind: ServiceAccount
@@ -120,7 +123,7 @@ objects:
         app: migration-planner
     spec:
       accessModes:
-        - ReadWriteOnce
+        - ${ISO_PV_ACCESS_MODE}
       resources:
         requests:
           storage: 5Gi


### PR DESCRIPTION
AccessMode for iso pvc should be RWO for github and RWX for prod

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Allow customizing the ISO persistent volume claim access mode by adding an ISO_PV_ACCESS_MODE template variable and propagating it to deployment and deletion commands

Enhancements:
- Introduce ISO_PV_ACCESS_MODE parameter in service-template.yml for PVC access mode
- Replace hardcoded ReadWriteOnce access mode in PVC spec with the ISO_PV_ACCESS_MODE variable
- Update Makefile deploy and delete targets to pass the ISO_PV_ACCESS_MODE parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option for the access mode of ISO persistent storage, allowing users to customize storage access settings during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->