### PR TITLE
ECOPROJECT-3167 | build: Use the the version flags also from Containerfile

### DIFF
--- a/Containerfile.agent
+++ b/Containerfile.agent
@@ -22,13 +22,12 @@ RUN go mod download
 COPY . .
 
 ARG GCFLAGS=""
-ARG VERSION
-ENV VERSION=${VERSION}
 
 USER 0
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false ${GCFLAGS:+-gcflags "$GCFLAGS"} \
-  -ldflags "-X github.com/kubev2v/migration-planner/internal/agent.version=${VERSION}" \
-  -o /planner-agent cmd/planner-agent/main.go
+RUN source hack/version.sh && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false ${GCFLAGS:+-gcflags "$GCFLAGS"} \
+    -ldflags "-X github.com/kubev2v/migration-planner/internal/agent.version=${SOURCE_GIT_TAG}" \
+    -o /planner-agent cmd/planner-agent/main.go
 
 RUN echo "Downloading OPA policies using Makefile target..." && \
     OPA_POLICIES_DIR=/app/policies make setup-opa-policies

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -11,7 +11,10 @@ RUN go mod download
 COPY . .
 
 USER 0
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false ${GCFLAGS:+-gcflags "$GCFLAGS"} -o /planner-api cmd/planner-api/*.go
+RUN source hack/version.sh && \
+    CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false ${GCFLAGS:+-gcflags "$GCFLAGS"} \
+    -ldflags "${GO_LDFLAGS}" \
+    -o /planner-api cmd/planner-api/*.go
 
 # Download OPA policies from Forklift repository
 RUN echo "Downloading OPA policies using Makefile target..." && \

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# This script calculates version information from git and exports them as environment variables
+# Usage:
+#   source hack/version.sh    - sources all version variables into current shell
+
+set -e
+
+# Get git commit
+export SOURCE_GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null || echo "")
+export SOURCE_GIT_COMMIT_SHORT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "")
+
+# Get git tag
+export SOURCE_GIT_TAG=$(git describe --always --tags --abbrev=7 \
+    --match '[0-9]*.[0-9]*.[0-9]*' \
+    --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null \
+    || echo "v0.0.0-unknown-${SOURCE_GIT_COMMIT_SHORT}")
+
+# Get git tree state
+if [ ! -d ".git/" ] || git diff --quiet 2>/dev/null; then
+    export SOURCE_GIT_TREE_STATE="clean"
+else
+    export SOURCE_GIT_TREE_STATE="dirty"
+fi
+
+# Get build timestamp
+export BIN_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Parse version numbers from tag
+export MAJOR=$(echo $SOURCE_GIT_TAG | sed 's/^v//' | awk -F'[._~-]' '{print $1}')
+export MINOR=$(echo $SOURCE_GIT_TAG | sed 's/^v//' | awk -F'[._~-]' '{print $2}')
+export PATCH=$(echo $SOURCE_GIT_TAG | sed 's/^v//' | awk -F'[._~-]' '{print $3}')
+
+# Build ldflags
+export GO_LDFLAGS="\
+-X github.com/kubev2v/migration-planner/pkg/version.majorFromGit=${MAJOR} \
+-X github.com/kubev2v/migration-planner/pkg/version.minorFromGit=${MINOR} \
+-X github.com/kubev2v/migration-planner/pkg/version.patchFromGit=${PATCH} \
+-X github.com/kubev2v/migration-planner/pkg/version.versionFromGit=${SOURCE_GIT_TAG} \
+-X github.com/kubev2v/migration-planner/pkg/version.commitFromGit=${SOURCE_GIT_COMMIT} \
+-X github.com/kubev2v/migration-planner/pkg/version.gitTreeState=${SOURCE_GIT_TREE_STATE} \
+-X github.com/kubev2v/migration-planner/pkg/version.buildDate=${BIN_TIMESTAMP} \
+-X github.com/kubev2v/migration-planner/internal/agent.version=${SOURCE_GIT_TAG}"


### PR DESCRIPTION
This change is done in order to have the version updated also
in builds triggered by konflux (tekton file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now dynamically collects version metadata at build time and embeds richer version info (commit, tag, tree state, build timestamp, semantic version parts) into binaries and container images.
  * Simplified build invocation: no static VERSION build-arg; linker flags are applied dynamically during the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->