### PR TITLE
NO-JIRA | ci: Use task-rpms-signature-scan from tekton-catalog (instead of konflux-vanguard)

### DIFF
--- a/.tekton/migration-planner-rhcos-iso-pull-request.yaml
+++ b/.tekton/migration-planner-rhcos-iso-pull-request.yaml
@@ -620,7 +620,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/migration-planner-rhcos-iso-push.yaml
+++ b/.tekton/migration-planner-rhcos-iso-push.yaml
@@ -619,7 +619,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI pipelines to use the rpms signature scan task from the official catalog for both pull request and push workflows, improving consistency and maintainability.
  - Aligns scan task source across workflows for more predictable results and easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->