### PR TITLE
ECOPROJECT-3269 | Add username to assessment

### DIFF
--- a/internal/handlers/v1alpha1/assessment.go
+++ b/internal/handlers/v1alpha1/assessment.go
@@ -45,13 +45,13 @@ func (h *ServiceHandler) CreateAssessment(ctx context.Context, request server.Cr
 			return server.CreateAssessment400JSONResponse{Message: err.Error()}, nil
 		}
 
-		createForm = mappers.AssessmentFormToCreateForm(form, user.Organization)
+		createForm = mappers.AssessmentFormToCreateForm(form, user)
 	}
 
 	// Handle multipart content type (RVTools upload)
 	if request.MultipartBody != nil {
 		var err error
-		createForm, err = mappers.AssessmentCreateFormFromMultipart(request.MultipartBody, user.Organization)
+		createForm, err = mappers.AssessmentCreateFormFromMultipart(request.MultipartBody, user)
 		if err != nil {
 			return server.CreateAssessment400JSONResponse{Message: fmt.Sprintf("failed to parse multipart form: %v", err)}, nil
 		}

--- a/internal/handlers/v1alpha1/assessment_test.go
+++ b/internal/handlers/v1alpha1/assessment_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	insertAssessmentStm = "INSERT INTO assessments (id, created_at, name, org_id, source_type, source_id) VALUES ('%s', now(), '%s', '%s', '%s', %s);"
+	insertAssessmentStm = "INSERT INTO assessments (id, created_at, name, org_id, username, source_type, source_id) VALUES ('%s', now(), '%s', '%s', '%s', '%s', %s);"
 	insertSnapshotStm   = "INSERT INTO snapshots (created_at, inventory, assessment_id) VALUES (now(), '%s', '%s');"
 )
 
@@ -50,11 +50,11 @@ var _ = Describe("assessment handler", Ordered, func() {
 			assessmentID3 := uuid.New()
 
 			// Create assessments for different organizations
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1.String(), "assessment1", "admin", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1.String(), "assessment1", "admin", "user1", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2.String(), "assessment2", "admin", service.SourceTypeInventory, "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2.String(), "assessment2", "admin", "user2", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3.String(), "assessment3", "batman", service.SourceTypeInventory, "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3.String(), "assessment3", "batman", "user3", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			// Create snapshots for assessments
@@ -172,21 +172,39 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(assessment.SourceId).To(Equal(&sourceID))
 		})
 
-		It("fails to create assessment with empty body", func() {
+		It("creates assessment with correct username from auth context", func() {
 			user := auth.User{
-				Username:     "admin",
-				Organization: "admin",
-				EmailDomain:  "admin.example.com",
+				Username:     "test-username",
+				Organization: "test-org",
+				EmailDomain:  "test.example.com",
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil))
-			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{})
-			Expect(err).To(BeNil())
-			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.CreateAssessment400JSONResponse{}).String()))
+			inventory := v1alpha1.Inventory{
+				Vcenter: v1alpha1.VCenter{
+					Id: "test-vcenter",
+				},
+			}
 
