### PR TITLE
ECOPROJECT-3338 | ci: As part of the RHCOS component, temporarily build the planner agent container.

### DIFF
--- a/.tekton/migration-planner-rhcos-iso-pull-request.yaml
+++ b/.tekton/migration-planner-rhcos-iso-pull-request.yaml
@@ -25,6 +25,8 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:on-pr-{{revision}}
+  - name: agent-output-image
+    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:migration-planner-agent-on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -46,6 +48,9 @@ spec:
     - default: ""
       description: Revision of the Source Repository
       name: revision
+      type: string
+    - description: Fully Qualified Agent Output Image
+      name: agent-output-image
       type: string
     - description: Fully Qualified Output Image
       name: output-image
@@ -187,6 +192,47 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: build-planner-agent-container
+      params:
+        - name: IMAGE
+          value: $(params.agent-output-image)
+        - name: DOCKERFILE
+          value: Containerfile.agent
+        - name: CONTEXT
+          value: .
+        - name: HERMETIC
+          value: ""
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: "1d"
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        params:
+          - name: name
+            value: buildah
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -206,7 +252,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
-        - AGENT_TAG=on-pr-$(tasks.clone-repository.results.commit)
+        - AGENT_IMAGE=$(params.agent-output-image)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
@@ -216,7 +262,7 @@ spec:
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:
-      - prefetch-dependencies
+      - build-planner-agent-container
       taskRef:
         params:
         - name: name

--- a/.tekton/migration-planner-rhcos-iso-pull-request.yaml
+++ b/.tekton/migration-planner-rhcos-iso-pull-request.yaml
@@ -194,45 +194,45 @@ spec:
         workspace: netrc
     - name: build-planner-agent-container
       params:
-        - name: IMAGE
-          value: $(params.agent-output-image)
-        - name: DOCKERFILE
-          value: Containerfile.agent
-        - name: CONTEXT
-          value: .
-        - name: HERMETIC
-          value: ""
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: "1d"
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository.results.commit)
-        - name: PRIVILEGED_NESTED
-          value: $(params.privileged-nested)
-        - name: SOURCE_URL
-          value: $(tasks.clone-repository.results.url)
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
+      - name: IMAGE
+        value: $(params.agent-output-image)
+      - name: DOCKERFILE
+        value: Containerfile.agent
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: "1d"
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
       runAfter:
-        - prefetch-dependencies
+      - prefetch-dependencies
       taskRef:
         params:
-          - name: name
-            value: buildah
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
-          - name: kind
-            value: task
+        - name: name
+          value: buildah
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
+        - name: kind
+          value: task
         resolver: bundles
       when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
       workspaces:
-        - name: source
-          workspace: workspace
+      - name: source
+        workspace: workspace
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/migration-planner-rhcos-iso-push.yaml
+++ b/.tekton/migration-planner-rhcos-iso-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:{{revision}}
   - name: agent-output-image
-    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:migration-planner-agent-{{revision}}
+    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:migration-planner-agent:{{revision}}
   - name: dockerfile
     value: build/migration-planner-iso/Containerfile
   - name: path-context
@@ -191,45 +191,45 @@ spec:
         workspace: netrc
     - name: build-planner-agent-container
       params:
-        - name: IMAGE
-          value: $(params.agent-output-image)
-        - name: DOCKERFILE
-          value: Containerfile.agent
-        - name: CONTEXT
-          value: .
-        - name: HERMETIC
-          value: ""
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: "1d"
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository.results.commit)
-        - name: PRIVILEGED_NESTED
-          value: $(params.privileged-nested)
-        - name: SOURCE_URL
-          value: $(tasks.clone-repository.results.url)
-        - name: BUILDAH_FORMAT
-          value: $(params.buildah-format)
+      - name: IMAGE
+        value: $(params.agent-output-image)
+      - name: DOCKERFILE
+        value: Containerfile.agent
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: "1d"
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
+      - name: SOURCE_URL
+        value: $(tasks.clone-repository.results.url)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
       runAfter:
