### PR TITLE
NO-JIRA | ci: add owners file for the openshift-ci robot

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- nirarg
+- machacekondra
+- bardielle
+- tupyy
+- ronenav
+- Jos-Jerus
+- AvielSegev
+reviewers:
+- nirarg
+- machacekondra
+- bardielle
+- tupyy
+- ronenav
+- Jos-Jerus
+- AvielSegev


### PR DESCRIPTION
It seems that the bot is expecting the OWNERS file as described in every PR we open:

```
Needs approval from an approver in each of these files:
[OWNERS](https://github.com/kubev2v/migration-planner/blob/main/OWNERS)
Approvers can indicate their approval by writing /approve in a comment
Approvers can cancel approval by writing /approve cancel in a comment
```

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced repository ownership configuration to define approver and reviewer groups, streamlining code review and governance.
  * No changes to functionality, UI, performance, or APIs.
  * Does not alter user workflows or compatibility; no action required from end-users.
  * Internal process improvement only, ensuring clearer accountability and faster reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->