### PR TITLE
NO-JIRA | feat: Add Envoy request ID extension to backend agent API

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -303,6 +303,9 @@ objects:
                     skip_xff_append: false
                     xff_num_trusted_hops: 1
                     stat_prefix: backend-agent-api
+                    request_id_extension:
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.request_id.uuid.v3.UuidRequestIdConfig
                     access_log:
                     - name: envoy.access_loggers.file
                       typed_config:


### PR DESCRIPTION
Configure UUID request ID generation for the backend-agent-api HTTP connection manager to enable request tracking and error tracing in the backend processing pipeline.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Each incoming request now receives a unique UUID at the edge, ensuring consistent request identification across services.
  - Improves log correlation and end-to-end tracing, simplifying debugging and support workflows.
  - No behavior changes required from clients; applies transparently to requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->