### PR TITLE
ECOPROJECT-3250 | fix: opa validation to support local policies dir

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -34,7 +34,7 @@ const (
 	// DefaultWwwDir is the default directory from which the agent serves static files
 	DefaultWwwDir = "/app/www"
 	// DefaultOpaPoliciesDir is the default directory where the OPA policies are stored
-	DefaultOpaPoliciesDir = "/app/policies"
+	DefaultOpaPoliciesDir = "./policies"
 	// DefaultPlannerEndpoint is the default address of the migration planner server
 	DefaultPlannerEndpoint = "https://localhost:7443"
 	// DefaultHealthCheck is the default value for health check interval in seconds.
@@ -96,12 +96,18 @@ func (s *PlannerService) Equal(s2 *PlannerService) bool {
 }
 
 func NewDefault() *Config {
+	opaPoliciesDir := DefaultOpaPoliciesDir
+	// Override with environment variable if set when running locally
+	if envDir := os.Getenv("MIGRATION_PLANNER_OPA_POLICIES_FOLDER"); envDir != "" {
+		opaPoliciesDir = envDir
+	}
+
 	c := &Config{
 		ConfigDir:         DefaultConfigDir,
 		DataDir:           DefaultDataDir,
 		PersistentDataDir: DefaultPersistentDataDir,
 		WwwDir:            DefaultWwwDir,
-		OpaPoliciesDir:    DefaultOpaPoliciesDir,
+		OpaPoliciesDir:    opaPoliciesDir,
 		SourceID:          DefaultSourceId,
 		PlannerService:    PlannerService{Config: *client.NewDefault()},
 		UpdateInterval:    util.Duration{Duration: DefaultUpdateInterval},


### PR DESCRIPTION
This PR fixes opa validations when running locally:
1. fix the env variable name in Makefile 
2. add support for override the agent policies dir when env variable is set

Testing:
1. run the planner-api locally (make build; make run)
2. create a new source
3. upload rvtools and verify validations are added
4. create a new source
5. associate the agent with the new source and run the agent
6. veruify the validations are added

## Summary by Sourcery

Enable custom local OPA policies directory by renaming the Makefile variable, adding a run-agent target, and making the agent config read from the environment

New Features:
- Support overriding the agent OPA policies directory via the MIGRATION_PLANNER_OPA_POLICIES_FOLDER environment variable

Bug Fixes:
- Fix the environment variable name for the OPA policies folder in the Makefile

Enhancements:
- Add a run-agent Makefile target that passes the custom policies folder
- Update the agent’s default policies directory to "./policies" and allow it to be overridden from the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New run-agent command to launch the planner agent.
  * Unified configuration for OPA policies via MIGRATION_PLANNER_OPA_POLICIES_FOLDER (Make/env), with improved setup/cleanup and clearer status messages.
  * Default OPA policies directory updated to ./policies, with environment override support.

* **Chores**
  * Integrated end-to-end deployment/test targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->