-        - prefetch-dependencies
+      - prefetch-dependencies
       taskRef:
         params:
-          - name: name
-            value: buildah
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
-          - name: kind
-            value: task
+        - name: name
+          value: buildah
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
+        - name: kind
+          value: task
         resolver: bundles
       when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
       workspaces:
-        - name: source
-          workspace: workspace
+      - name: source
+        workspace: workspace
     - name: build-container
       params:
       - name: IMAGE

--- a/.tekton/migration-planner-rhcos-iso-push.yaml
+++ b/.tekton/migration-planner-rhcos-iso-push.yaml
@@ -24,6 +24,8 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:{{revision}}
+  - name: agent-output-image
+    value: quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-rhcos-iso:migration-planner-agent-{{revision}}
   - name: dockerfile
     value: build/migration-planner-iso/Containerfile
   - name: path-context
@@ -43,6 +45,9 @@ spec:
     - default: ""
       description: Revision of the Source Repository
       name: revision
+      type: string
+    - description: Fully Qualified Agent Output Image
+      name: agent-output-image
       type: string
     - description: Fully Qualified Output Image
       name: output-image
@@ -184,6 +189,47 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: build-planner-agent-container
+      params:
+        - name: IMAGE
+          value: $(params.agent-output-image)
+        - name: DOCKERFILE
+          value: Containerfile.agent
+        - name: CONTEXT
+          value: .
+        - name: HERMETIC
+          value: ""
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: "1d"
+        - name: COMMIT_SHA
+          value: $(tasks.clone-repository.results.commit)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(tasks.clone-repository.results.url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+      runAfter:
+        - prefetch-dependencies
+      taskRef:
+        params:
+          - name: name
+            value: buildah
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.5@sha256:9ac12870766a980e1f7ae7ddd0852f767da000d8a6d24f5b37e906eb14932355
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(tasks.init.results.build)
+          operator: in
+          values:
+            - "true"
+      workspaces:
+        - name: source
+          workspace: workspace
     - name: build-container
       params:
       - name: IMAGE
@@ -203,7 +249,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
-        - AGENT_TAG=$(tasks.clone-repository.results.commit)
+        - AGENT_IMAGE=$(params.agent-output-image)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
@@ -213,7 +259,7 @@ spec:
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
       runAfter:
-      - prefetch-dependencies
+      - build-planner-agent-container
       taskRef:
         params:
         - name: name

--- a/build/migration-planner-iso/Containerfile
+++ b/build/migration-planner-iso/Containerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 quay.io/centos/centos:stream9 AS builder
 
-ARG ISO_URL ISO_CHECKSUM AGENT_IMAGE AGENT_TAG
+ARG ISO_URL ISO_CHECKSUM AGENT_IMAGE
 
 USER root
 
@@ -37,7 +37,6 @@ RUN /tmp/build-ove-image.sh \
     --dir / \
     --output-file /output/final.iso \
     --agent-image ${AGENT_IMAGE} \
-    --agent-tag ${AGENT_TAG} \
     && rm /initial-rhcos.iso && rm -rf /isomnt
 
 # Final stage with minimal image

--- a/build/migration-planner-iso/build-ove-image.sh
+++ b/build/migration-planner-iso/build-ove-image.sh
@@ -11,7 +11,6 @@ export DIR_PATH=""
 export ISO_FILE_PATH=""
 export OUTPUT_FILE_PATH=""
 export AGENT_IMAGE=""
-export AGENT_TAG=""
 export REGISTRY=""
 export ORG=""
 export AGENT_IMAGE_NAME=""
@@ -91,10 +90,6 @@ parse_arguments() {
                 AGENT_IMAGE="$2"
                 shift 2
                 ;;
-            --agent-tag)
-                AGENT_TAG="$2"
-                shift 2
-                ;;
             --dry-run)
                 DRY_RUN=true
                 shift
