### PR TITLE
Fix histogram for binsize=1.0

### DIFF
--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -401,12 +401,13 @@ func calculateBinIndex(data, minVal int, binSize float64, rangeValues, numberOfB
 		return 0
 	}
 
+	var binIndex int
 	if binSize == 1.0 {
-		return data - minVal
+		binIndex = data - minVal
+	} else {
+		// Division-based mapping for larger ranges
+		binIndex = int(float64(data-minVal) / binSize)
 	}
-
-	// Division-based mapping for larger ranges
-	binIndex := int(float64(data-minVal) / binSize)
 
 	// Ensure bin index is within bounds
 	if binIndex >= numberOfBins {


### PR DESCRIPTION
## Summary by Sourcery

Fix calculateBinIndex to correctly handle binsize 1.0 and simplify bin index assignment logic

Bug Fixes:
- Correct bin index computation for binsize=1.0 by using integer subtraction rather than float division

Enhancements:
- Unify binIndex assignment into a single variable and remove redundant division mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic for bin index calculation to enhance code clarity and maintainability. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->