### PR TITLE
Fix the new upload command for RVTools

### DIFF
--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
@@ -107,14 +108,17 @@ func (o *UploadOptions) uploadRVTools(ctx context.Context) error {
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
-	defer mw.Close()
 
-	part, err := mw.CreateFormFile("file", "")
+	part, err := mw.CreateFormFile("file", filepath.Base(o.filePath))
 	if err != nil {
-		return err
+		return fmt.Errorf("creating form file: %w", err)
 	}
 	if _, err := io.Copy(part, f); err != nil {
-		return err
+		return fmt.Errorf("copying file into multipart: %w", err)
+	}
+
+	if err := mw.Close(); err != nil {
+		return fmt.Errorf("closing multipart writer: %w", err)
 	}
 
 	sourceUUID, err := uuid.Parse(o.sourceId)


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

## Summary by Sourcery

Fix the uploadRVTools command by including the actual filename in the multipart form, adding contextual error wrapping, and ensuring the multipart writer is closed after copying the file

Bug Fixes:
- Include base filename in multipart form file creation to correct file uploads
- Explicitly close multipart writer after file copy to avoid incomplete uploads

Enhancements:
- Wrap errors in uploadRVTools steps with contextual messages for easier troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File uploads now include the correct base filename, improving compatibility with servers that rely on filename metadata.
  - Ensures proper completion of multipart uploads to prevent intermittent upload failures.

- **Chores**
  - Enhanced error messages during file upload steps for clearer troubleshooting (e.g., when creating the form file, copying data, or finalizing the upload).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->