### PR TITLE
ECOPROJECT-2490 | fix: Solving errors when user clicks 'Go back to assessment wizard' button in Agent UI

### DIFF
--- a/agent-ui/js/views/form.js
+++ b/agent-ui/js/views/form.js
@@ -38,8 +38,7 @@ export default class FormView extends Observable {
                     )
                 },
                 goBackBtnCallback: () => {
-                    const serviceUrl = self.store.state.url || "http://localhost:3000/migrate/wizard";
-                    window.open(serviceUrl, '_blank', 'noopener,noreferrer');
+                    window.close();
                 },
             }).render();
 


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-2490

When the user click en the IP of the source that is in status 'Waiting for credentials' we are opening a new tab with the Agent UI. With this change the tab is closed when user clicks the button 'Go back to assessment wizard'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Back button in forms now closes the current window instead of opening a new service URL in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->