@@ -128,8 +123,7 @@ OPTIONS:
     --iso-file PATH         Path to the RHCOS ISO file (required)
     --dir PATH              Working directory path (default: $DEFAULT_WORK_DIR)
     --output-file PATH      Full path to the output ISO file (required)
-    --agent-image NAME      Agent image name (required)
-    --agent-tag TAG         Agent image tag (required)
+    --agent-image NAME      Agent image pull spec with tag (required)
     --dry-run               Show what would be done without executing
     -h, --help              Show this help message
 
@@ -137,18 +131,17 @@ ENVIRONMENT VARIABLES:
     ISO_FILE_PATH           Path to the RHCOS ISO file (overridden by --iso-file)
     DIR_PATH                Working directory path (overridden by --dir)
     OUTPUT_FILE_PATH        Full path to the output ISO file (overridden by --output-file)
-    AGENT_IMAGE             Agent image name (overridden by --agent-image)
-    AGENT_TAG               Agent image tag (overridden by --agent-tag)
+    AGENT_IMAGE             Agent image pull spec with tag (overridden by --agent-image)
 
 EXAMPLES:
     # Basic usage with all required parameters
-    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent --agent-tag latest
+    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent:latest
 
     # Specify custom working directory
-    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent --agent-tag latest --dir /tmp/work
+    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent:latest --dir /tmp/work
 
     # Dry run to preview operations
-    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent --agent-tag latest --dry-run
+    $(basename "$0") --iso-file /path/to/rhcos.iso --output-file /path/to/agent.iso --agent-image docker.io/myorg/my-agent:latest --dry-run
 
 OUTPUTS:
     The script will create the ISO file at the specified --output-file path
@@ -177,12 +170,6 @@ function setup_vars() {
 
     if [[ -z "$AGENT_IMAGE" ]]; then
         log_error "AGENT_IMAGE is required. Please provide --agent-image parameter."
-        log_error "Use --help for usage information."
-        exit 1
-    fi
-
-    if [[ -z "$AGENT_TAG" ]]; then
-        log_error "AGENT_TAG is required. Please provide --agent-tag parameter."
         log_error "Use --help for usage information."
         exit 1
     fi
@@ -224,7 +211,7 @@ function setup_vars() {
     log_info "Working directory: $DIR_PATH"
     log_info "Output file: $OUTPUT_FILE_PATH"
     log_info "ISO file: $ISO_FILE_PATH"
-    log_info "Agent image: ${AGENT_IMAGE}:${AGENT_TAG}"
+    log_info "Agent image: ${AGENT_IMAGE}"
 }
 
 function extract_live_iso() {
@@ -287,7 +274,7 @@ function wait_for_image_availability() {
 
 function setup_agent_artifacts() {
     local image_dir="${work_dir}/images"
-    local pull_spec="${AGENT_IMAGE}:${AGENT_TAG}"
+    local pull_spec="${AGENT_IMAGE}"
     local image_tar="${image_dir}/migration-planner-agent.tar"
 
     if [[ -f "${image_tar}" ]]; then

--- a/build/migration-planner-iso/config
+++ b/build/migration-planner-iso/config
@@ -1,4 +1,3 @@
 FINAL_ISO_PATH=/rhcos.iso
 ISO_URL=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.19/4.19.10/rhcos-4.19.10-x86_64-live-iso.x86_64.iso
 ISO_CHECKSUM=7a47d0c7a9bf5edb143d52809e793af2d74731567b95d91c6225171a1c49b5ab
-AGENT_IMAGE=quay.io/redhat-user-workloads/assisted-migration-tenant/migration-planner-agent


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pipeline task to build the planner agent container and run it before the main build (conditional on init results).
  * Added a public parameter (agent-output-image) and propagated it into builds via AGENT_IMAGE.
  * Replaced separate agent-tag handling with a single AGENT_IMAGE pull spec (tag included); removed AGENT_TAG usage across build scripts and Containerfile.
  * Removed default AGENT_IMAGE from configuration and updated docs/examples/help to reflect the new single-image workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->