### PR TITLE
NO-JIRA | ci: Enhance run-locally guide with OPA policies setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+policies/
 /rpmbuild/
 /.vscode/
 /reports/

--- a/Makefile
+++ b/Makefile
@@ -376,10 +376,7 @@ setup-opa-policies:
 		echo "Downloading policies from Forklift GitHub repository..."; \
 		mkdir -p $(FORKLIFT_POLICIES_TMP_DIR); \
 		curl -L https://github.com/kubev2v/forklift/archive/main.tar.gz \
-			| tar -xz -C $(FORKLIFT_POLICIES_TMP_DIR) \
-				--wildcards '*/validation/policies/io/konveyor/forklift/vmware/*' \
-				--strip-components=1 \
-				--exclude='*/..*' --exclude='*/.*'; \
+			| tar -xz -C $(FORKLIFT_POLICIES_TMP_DIR) --strip-components=1; \
 		if [ -d "$(FORKLIFT_POLICIES_TMP_DIR)/validation/policies/io/konveyor/forklift/vmware" ]; then \
 			find $(FORKLIFT_POLICIES_TMP_DIR)/validation/policies/io/konveyor/forklift/vmware \
 				-name "*.rego" ! -name "*_test.rego" -exec cp {} $(MIGRATION_PLANNER_OPA_POLICIES_FOLDER)/ \; ; \

--- a/doc/run-locally.md
+++ b/doc/run-locally.md
@@ -38,7 +38,17 @@ make kill-db
 make deploy-db
 ```
 
-### 3. Configure Environment Variables
+### 3. Download OPA Policies
+
+Download the OPA (Open Policy Agent) policies required for validation. These policies are used to assess and validate the source environment.
+
+```bash
+make setup-opa-policies
+```
+
+> **Note:** Once you are done with your work, you can run `make clean-opa-policies` to remove the downloaded policies from your local machine.
+
+### 4. Configure Environment Variables
 
 Set the required environment variables for local development:
 
@@ -49,7 +59,7 @@ export MIGRATION_PLANNER_AUTH=none
 
 These settings disable authentication for local development, making it easier to test and develop the application.
 
-### 4. Run the Application
+### 5. Run the Application
 
 Start the Migration Planner API server:
 
@@ -57,7 +67,7 @@ Start the Migration Planner API server:
 make run
 ```
 
-### 5. Verify API is Running
+### 6. Verify API is Running
 
 The migration-planner API should be running on `http://localhost:3443`. Verify it's working:
 


### PR DESCRIPTION
- Add new step for downloading OPA policies required for validation
- Simplify tar extraction in Makefile by removing complex wildcards
- Update section numbering to accommodate new OPA policies step
- Include cleanup note for removing policies after development

🤖 Code and Description was generated with [Claude Code](https://claude.ai/code) and CursorAI
Signed-off-by: Shelly Miron [smiron@redhat.com](mailto:smiron@redhat.com)

## Summary by Sourcery

Add a new step to download OPA policies in the run-locally guide, simplify the Makefile policy extraction, and renumber documentation sections

New Features:
- Add make setup-opa-policies step to download and clean up OPA policies for local development

Enhancements:
- Simplify tar extraction in the Makefile by removing complex wildcards and exclusions

Documentation:
- Update run-locally guide to include the OPA policies step, adjust section numbering, and note cleanup command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new step to download OPA policies during local setup (with cleanup instruction) and renumbered subsequent setup steps.
  * Documented an environment variable to disable agent authentication for local development.
* **Chores**
  * Broadened policy extraction then select required policies, and added clear success/failure messages for policy download.
  * Added repository ignore entry for the policies directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->