### PR TITLE
NO-JIRA | refactor: e2e - separate the interfaces of the migration planner to small interfaces and create test wrappers

### DIFF
--- a/test/e2e/agent/agent.go
+++ b/test/e2e/agent/agent.go
@@ -1,12 +1,12 @@
-package e2e_agent
+package agent
 
 import (
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_service"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/kubev2v/migration-planner/test/e2e/service"
+	. "github.com/kubev2v/migration-planner/test/e2e/utils"
 	libvirt "github.com/libvirt/libvirt-go"
 	. "github.com/onsi/ginkgo/v2"
 	"go.uber.org/zap"
@@ -14,21 +14,18 @@ import (
 
 // PlannerAgent defines the interface for interacting with a planner agent instance
 type PlannerAgent interface {
-	AgentApi() *AgentApi
 	DumpLogs(string)
 	GetIp() (string, error)
 	IsServiceRunning(string, string) bool
 	Run() error
 	Restart() error
 	Remove() error
-	SetAgentApi(*AgentApi)
 }
 
 // plannerAgentLibvirt is an implementation of the PlannerAgent interface
 type plannerAgentLibvirt struct {
 	agentEndToEndTestID string
 	con                 *libvirt.Connect
-	localApi            *AgentApi
 	name                string
 	service             PlannerService
 	sourceID            uuid.UUID
@@ -43,11 +40,6 @@ func NewPlannerAgent(sourceID uuid.UUID, name string, idForTest string, svc Plan
 	}
 	return &plannerAgentLibvirt{agentEndToEndTestID: idForTest, con: conn,
 		name: name, service: svc, sourceID: sourceID}, nil
-}
-
-// AgentApi returns the associated Agent API instance
-func (p *plannerAgentLibvirt) AgentApi() *AgentApi {
-	return p.localApi
 }
 
 // DumpLogs prints journal logs from the agent VM to the GinkgoWriter
@@ -164,9 +156,4 @@ func (p *plannerAgentLibvirt) Remove() error {
 	}
 
 	return nil
-}
-
-// SetAgentApi allows assigning a reference to the AgentApi instance used by the agent
-func (p *plannerAgentLibvirt) SetAgentApi(agentApi *AgentApi) {
-	p.localApi = agentApi
 }

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -1,4 +1,4 @@
-package e2e_agent
+package agent
 
 import (
 	"bytes"

--- a/test/e2e/agent/agent_helpers.go
+++ b/test/e2e/agent/agent_helpers.go
@@ -1,4 +1,4 @@
-package e2e_agent
+package agent
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "github.com/kubev2v/migration-planner/test/e2e"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/kubev2v/migration-planner/test/e2e/utils"
 	"github.com/libvirt/libvirt-go"
 	"go.uber.org/zap"
 )

--- a/test/e2e/e2e_global_vars.go
+++ b/test/e2e/e2e_global_vars.go
@@ -12,22 +12,22 @@ var TestOptions = struct {
 }{}
 
 const (
-	DefaultOrganization string = "admin"
-	DefaultUsername     string = "admin"
-	DefaultEmailDomain  string = "example.com"
-	VmName              string = "coreos-vm"
-	Vsphere1Port        string = "8989"
-	Vsphere2Port        string = "8990"
+	DefaultOrganization = "admin"
+	DefaultUsername     = "admin"
+	DefaultEmailDomain  = "example.com"
+	VmName              = "coreos-vm"
+	Vsphere1Port        = "8989"
+	Vsphere2Port        = "8990"
 )
 
 var (
-	DefaultAgentTestID string = "1"
-	DefaultBasePath    string = "/tmp/untarova/"
-	DefaultVmdkName    string = filepath.Join(DefaultBasePath, "persistence-disk.vmdk")
-	DefaultOvaPath     string = filepath.Join(Home, "myimage.ova")
-	DefaultServiceUrl  string = fmt.Sprintf("http://%s:7443/api/migration-assessment", SystemIP)
-	Home               string = os.Getenv("HOME")
-	PrivateKeyPath     string = filepath.Join(os.Getenv("E2E_PRIVATE_KEY_FOLDER_PATH"), "private-key")
-	SystemIP           string = os.Getenv("PLANNER_IP")
-	TestsExecutionTime        = make(map[string]time.Duration)
+	DefaultAgentTestID = "1"
+	DefaultBasePath    = "/tmp/untarova/"
+	DefaultVmdkName    = filepath.Join(DefaultBasePath, "persistence-disk.vmdk")
+	DefaultOvaPath     = filepath.Join(Home, "myimage.ova")
+	DefaultServiceUrl  = fmt.Sprintf("http://%s:7443/api/migration-assessment", SystemIP)
+	Home               = os.Getenv("HOME")
+	PrivateKeyPath     = filepath.Join(os.Getenv("E2E_PRIVATE_KEY_FOLDER_PATH"), "private-key")
+	SystemIP           = os.Getenv("PLANNER_IP")
+	TestsExecutionTime = make(map[string]time.Duration)
 )

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	. "github.com/kubev2v/migration-planner/test/e2e"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/kubev2v/migration-planner/test/e2e/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"

--- a/test/e2e/helpers/test_helpers.go
+++ b/test/e2e/helpers/test_helpers.go
@@ -1,12 +1,12 @@
-package e2e_helpers
+package helpers
 
 import (
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_agent"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_service"
+	. "github.com/kubev2v/migration-planner/test/e2e/agent"
+	. "github.com/kubev2v/migration-planner/test/e2e/service"
 	"go.uber.org/zap"
 )
 
@@ -21,7 +21,7 @@ func CreateAgent(idForTest string, uuid uuid.UUID, vmName string, svc PlannerSer
 	if err != nil {
 		return nil, err
 	}
-	zap.S().Info("Agent created successfully")
+	zap.S().Info("agent created successfully")
 	return agent, nil
 }
 
@@ -35,7 +35,7 @@ func AgentIsUpToDate(svc PlannerService, uuid uuid.UUID) (bool, error) {
 	return source.Agent.Status == v1alpha1.AgentStatusUpToDate, nil
 }
 
-// CredentialURL helper function which return credential url for an Agent by source UUID
+// CredentialURL helper function which return credential url for an agent by source UUID
 func CredentialURL(svc PlannerService, uuid uuid.UUID) (string, error) {
 	zap.S().Info("try to retrieve valid credentials url")
 	s, err := svc.GetSource(uuid)

--- a/test/e2e/model/e2e_models.go
+++ b/test/e2e/model/e2e_models.go
@@ -1,0 +1,10 @@
+package model
+
+import (
+	. "github.com/kubev2v/migration-planner/test/e2e/agent"
+)
+
+type E2EAgent struct {
+	Agent PlannerAgent
+	Api   *AgentApi
+}

--- a/test/e2e/service/interfaces.go
+++ b/test/e2e/service/interfaces.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/google/uuid"
+	"github.com/kubev2v/migration-planner/api/v1alpha1"
+)
+
+// PlannerService defines the interface for interacting with the planner service
+type PlannerService interface {
+	sourceApi
+	imageApi
+}
+
+type sourceApi interface {
+	CreateSource(string) (*v1alpha1.Source, error)
+	GetSource(uuid.UUID) (*v1alpha1.Source, error)
+	GetSources() (*v1alpha1.SourceList, error)
+	RemoveSource(uuid.UUID) error
+	RemoveSources() error
+	UpdateSource(uuid.UUID, *v1alpha1.Inventory) error
+}
+
+type imageApi interface {
+	GetImageUrl(uuid.UUID) (string, error)
+}

--- a/test/e2e/service/service.go
+++ b/test/e2e/service/service.go
@@ -1,4 +1,4 @@
-package e2e_service
+package service
 
 import (
 	"encoding/json"
@@ -13,21 +13,9 @@ import (
 	internalclient "github.com/kubev2v/migration-planner/internal/api/client"
 	"github.com/kubev2v/migration-planner/internal/auth"
 	. "github.com/kubev2v/migration-planner/test/e2e"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/kubev2v/migration-planner/test/e2e/utils"
 	"go.uber.org/zap"
 )
-
-// PlannerService defines the interface for interacting with the planner service
-type PlannerService interface {
-	CreateSource(string) (*api.Source, error)
-	GetImageUrl(uuid.UUID) (string, error)
-	GetSource(uuid.UUID) (*api.Source, error)
-	GetSources() (*api.SourceList, error)
-	RemoveSource(uuid.UUID) error
-	RemoveSources() error
-	UpdateSource(uuid.UUID, *v1alpha1.Inventory) error
-	ChangeCredentials(user *auth.User) error
-}
 
 // plannerService is the concrete implementation of PlannerService
 type plannerService struct {
@@ -220,20 +208,4 @@ func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Invent
 	}
 
 	return err
-}
-
-// ChangeCredentials sets the plannerService's credentials and initializes a new Service API instance
-// if the provided credentials differ from the currently stored ones.
-func (s *plannerService) ChangeCredentials(newCredentials *auth.User) error {
-	if s.credentials.Organization == newCredentials.Organization &&
-		s.credentials.Username == newCredentials.Username {
-		return nil
-	}
-	newApi, err := NewServiceApi(newCredentials)
-	if err != nil {
-		return fmt.Errorf("error creating new Service api instance %s", err)
-	}
-	s.api = newApi
-	s.credentials = newCredentials
-	return nil
 }

--- a/test/e2e/service/service_api.go
+++ b/test/e2e/service/service_api.go
@@ -1,4 +1,4 @@
-package e2e_service
+package service
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/kubev2v/migration-planner/internal/auth"
 	. "github.com/kubev2v/migration-planner/test/e2e"
-	. "github.com/kubev2v/migration-planner/test/e2e/e2e_utils"
+	. "github.com/kubev2v/migration-planner/test/e2e/utils"
 	"go.uber.org/zap"
 )
 

--- a/test/e2e/utils/auth.go
+++ b/test/e2e/utils/auth.go
@@ -1,4 +1,4 @@
-package e2e_utils
+package utils
 
 import (
 	"fmt"

--- a/test/e2e/utils/command.go
+++ b/test/e2e/utils/command.go
@@ -1,4 +1,4 @@
-package e2e_utils
+package utils
 
 import (
 	"bytes"

--- a/test/e2e/utils/file.go
+++ b/test/e2e/utils/file.go
@@ -1,4 +1,4 @@
-package e2e_utils
+package utils
 
 import (
 	"archive/tar"

--- a/test/e2e/utils/log.go
+++ b/test/e2e/utils/log.go
@@ -1,4 +1,4 @@
-package e2e_utils
+package utils
 
 import (
 	"sort"


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - End-to-end tests now support per-user/per-organization service instances for stronger isolation and coverage.

- Tests
  - Introduced a unified agent wrapper and added two-agent scenarios to clarify test flows and API interactions.
  - Updated tests and helpers to use consolidated utilities for maintainability.

- Refactor
  - Standardized internal package names and simplified global declarations.

- Chores
  - Minor log message wording/casing consistency tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->