### PR TITLE
ECOPROJECT-3261 | fix: photonOS is shown as supported in stage

### DIFF
--- a/internal/opa/validator_test.go
+++ b/internal/opa/validator_test.go
@@ -11,26 +11,27 @@ import (
 )
 
 const testPolicy = `package io.konveyor.forklift.vmware
-import future.keywords.in
 
-concerns[flag] {
-    input.name == "test-vm-with-concern"
-    flag := {
-        "id": "test.simple.concern",
-        "category": "Warning", 
-        "label": "Test VM detected",
-        "assessment": "This is a test concern."
-    }
+import rego.v1
+
+concerns contains flag if {
+	input.name == "test-vm-with-concern"
+	flag := {
+		"id": "test.simple.concern",
+		"category": "Warning",
+		"label": "Test VM detected",
+		"assessment": "This is a test concern.",
+	}
 }
 
-concerns[flag] {
-    input.guestId == "rhel6guest"
-    flag := {
-        "id":         "test.simple.concern",
-        "category":   "Warning",
-        "label":      "Test VM detected",
-        "assessment": "This is a test concern."
-    }
+concerns contains flag if {
+	input.guestId == "rhel6guest"
+	flag := {
+		"id": "test.simple.concern",
+		"category": "Warning",
+		"label": "Test VM detected",
+		"assessment": "This is a test concern.",
+	}
 }
 `
 
@@ -172,17 +173,16 @@ func TestValidator_ValidateVMS(t *testing.T) {
 		GuestID: "rhel6guest",
 	})
 
-	validatedVMs, err := validator.ValidateVMs(context.Background(), vms)
-	if err != nil {
+	if err := validator.ValidateVMs(context.Background(), &vms); err != nil {
 		t.Fatalf("concerns() failed: %v", err)
 	}
 
-	if len(validatedVMs) != 1 {
-		t.Errorf("Expected 1 vm, got %d", len(validatedVMs))
+	if len(vms) != 1 {
+		t.Errorf("Expected 1 vm, got %d", len(vms))
 	}
 
-	if len(validatedVMs[0].Concerns) != 1 {
-		t.Errorf("Expected 1 concern, got %d", len(validatedVMs[0].Concerns))
+	if len(vms[0].Concerns) != 1 {
+		t.Errorf("Expected 1 concern, got %d", len(vms[0].Concerns))
 	}
 }
 

--- a/internal/rvtools/parser.go
+++ b/internal/rvtools/parser.go
@@ -55,11 +55,8 @@ func ParseRVTools(ctx context.Context, rvtoolsContent []byte, opaValidator *opa.
 
 	if len(vms) > 0 && opaValidator != nil {
 		zap.S().Named("rvtools").Infof("Validating %d VMs using OPA validator", len(vms))
-		validatedVms, err := opaValidator.ValidateVMs(ctx, vms)
-		if err != nil {
-			zap.S().Named("rvtools").Warnf("OPA validation failed, continuing without validation: %v", err)
-		} else {
-			vms = validatedVms
+		if err := opaValidator.ValidateVMs(ctx, &vms); err != nil {
+			zap.S().Named("rvtools").Warnf("At least one error during VMs validation: %v", err)
 		}
 	}
 

--- a/internal/rvtools/parser_test.go
+++ b/internal/rvtools/parser_test.go
@@ -369,14 +369,16 @@ var _ = Describe("Parser", func() {
 				// Create a properly initialized OPA validator with a simple test policy
 				testPolicy := `package io.konveyor.forklift.vmware
 
-concerns[flag] {
-    input.name == "test-vm"
-    flag := {
-        "id": "test.concern",
-        "category": "Warning", 
-        "label": "Test concern",
-        "assessment": "This is a test VM with a concern."
-    }
+import rego.v1
+
+concerns contains flag if {
+	input.name == "test-vm"
+	flag := {
+		"id": "test.concern",
+		"category": "Warning",
+		"label": "Test concern",
+		"assessment": "This is a test VM with a concern.",
+	}
 }`
 				policies := map[string]string{
 					"test.rego": testPolicy,
@@ -949,7 +951,9 @@ invalid syntax here`
 
 			testPolicy := `package io.konveyor.forklift.vmware
 			
-			concerns[flag] {
+			import rego.v1
+
+			concerns contains flag if {
 				false  # No concerns for this test
 				flag := {}
 			}`


### PR DESCRIPTION
Let's wait for this [PR](https://github.com/kubev2v/forklift/pull/2711) to be merged first. 

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Policy engine upgraded to Rego v1 for improved VM policy validation compatibility.

- Bug Fixes
  - OS support detection now re-evaluates entries previously marked as supported, improving support counts and flags.
  - Validation failures are now logged as warnings to reduce noise while preserving visibility.

- Refactor
  - VM validation now updates VMs in-place and consolidates validation issues into a single aggregated result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->