### PR TITLE
NO-JIRA | feat: remove example source

### DIFF
--- a/api/v1alpha1/openapi.yaml
+++ b/api/v1alpha1/openapi.yaml
@@ -14,13 +14,6 @@ paths:
         - source
       description: List sources
       operationId: listSources
-      parameters:
-        - name: include_default
-          in: query
-          description: control whatever the default report should be added to the result
-          required: false
-          schema:
-            type: boolean
       responses:
         "200":
           description: OK

--- a/api/v1alpha1/spec.gen.go
+++ b/api/v1alpha1/spec.gen.go
@@ -67,15 +67,14 @@ var swaggerSpec = []string{
 	"fyCY2ceCqg37JYn1dDduPtxJSO4Kx38TU58e/bT/Q59xMaeEALMnTvd/4kuunvGUfYu3nDNleQ7K5noJ",
 	"BHRBgXR57XNQB5c9uOzBZe8sMU1V6zcvui9YC/Steus+E+TsUXZQLnsIFIdA8T0EiisQKxDo6eCEPW+0",
 	"tN75cc8gf+Piz74evjcHsq37Ntf52nHZyLMiYdsck12VEMkqIRTYr3Nmj+b5TndNdLVd3ZuosymGQ0uo",
-	"rOH8e9RtibLp7bWpTi8Wiuu8aM2zP4/QOsQKtFPrOzebKEYCEi4UkiFPI4LmgDAhQJDiBkqATKPtrfxn",
-	"Cub9PL+WWRClBD5mqLzyndzoZe8zZS7NWR0srMXCuhuOmZm19Bqv8sV9pFGVOck7bgfm03aHVuA3Za3N",
-	"O29wC7DNkMs33fDCZIvs+2ohtJv1oSo4VAVfdOAt0pdmn6/FN5+DOjjmwTEPjrm33K+jp9fik3b1W3PL",
-	"fWWfX6eB1x4NLD3bgHmIDIfIsPtGXl+6PTGzV2Y0HbDjd0peACbG61+9O7FzWo0ookHOspXuEEK+3s3e",
-	"cREPcY9B5txvfr3mclv1Wo30aDcfEuxM4Lb6Nb8d9/b1eXsG9ySb57NAnSrPftDOaOr7yuKqI5aumGYG",
-	"JrfDjSUH+XtF8ulXqkx6Tb/yraSO5Kj8pSFXfnRWWv+/TZHqrH6jWVJJWYd86ZAvfYV8Kf+F3J6gkvco",
-	"0Tz/TVbKlggz9PrdG70fLWgEiFABgYpckUdvyWdoafQdlGe9c8NDflf1TQhVCf3z6acAon8N+EHV+rcF",
-	"Wn6DdPdxrfXr1b1foHX4YPG7sjrm2S8DL9IoOsS7Q7zbe7wLAUcqbC0V7DIKQgiuXVVgZELNsOqrREJ2",
-	"6gdDvzSE2ghnv64z8W4+3PwvAAD//xpOmD8RYgAA",
+	"rOH8e9RtibLp7bWpTi/eheKKEaaD8lqU193LyzTY0sa7yhf3kaFURhDvuNOWD7IdumzflLU2r5PB3bU2",
+	"Qy5fIsNz/i2y76s6bzfrQ8J9SLi/6MBbZAbNFlqLbz4HdXDMg2MeHHNvuV9Hu6zFJ+3qt+aW+8o+v05v",
+	"rD0aWHq2AfMQGQ6RYfc9sr50e2LGmszUN2DHT4C8AEyM1796d2JHoBpRRIOcZSvdIYR8vZu94yIe4h6D",
+	"zLnf/HrN5bbqtRrp0W4+f9eZwG31a36W7e3r8/YM7kk2KmeBOlWe/Vac0dT3lcVVpxddMc3MIm7nBksO",
+	"8veK5NOvVJn0mn7lCz8dyVH5+ziu/OistP5/myLVWf1Gs6SSsg750iFf+gr5Uv7jsz1BJe9Ronn+c6eU",
+	"LRFm6PW7N3o/WtAIEKECAhW5Io/eko+n0ug7KM96R3KH/GTpmxCqEvrn008BRP8a8Ful9UH8lp/33H1c",
+	"a/3mcu93Ux0+WPxkq4559nu2izSKDvHuEO/2Hu9CwJEKW0sFu4yCEIJrVxUYmVAzrPoqkZCd+sHQLw2h",
+	"NsLZb8JMvJsPN/8LAAD///btz4hsYQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v1alpha1/types.gen.go
+++ b/api/v1alpha1/types.gen.go
@@ -338,12 +338,6 @@ type PresignedUrl struct {
 	Url string `json:"url"`
 }
 
-// ListSourcesParams defines parameters for ListSources.
-type ListSourcesParams struct {
-	// IncludeDefault control whatever the default report should be added to the result
-	IncludeDefault *bool `form:"include_default,omitempty" json:"include_default,omitempty"`
-}
-
 // UploadRvtoolsFileMultipartBody defines parameters for UploadRvtoolsFile.
 type UploadRvtoolsFileMultipartBody struct {
 	// File The RVTools file (Excel)

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -61,13 +61,6 @@ var runCmd = &cobra.Command{
 			zap.S().Fatalw("running initial migration", "error", err)
 		}
 
-		// Initialize database with basic example report
-		if v, b := os.LookupEnv("NO_SEED"); !b || v == "false" {
-			if err := store.Seed(); err != nil {
-				zap.S().Fatalw("seeding database with default report", "error", err)
-			}
-		}
-
 		// The migration planner API expects the RHCOS ISO to be on disk
 		if err := ensureIsoExist(cfg.Service.IsoPath); err != nil {
 			zap.S().Fatalw("validate iso", "error", err)

--- a/internal/api/client/client.gen.go
+++ b/internal/api/client/client.gen.go
@@ -117,7 +117,7 @@ type ClientInterface interface {
 	DeleteSources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListSources request
-	ListSources(ctx context.Context, params *ListSourcesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListSources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateSourceWithBody request with any body
 	CreateSourceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -261,8 +261,8 @@ func (c *Client) DeleteSources(ctx context.Context, reqEditors ...RequestEditorF
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListSources(ctx context.Context, params *ListSourcesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListSourcesRequest(c.Server, params)
+func (c *Client) ListSources(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSourcesRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ func NewDeleteSourcesRequest(server string) (*http.Request, error) {
 }
 
 // NewListSourcesRequest generates requests for ListSources
-func NewListSourcesRequest(server string, params *ListSourcesParams) (*http.Request, error) {
+func NewListSourcesRequest(server string) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -670,28 +670,6 @@ func NewListSourcesRequest(server string, params *ListSourcesParams) (*http.Requ
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.IncludeDefault != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_default", runtime.ParamLocationQuery, *params.IncludeDefault); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -1104,7 +1082,7 @@ type ClientWithResponsesInterface interface {
 	DeleteSourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*DeleteSourcesResponse, error)
 
 	// ListSourcesWithResponse request
-	ListSourcesWithResponse(ctx context.Context, params *ListSourcesParams, reqEditors ...RequestEditorFn) (*ListSourcesResponse, error)
+	ListSourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListSourcesResponse, error)
 
 	// CreateSourceWithBodyWithResponse request with any body
 	CreateSourceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSourceResponse, error)
@@ -1650,8 +1628,8 @@ func (c *ClientWithResponses) DeleteSourcesWithResponse(ctx context.Context, req
 }
 
 // ListSourcesWithResponse request returning *ListSourcesResponse
-func (c *ClientWithResponses) ListSourcesWithResponse(ctx context.Context, params *ListSourcesParams, reqEditors ...RequestEditorFn) (*ListSourcesResponse, error) {
-	rsp, err := c.ListSources(ctx, params, reqEditors...)
+func (c *ClientWithResponses) ListSourcesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListSourcesResponse, error) {
+	rsp, err := c.ListSources(ctx, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -11,7 +11,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/google/uuid"
-	"github.com/kubev2v/migration-planner/api/v1alpha1"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	apiclient "github.com/kubev2v/migration-planner/internal/api/client"
 	"github.com/spf13/cobra"
@@ -108,8 +107,7 @@ func (o *GetOptions) Run(ctx context.Context, args []string) error { // nolint: 
 	case kind == SourceKind && id != nil:
 		response, err = c.GetSourceWithResponse(ctx, *id)
 	case kind == SourceKind && id == nil:
-		params := v1alpha1.ListSourcesParams{}
-		response, err = c.ListSourcesWithResponse(ctx, &params)
+		response, err = c.ListSourcesWithResponse(ctx)
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", kind)
 	}

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -40,11 +40,6 @@ func (s *ServiceHandler) ListSources(ctx context.Context, request apiServer.List
 
 	filter := service.NewSourceFilter(service.WithOrgID(user.Organization))
 
-	includeDefault := request.Params.IncludeDefault
-	if includeDefault != nil && *includeDefault {
-		filter = filter.WithOption(service.WithDefaultInventory())
-	}
-
 	sources, err := s.sourceSrv.ListSources(ctx, filter)
 	if err != nil {
 		return server.ListSources500JSONResponse{}, nil

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -59,15 +59,6 @@ func (s *SourceService) ListSources(ctx context.Context, filter *SourceFilter) (
 		return nil, err
 	}
 
-	if filter.IncludeDefault {
-		// Get default content
-		defaultResult, err := s.store.Source().List(ctx, store.NewSourceQueryFilter().ByDefaultInventory())
-		if err != nil {
-			return nil, err
-		}
-		return append(userResult, defaultResult...), nil
-	}
-
 	return userResult, nil
 }
 
@@ -254,7 +245,7 @@ func (s *SourceService) UploadRvtoolsFile(ctx context.Context, sourceID uuid.UUI
 
 	zap.S().Infow("received RVTools data", "size [bytes]", len(rvtoolsContent))
 
-	//TODO: support csv files
+	// TODO: support csv files
 	if !rvtools.IsExcelFile(rvtoolsContent) {
 		return NewErrExcelFileNotValid()
 	}
@@ -312,9 +303,8 @@ func (s *SourceService) UploadRvtoolsFile(ctx context.Context, sourceID uuid.UUI
 type SourceFilterFunc func(s *SourceFilter)
 
 type SourceFilter struct {
-	OrgID          string
-	ID             uuid.UUID
-	IncludeDefault bool
+	OrgID string
+	ID    uuid.UUID
 }
 
 func NewSourceFilter(filters ...SourceFilterFunc) *SourceFilter {
@@ -339,11 +329,5 @@ func WithSourceID(id uuid.UUID) SourceFilterFunc {
 func WithOrgID(orgID string) SourceFilterFunc {
 	return func(s *SourceFilter) {
 		s.OrgID = orgID
-	}
-}
-
-func WithDefaultInventory() SourceFilterFunc {
-	return func(s *SourceFilter) {
-		s.IncludeDefault = true
 	}
 }

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -269,7 +269,6 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Raw("SELECT COUNT(*) FROM SOURCES;").Scan(&count)
 			Expect(tx.Error).To(BeNil())
 			Expect(count).To(Equal(0))
-
 		})
 
 		It("successfully deletes a source", func() {
@@ -609,14 +608,6 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 	})
 
 	Context("source filter", func() {
-		It("filter does not have default inventory", func() {
-			f := service.NewSourceFilter()
-			Expect(f.IncludeDefault).To(BeFalse())
-		})
-		It("filter does have default inventory", func() {
-			f := service.NewSourceFilter(service.WithDefaultInventory())
-			Expect(f.IncludeDefault).To(BeTrue())
-		})
 		It("filter has orgID set properlly", func() {
 			f := service.NewSourceFilter(service.WithOrgID("test"))
 			Expect(f.OrgID).To(Equal("test"))

--- a/internal/store/options.go
+++ b/internal/store/options.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -67,20 +66,6 @@ func (sf *SourceQueryFilter) ByUsername(username string) *SourceQueryFilter {
 func (sf *SourceQueryFilter) ByOrgID(id string) *SourceQueryFilter {
 	sf.QueryFn = append(sf.QueryFn, func(tx *gorm.DB) *gorm.DB {
 		return tx.Where("org_id = ?", id)
-	})
-	return sf
-}
-
-func (sf *SourceQueryFilter) ByDefaultInventory() *SourceQueryFilter {
-	sf.QueryFn = append(sf.QueryFn, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("id = ?", uuid.UUID{})
-	})
-	return sf
-}
-
-func (sf *SourceQueryFilter) WithoutDefaultInventory() *SourceQueryFilter {
-	sf.QueryFn = append(sf.QueryFn, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("id != ?", uuid.UUID{})
 	})
 	return sf
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -87,16 +87,6 @@ var _ = Describe("Store", Ordered, func() {
 			Expect(count).To(Equal(0))
 		})
 
-		It("Seed the databsae", func() {
-			err := store.Seed()
-			Expect(err).To(BeNil())
-
-			count := 0
-			err = gormDB.Raw("SELECT COUNT(*) from sources;").Scan(&count).Error
-			Expect(err).To(BeNil())
-			Expect(count).To(Equal(1))
-		})
-
 		AfterEach(func() {
 			gormDB.Exec("DELETE from agents;")
 			gormDB.Exec("DELETE from sources;")


### PR DESCRIPTION
this commit removes the example source from the code.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Source listing now returns only your organization’s sources; default-inventory inclusion removed.
- Chores
  - Removed the include_default query parameter and related parameter passing across client/server and CLI.
  - Removed automatic DB seeding and public helpers for default inventory.
- Documentation
  - OpenAPI spec updated to reflect the removed parameter.
- Tests
  - Tests updated to match new listing behavior and removed seed-related cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->