### PR TITLE
ECOPROJECT-3258 | feat: Update vsphere collector to collect all hosts…

### DIFF
--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -661,21 +661,22 @@ func getDatastores(hosts *[]vspheremodel.Host, collector *vsphere.Collector) []a
 		return nil
 	}
 
-	// Create datastore-to-hostID mapping once for better performance
-	datastoreToHostID := make(map[string]string)
+	// Create datastore-to-hostIDs mapping once for better performance
+	datastoreToHostIDs := make(map[string][]string)
 	for _, host := range *hosts {
 		for _, dsRef := range host.Datastores {
-			datastoreToHostID[dsRef.ID] = host.ID
+			datastoreToHostIDs[dsRef.ID] = append(datastoreToHostIDs[dsRef.ID], host.ID)
 		}
 	}
 
 	res := []apiplanner.Datastore{}
 	for _, ds := range *datastores {
 		dsVendor, dsModel, dsProtocol := findDataStoreInfo(*hosts, ds.BackingDevicesNames)
-		hostID := datastoreToHostID[ds.ID]
+		hostIDs := datastoreToHostIDs[ds.ID]
 		var hostIDPtr *string
-		if hostID != "" {
-			hostIDPtr = &hostID
+		if len(hostIDs) > 0 {
+			joined := strings.Join(hostIDs, ", ")
+			hostIDPtr = &joined
 		}
 
 		res = append(res, apiplanner.Datastore{


### PR DESCRIPTION
This PR aligns vsphere collector with rvtools to collect all the hosts that ave access to the datastore.

## Summary by Sourcery

New Features:
- Collect multiple host IDs per datastore rather than a single host ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Datastore entries now list all connected host IDs, showing multiple hosts as comma-separated values for clearer visibility.
- Bug Fixes
  - Fixed an issue where only one host was reported per datastore, leading to incomplete host-to-datastore mappings. Datastores with multiple hosts are now accurately represented.
  - Correct handling when no hosts are associated with a datastore; the host field remains empty instead of showing incorrect data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->