### PR TITLE
kind: collect logs for migration-planner container only

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -41,10 +41,10 @@ jobs:
             echo "=== Logs for ${pod} ==="
             oc logs ${pod} || echo "Failed to get logs for ${pod}"
             
-            # Collect logs for migration-planner-init container if pod starts with migration-planner
-            if [[ ${pod} == *"migration-planner"* ]]; then
-              echo "=== Logs for ${pod} migration-planner-init container ==="
-              oc logs ${pod} -c migration-planner-init || echo "Failed to get logs for migration-planner-init container in ${pod}"
+            # Collect logs for migration-planner container if pod starts with migration-planner but exclude postgres
+            if [[ ${pod} == *"migration-planner"* && ${pod} != *"postgres"* ]]; then
+              echo "=== Logs for ${pod} migration-planner container ==="
+              oc logs ${pod} -c migration-planner || echo "Failed to get logs for migration-planner container in ${pod}"
             fi
             echo "======================="
           done


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

## Summary by Sourcery

Enhancements:
- Collect logs from the ‘migration-planner’ container rather than the init container and skip pods matching postgres

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log collection in workflow to gather logs from the correct container for migration-planner pods, excluding those related to postgres.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->