### PR TITLE
ECOPROJECT-3218 | Add envoy route for assessments

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -376,6 +376,15 @@ objects:
                               pattern:
                                 regex: "^/api/migration-assessment/api/v1/image"
                               substitution: "/api/v1/image"
+                        - match:
+                            prefix: "/api/migration-assessment/api/v1/assessments"
+                          route:
+                            cluster: backend-api
+                            timeout: 0s
+                            regex_rewrite:
+                              pattern:
+                                regex: "^/api/migration-assessment/api/v1/assessments"
+                              substitution: "/api/v1/assessments"
                     http_filters:
                     - name: envoy.filters.http.router
                       typed_config:


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add Envoy route for assessments endpoint with prefix match and regex rewrite to /api/v1/assessments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a public API route for migration assessments: /api/migration-assessment/api/v1/assessments.
  * Requests to this route are routed to the backend assessment service and internally mapped to the service’s v1 assessments endpoint.

* Chores
  * Configuration updated to support the new route without affecting existing endpoints or routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->