### PR TITLE
ECOPROJECT-3167 | fix: update git describe to return short tag format when on exact tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ FORKLIFT_POLICIES_TMP_DIR ?= /tmp/forklift-policies
 
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse "HEAD^{commit}" 2>/dev/null)
 SOURCE_GIT_COMMIT_SHORT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)
-SOURCE_GIT_TAG ?=$(shell git describe --always --long --tags --abbrev=7 --match '[0-9]*\.[0-9]*\.[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT_SHORT)')
+SOURCE_GIT_TAG ?=$(shell git describe --always --tags --abbrev=7 --match '[0-9]*\.[0-9]*\.[0-9]*' --match 'v[0-9]*\.[0-9]*\.[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT_SHORT)')
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d ".git/" ] || git diff --quiet ) && echo 'clean' ) || echo 'dirty')
 BIN_TIMESTAMP ?=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-MAJOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$1}')
-MINOR := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$2}')
-PATCH := $(shell echo $(SOURCE_GIT_TAG) | awk -F'[._~-]' '{print $$3}')
+MAJOR := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//' | awk -F'[._~-]' '{print $$1}')
+MINOR := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//' | awk -F'[._~-]' '{print $$2}')
+PATCH := $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//' | awk -F'[._~-]' '{print $$3}')
 
 GO_LD_FLAGS := -ldflags "\
 	-X github.com/kubev2v/migration-planner/pkg/version.majorFromGit=$(MAJOR) \


### PR DESCRIPTION
Remove --long flag from git describe to return just the tag name when on an exact tag, 
while preserving long format when ahead of tags.
Also add proper version prefix handling for MAJOR/MINOR/PATCH parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version detection to recognize tags with or without a leading “v”.
  * Ensured major/minor/patch numbers are parsed consistently; reported numeric values no longer include a leading “v”.
  * Version string in build outputs may be shorter and more consistent across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->