-			errorResp := resp.(server.CreateAssessment400JSONResponse)
-			Expect(errorResp.Message).To(Equal("empty body"))
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil))
+			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
+				JSONBody: &v1alpha1.AssessmentForm{
+					Name:       "username-test-assessment",
+					SourceType: service.SourceTypeInventory,
+					Inventory:  &inventory,
+				},
+			})
+			Expect(err).To(BeNil())
+			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.CreateAssessment201JSONResponse{}).String()))
+
+			assessment := resp.(server.CreateAssessment201JSONResponse)
+			Expect(assessment.Name).To(Equal("username-test-assessment"))
+
+			// Verify the assessment was stored with the correct username in the database
+			createdAssessment, err := s.Assessment().Get(context.TODO(), assessment.Id)
+			Expect(err).To(BeNil())
+			Expect(createdAssessment.Username).To(Equal("test-username"))
+			Expect(createdAssessment.OrgID).To(Equal("test-org"))
 		})
 
 		It("fails to create assessment with sourceID from different organization", func() {
@@ -557,7 +575,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 	Context("get assessment", func() {
 		It("successfully retrieves an assessment", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", "testuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -582,6 +600,21 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(assessment.Snapshots).To(HaveLen(1))
 		})
 
+		It("assessment contains username from database", func() {
+			assessmentID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment-username", "admin", "test-username", service.SourceTypeInventory, "NULL"))
+			Expect(tx.Error).To(BeNil())
+
+			inventory := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			Expect(tx.Error).To(BeNil())
+
+			// Check that the assessment in the database has the username
+			assessment, err := s.Assessment().Get(context.TODO(), assessmentID)
+			Expect(err).To(BeNil())
+			Expect(assessment.Username).To(Equal("test-username"))
+		})
+
 		It("returns 404 for non-existent assessment", func() {
 			nonExistentID := uuid.New()
 
@@ -600,7 +633,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 		It("returns 403 for assessment from different organization", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batmanuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -629,7 +662,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 	Context("update assessment", func() {
 		It("successfully updates an assessment name", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "original-name", "admin", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "original-name", "admin", "adminuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -704,7 +737,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 		It("returns 403 for assessment from different organization", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batmanuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -732,7 +765,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 		It("successfully updates assessment created from inventory sourceType but keeps same number of snapshots", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "inventory-assessment", "admin", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "inventory-assessment", "admin", "adminuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -768,7 +801,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 		It("successfully updates assessment created from rvtools sourceType but keeps same number of snapshots", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "rvtools-assessment", "admin", service.SourceTypeRvtools, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "rvtools-assessment", "admin", "adminuser", service.SourceTypeRvtools, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -812,8 +845,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 			// Create assessment with agent sourceType
 			assessmentID := uuid.New()
-			tx = gormdb.Exec(fmt.Sprintf("INSERT INTO assessments (id, created_at, name, org_id, source_type, source_id) VALUES ('%s', now(), '%s', '%s', '%s', '%s');",
-				assessmentID.String(), "agent-assessment", "admin", service.SourceTypeAgent, sourceID.String()))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm,
+				assessmentID.String(), "agent-assessment", "admin", "admin", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID.String())))
 			Expect(tx.Error).To(BeNil())
 
 			// Create initial snapshot
@@ -854,7 +887,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 	Context("delete assessment", func() {
 		It("successfully deletes an assessment", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", "testuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`
@@ -903,7 +936,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 		It("returns 403 for assessment from different organization", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batmanuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			inventory := `{"vcenter": {"id": "test-vcenter"}}`

--- a/internal/handlers/v1alpha1/mappers/inbound.go
+++ b/internal/handlers/v1alpha1/mappers/inbound.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/util"
@@ -100,12 +101,13 @@ func SourceUpdateFormApi(resource v1alpha1.SourceUpdate) mappers.SourceUpdateFor
 
 // Assessment-related mappers
 
-func AssessmentFormToCreateForm(resource v1alpha1.AssessmentForm, orgID string) mappers.AssessmentCreateForm {
+func AssessmentFormToCreateForm(resource v1alpha1.AssessmentForm, user auth.User) mappers.AssessmentCreateForm {
 	form := mappers.AssessmentCreateForm{
-		ID:     uuid.New(),
-		Name:   resource.Name,
-		OrgID:  orgID,
-		Source: resource.SourceType,
+		ID:       uuid.New(),
+		Name:     resource.Name,
+		OrgID:    user.Organization,
+		Username: user.Username,
+		Source:   resource.SourceType,
 	}
 
 	// Set source ID if provided
@@ -127,11 +129,12 @@ func InventoryToForm(inventory v1alpha1.Inventory) mappers.InventoryForm {
 	}
 }
 
-func AssessmentCreateFormFromMultipart(multipartBody *multipart.Reader, orgID string) (mappers.AssessmentCreateForm, error) {
+func AssessmentCreateFormFromMultipart(multipartBody *multipart.Reader, user auth.User) (mappers.AssessmentCreateForm, error) {
 	form := mappers.AssessmentCreateForm{
-		ID:     uuid.New(),
-		OrgID:  orgID,
-		Source: service.SourceTypeRvtools,
+		ID:       uuid.New(),
+		OrgID:    user.Organization,
+		Username: user.Username,
+		Source:   service.SourceTypeRvtools,
 	}
 
 	for {

--- a/internal/service/assessment_test.go
+++ b/internal/service/assessment_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	insertSourceStm     = "INSERT INTO sources (id, name, username, org_id, inventory) VALUES ('%s', '%s', '%s', '%s', '%s');"
-	insertAssessmentStm = "INSERT INTO assessments (id, name, org_id, source_type, source_id) VALUES ('%s', '%s', '%s', '%s', %s);"
+	insertAssessmentStm = "INSERT INTO assessments (id, created_at, name, org_id, username, source_type, source_id) VALUES ('%s', now(), '%s', '%s', '%s', '%s', %s);"
 	insertSnapshotStm   = "INSERT INTO snapshots (assessment_id, inventory) VALUES ('%s', '%s');"
 )
 
@@ -49,11 +49,11 @@ var _ = Describe("assessment service", Ordered, func() {
 			assessment1ID := uuid.New()
 			assessment2ID := uuid.New()
 			assessment3ID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment1ID, "Test Assessment 1", "org1", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment1ID, "Test Assessment 1", "org1", "testuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment2ID, "Another Test", "org1", service.SourceTypeRvtools, "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment2ID, "Another Test", "org1", "testuser", service.SourceTypeRvtools, "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment3ID, "Production Assessment", "org2", service.SourceTypeInventory, "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment3ID, "Production Assessment", "org2", "testuser2", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 		})
 
@@ -98,7 +98,7 @@ var _ = Describe("assessment service", Ordered, func() {
 	Context("GetAssessment", func() {
 		It("successfully gets an assessment", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", "testuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			assessment, err := svc.GetAssessment(context.TODO(), assessmentID)
@@ -268,7 +268,7 @@ var _ = Describe("assessment service", Ordered, func() {
 
 				// Create assessment with sourceID
 				assessmentID := uuid.New()
-				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
+				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -300,7 +300,7 @@ var _ = Describe("assessment service", Ordered, func() {
 
 				// Create assessment with sourceID
 				assessmentID := uuid.New()
-				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
+				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -330,7 +330,7 @@ var _ = Describe("assessment service", Ordered, func() {
 
 				// Create assessment with sourceID
 				assessmentID := uuid.New()
-				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
+				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -384,7 +384,7 @@ var _ = Describe("assessment service", Ordered, func() {
 
 				// Create assessment with the sourceID
 				assessmentID := uuid.New()
-				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
+				tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", "testuser", service.SourceTypeAgent, fmt.Sprintf("'%s'", sourceID)))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -415,7 +415,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			It("successfully updates assessment name only (no new snapshot)", func() {
 				// Create assessment without sourceID (inventory type)
 				assessmentID := uuid.New()
-				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeInventory, "NULL"))
+				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeInventory, "NULL"))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -440,7 +440,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			It("successfully updates rvtools assessment name only", func() {
 				// Create assessment without sourceID (rvtools type)
 				assessmentID := uuid.New()
-				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeRvtools, "NULL"))
+				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeRvtools, "NULL"))
 				Expect(tx.Error).To(BeNil())
 
 				newName := "Updated Name"
@@ -454,7 +454,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			It("maintains only one snapshot after multiple updates for non-sourceID assessments", func() {
 				// Create assessment without sourceID (inventory type)
 				assessmentID := uuid.New()
-				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", service.SourceTypeInventory, "NULL"))
+				tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Original Name", "org1", "testuser", service.SourceTypeInventory, "NULL"))
 				Expect(tx.Error).To(BeNil())
 
 				// Add initial snapshot
@@ -520,7 +520,7 @@ var _ = Describe("assessment service", Ordered, func() {
 	Context("DeleteAssessment", func() {
 		It("successfully deletes an assessment", func() {
 			assessmentID := uuid.New()
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", service.SourceTypeInventory, "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "Test Assessment", "org1", "testuser", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			err := svc.DeleteAssessment(context.TODO(), assessmentID)

--- a/internal/service/mappers/inbound.go
+++ b/internal/service/mappers/inbound.go
@@ -140,6 +140,7 @@ type AssessmentCreateForm struct {
 	ID          uuid.UUID
 	Name        string
 	OrgID       string
+	Username    string
 	Source      string
 	SourceID    *uuid.UUID
 	Inventory   v1alpha1.Inventory
@@ -151,6 +152,7 @@ func (f *AssessmentCreateForm) ToModel() model.Assessment {
 		ID:         f.ID,
 		Name:       f.Name,
 		OrgID:      f.OrgID,
+		Username:   f.Username,
 		SourceType: f.Source,
 		SourceID:   f.SourceID,
 	}

--- a/internal/store/assessment_test.go
+++ b/internal/store/assessment_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	insertAssessmentStm = "INSERT INTO assessments (id, name, org_id, source_type, source_id) VALUES ('%s', '%s', '%s', '%s', %s);"
+	insertAssessmentStm = "INSERT INTO assessments (id, name, org_id, username, source_type, source_id) VALUES ('%s', '%s', '%s', '%s', '%s', %s);"
 	insertSnapshotStm   = "INSERT INTO snapshots (assessment_id, inventory) VALUES ('%s', '%s');"
 )
 
@@ -44,9 +44,9 @@ var _ = Describe("assessment store", Ordered, func() {
 			assessmentID1 := uuid.New()
 			assessmentID2 := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "inventory", "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "user1", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org1", "rvtools", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org1", "user2", "rvtools", "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			assessments, err := s.Assessment().List(context.TODO(), store.NewAssessmentQueryFilter())
@@ -59,11 +59,11 @@ var _ = Describe("assessment store", Ordered, func() {
 			assessmentID2 := uuid.New()
 			assessmentID3 := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "inventory", "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "user1", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org2", "rvtools", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org2", "user2", "rvtools", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3, "assessment3", "org1", "agent", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3, "assessment3", "org1", "user3", "agent", "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			assessments, err := s.Assessment().List(context.TODO(), store.NewAssessmentQueryFilter().WithOrgID("org1"))
@@ -80,11 +80,11 @@ var _ = Describe("assessment store", Ordered, func() {
 			assessmentID2 := uuid.New()
 			assessmentID3 := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "inventory", "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID1, "assessment1", "org1", "user1", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org1", "rvtools", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID2, "assessment2", "org1", "user2", "rvtools", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3, "assessment3", "org1", "agent", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID3, "assessment3", "org1", "user3", "agent", "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			assessments, err := s.Assessment().List(context.TODO(), store.NewAssessmentQueryFilter().WithSourceType("rvtools"))
@@ -96,7 +96,7 @@ var _ = Describe("assessment store", Ordered, func() {
 		It("successfully list assessments with snapshots", func() {
 			assessmentID := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID, "assessment1", "org1", "inventory", "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID, "assessment1", "org1", "user1", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			// Add snapshots
@@ -128,7 +128,7 @@ var _ = Describe("assessment store", Ordered, func() {
 		It("successfully get an assessment", func() {
 			assessmentID := uuid.New()
 
-			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID, "test-assessment", "org1", "inventory", "NULL"))
+			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID, "test-assessment", "org1", "testuser", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
 
 			// Add a snapshot
@@ -141,6 +141,7 @@ var _ = Describe("assessment store", Ordered, func() {
 			Expect(assessment.ID).To(Equal(assessmentID))
 			Expect(assessment.Name).To(Equal("test-assessment"))
 			Expect(assessment.OrgID).To(Equal("org1"))
+			Expect(assessment.Username).To(Equal("testuser"))
 			Expect(assessment.SourceType).To(Equal("inventory"))
 			Expect(assessment.Snapshots).To(HaveLen(1))
 		})
@@ -551,11 +552,11 @@ var _ = Describe("assessment store", Ordered, func() {
 			assessment1ID := uuid.New()
 			assessment2ID := uuid.New()
 			assessment3ID := uuid.New()
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment1ID.String(), "Test Assessment 1", "org1", "inventory", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment1ID.String(), "Test Assessment 1", "org1", "testuser1", "inventory", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment2ID.String(), "Another Test", "org1", "rvtools", "NULL"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment2ID.String(), "Another Test", "org1", "testuser2", "rvtools", "NULL"))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment3ID.String(), "Production Assessment", "org2", "agent", "'12345678-1234-1234-1234-123456789012'"))
+			tx = gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessment3ID.String(), "Production Assessment", "org2", "produser", "agent", "'12345678-1234-1234-1234-123456789012'"))
 			Expect(tx.Error).To(BeNil())
 		})
 

--- a/internal/store/model/assessment.go
+++ b/internal/store/model/assessment.go
@@ -14,6 +14,7 @@ type Assessment struct {
 	UpdatedAt  *time.Time
 	Name       string     `gorm:"not null;uniqueIndex:org_id_name"`
 	OrgID      string     `gorm:"not null;uniqueIndex:org_id_name;index:assessments_org_id_idx"`
+	Username   string     `gorm:"not null;type:VARCHAR(255)"`
 	SourceType string     `gorm:"not null;type:VARCHAR(100)"`
 	SourceID   *uuid.UUID `gorm:"type:TEXT"`
 	Snapshots  []Snapshot `gorm:"foreignKey:AssessmentID;references:ID;constraint:OnDelete:CASCADE;"`

--- a/pkg/migrations/sql/20250901090447_add_username_to_assessment.sql
+++ b/pkg/migrations/sql/20250901090447_add_username_to_assessment.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE assessments ADD COLUMN username VARCHAR(255) NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE assessments DROP COLUMN username;
+-- +goose StatementEnd


### PR DESCRIPTION
This commit adds username to assessment db model and update the handler and service layer to allow the username to be set.

[ECOPROJECT-3269](https://issues.redhat.com//browse/ECOPROJECT-3269) | feat: Add username to assessment

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assessments now include and persist the authenticated user's username and organization on create; exposed in get/list/update/delete responses for both JSON and multipart upload flows.

- **Tests**
  - Added tests ensuring username and organization propagate through create, retrieve, list, update, and delete operations.

- **Chores**
  - Database migration adds a required username column; run migrations before deploy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->