### PR TITLE
ECOPROJECT-3266 | feat: RVools - Transform vendor names to expected format

### DIFF
--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -644,14 +644,15 @@ func isHardwareAcceleratedMove(hosts []vspheremodel.Host, names []string) bool {
 	return supported
 }
 
-func transformVendorName(vendor string) string {
-	vendor = strings.ToUpper(strings.TrimSpace(vendor))
+func TransformVendorName(vendor string) string {
+	raw := strings.TrimSpace(vendor) // Preserve original case
+	key := strings.ToUpper(raw)      // Use uppercase for lookup only
 
-	if transformed, exists := vendorMap[vendor]; exists {
+	if transformed, exists := vendorMap[key]; exists {
 		return transformed
 	}
 
-	return strings.TrimSpace(vendor)
+	return raw // Return original case for unmapped
 }
 
 func getDatastores(hosts *[]vspheremodel.Host, collector *vsphere.Collector) []apiplanner.Datastore {
@@ -684,7 +685,7 @@ func getDatastores(hosts *[]vspheremodel.Host, collector *vsphere.Collector) []a
 			FreeCapacityGB:          int(ds.Free / 1024 / 1024 / 1024),
 			HardwareAcceleratedMove: isHardwareAcceleratedMove(*hosts, ds.BackingDevicesNames),
 			Type:                    ds.Type,
-			Vendor:                  transformVendorName(dsVendor),
+			Vendor:                  TransformVendorName(dsVendor),
 			Model:                   dsModel,
 			ProtocolType:            dsProtocol,
 			DiskId:                  getNaa(&ds),

--- a/internal/rvtools/datastores.go
+++ b/internal/rvtools/datastores.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/kubev2v/migration-planner/internal/agent/collector"
 	"go.uber.org/zap"
 )
 
@@ -156,7 +157,7 @@ func extractMultipathInfo(multipathRows [][]string) map[string]struct {
 
 		datastoreName := getColumnValue(row, colMap, "datastore")
 		naaIdentifier := getColumnValue(row, colMap, "disk")
-		vendor := getColumnValue(row, colMap, "vendor")
+		vendor := collector.TransformVendorName(getColumnValue(row, colMap, "vendor"))
 		model := getColumnValue(row, colMap, "model")
 
 		if datastoreName != "" && naaIdentifier != "" {


### PR DESCRIPTION
RVtools: Normalize vendor names in inventory datastores using a predefined mapping:
{
"NETAPP": "NetApp",
"EMC": "Dell EMC",
"PURE": "Pure Storage",
"3PARDATA": "HPE", // 3PAR is an HPE product line
"ATA": "ATA",
"DELL EMC": "Dell EMC",
"DELL": "Dell",
"HPE": "HPE",
"IBM": "IBM",
"HITACHI": "Vantara",
"CISCO": "Cisco",
"FUJITSU": "Fujitsu",
"LENOVO": "Lenovo",
}
This is to align RVtools to vsphere collector as in https://github.com/kubev2v/migration-planner/pull/386.
**testing:**
- upload a rvtools excel
- in the report, verify the vendor names in the Datastores section are according to the name.
- in case the vendor name does not exist in the map (above), it is displayed as is


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardizes storage vendor names across vSphere collection and RVTools import for consistent labeling.
  - Preserves original casing for vendors that have no known mapping, while still applying existing mappings.
  - Improves accuracy and consistency of vendor-based filtering, grouping, dashboards, reports, and exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->