### PR TITLE
pvc: Add storage class name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ deploy-on-openshift: oc
        -p MIGRATION_PLANNER_URL=http://planner-agent-$${openshift_project}.apps.$${openshift_base_url}/api/migration-assessment \
        -p MIGRATION_PLANNER_UI_URL=http://planner-ui-$${openshift_project}.apps.$${openshift_base_url} \
        -p MIGRATION_PLANNER_IMAGE_URL=http://planner-image-$${openshift_project}.apps.$${openshift_base_url} \
+  	   -p ISO_PV_STORAGE_CLASS_NAME=standard \
 	   | oc apply -f -; \
 	oc expose service migration-planner-agent --name planner-agent; \
 	oc expose service migration-planner-image --name planner-image; \
@@ -204,6 +205,7 @@ delete-from-openshift: oc
        -p MIGRATION_PLANNER_URL=http://planner-agent-$${openshift_project}.apps.$${openshift_base_url} \
        -p MIGRATION_PLANNER_UI_URL=http://planner-ui-$${openshift_project}.apps.$${openshift_base_url} \
        -p MIGRATION_PLANNER_IMAGE_URL=http://planner-image-$${openshift_project}.apps.$${openshift_base_url} \
+  	   -p ISO_PV_STORAGE_CLASS_NAME=standard \
 	   | oc delete -f -; \
 	oc process -f deploy/templates/postgres-template.yml | oc delete -f -; \
 	oc process -f deploy/templates/s3-secret-template.yml | oc delete -f -; \
@@ -231,6 +233,7 @@ deploy-on-kind: oc
 	   -p INSECURE_REGISTRY=$(INSECURE_REGISTRY) \
 	   -p MIGRATION_PLANNER_AUTH=$(MIGRATION_PLANNER_AUTH) \
 	   -p RHCOS_PASSWORD=${RHCOS_PASSWORD} \
+  	   -p ISO_PV_STORAGE_CLASS_NAME=standard \
 	   | oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	echo "*** Migration Planner has been deployed successfully on Kind ***"
 
@@ -246,6 +249,7 @@ delete-from-kind: oc
 	   -p MIGRATION_PLANNER_REPLICAS=$(MIGRATION_PLANNER_REPLICAS) \
 	   -p PERSISTENT_DISK_DEVICE=$(PERSISTENT_DISK_DEVICE) \
 	   -p INSECURE_REGISTRY=$(INSECURE_REGISTRY) \
+  	   -p ISO_PV_STORAGE_CLASS_NAME=standard \
 	   | oc delete -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	oc process --local -f  deploy/templates/postgres-template.yml | oc delete -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	oc process --local -f deploy/templates/pk-secret-template.yml \

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -109,6 +109,9 @@ parameters:
   - name: ISO_PV_ACCESS_MODE
     description: "Access type for ISO PV"
     value: ReadWriteOnce
+  - name: ISO_PV_STORAGE_CLASS_NAME
+    description: "Storage class name for pvc ISO"
+    required: true
 
 objects:
   - kind: ServiceAccount
@@ -122,6 +125,7 @@ objects:
       labels:
         app: migration-planner
     spec:
+      storageClassName: ${ISO_PV_STORAGE_CLASS_NAME}
       accessModes:
         - ${ISO_PV_ACCESS_MODE}
       resources:


### PR DESCRIPTION
## Summary by Sourcery

Add support for configuring the storage class name for the ISO persistent volume claim by introducing a new parameter and applying it to the PVC spec.

New Features:
- Introduce ISO_PV_STORAGE_CLASS_NAME parameter with default value 'standard'
- Apply the ISO_PV_STORAGE_CLASS_NAME parameter to set storageClassName in the ISO PVC spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to specify the storage class for ISO PersistentVolumeClaims, allowing greater flexibility in storage selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->