### PR TITLE
ECOPROJECT-3167 | ci: Fix the way to extract the git_tag

### DIFF
--- a/.tekton/migration-planner-agent-tag.yaml
+++ b/.tekton/migration-planner-agent-tag.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-agent:{{target_branch.replace("refs/tags/", "")}}
+    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-agent:{{git_tag}}
   - name: dockerfile
     value: Containerfile.agent
   - name: path-context

--- a/.tekton/migration-planner-api-tag.yaml
+++ b/.tekton/migration-planner-api-tag.yaml
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-api:{{target_branch.replace("refs/tags/", "")}}
+    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-api:{{git_tag}}
   - name: dockerfile
     value: Containerfile.api
   - name: path-context


### PR DESCRIPTION
The Tekton pipeline files used an invalid template expression that wasn't being processed, causing to receive a literal string as the image tag instead of the actual tag name. Fix: Replaced the complex template expression with {{git_tag}} which directly provides the tag name for tag push events in PipelinesAsCode.

## Summary by Sourcery

Fix the extraction of the Git tag in Tekton pipeline configurations for image tagging

Bug Fixes:
- Replace invalid target_branch.replace expression with {{git_tag}} in migration-planner-agent-tag.yaml
- Replace invalid target_branch.replace expression with {{git_tag}} in migration-planner-api-tag.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipelines for tag builds to derive container image tags directly from the Git tag for both migration-planner agent and API. This improves consistency and traceability of released artifacts across environments and registries, reducing ambiguity in tag-based builds. No changes to application functionality or runtime behavior. No downtime or configuration updates required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->