### PR TITLE
ECOPROJECT-3167 | build: Allow setting version vals before script

### DIFF
--- a/.tekton/migration-planner-api-pull-request.yaml
+++ b/.tekton/migration-planner-api-pull-request.yaml
@@ -234,6 +234,8 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - SOURCE_GIT_COMMIT=$(tasks.clone-repository.results.commit)
+        - SOURCE_GIT_TAG={{target_branch}}-pull-request
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/.tekton/migration-planner-api-push.yaml
+++ b/.tekton/migration-planner-api-push.yaml
@@ -231,6 +231,8 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - SOURCE_GIT_COMMIT=$(tasks.clone-repository.results.commit)
+        - SOURCE_GIT_TAG={{target_branch}}-dev
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/.tekton/migration-planner-api-tag.yaml
+++ b/.tekton/migration-planner-api-tag.yaml
@@ -231,6 +231,8 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - SOURCE_GIT_COMMIT=$(tasks.clone-repository.results.commit)
+        - SOURCE_GIT_TAG={{git_tag}}
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -2,6 +2,8 @@
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS builder
 
 ARG GCFLAGS=""
+ARG SOURCE_GIT_COMMIT=""
+ARG SOURCE_GIT_TAG=""
 
 WORKDIR /app
 
@@ -12,6 +14,13 @@ COPY . .
 
 USER 0
 RUN source hack/version.sh && \
+    echo "=== VERSION BUILD INFO ===" && \
+    echo "SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT}" && \
+    echo "SOURCE_GIT_COMMIT_SHORT=${SOURCE_GIT_COMMIT_SHORT}" && \
+    echo "SOURCE_GIT_TAG=${SOURCE_GIT_TAG}" && \
+    echo "MAJOR=${MAJOR} MINOR=${MINOR} PATCH=${PATCH}" && \
+    echo "GO_LDFLAGS=${GO_LDFLAGS}" && \
+    echo "=== END VERSION BUILD INFO ===" && \
     CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=false ${GCFLAGS:+-gcflags "$GCFLAGS"} \
     -ldflags "${GO_LDFLAGS}" \
     -o /planner-api cmd/planner-api/*.go

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -7,14 +7,26 @@
 set -e
 
 # Get git commit
-export SOURCE_GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null || echo "")
-export SOURCE_GIT_COMMIT_SHORT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "")
+# If SOURCE_GIT_COMMIT is already set (from build args), use it
+if [ -z "$SOURCE_GIT_COMMIT" ]; then
+    export SOURCE_GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null || echo "")
+fi
+
+# Calculate short commit from full commit or from git
+if [ -n "$SOURCE_GIT_COMMIT" ]; then
+    export SOURCE_GIT_COMMIT_SHORT="${SOURCE_GIT_COMMIT:0:7}"
+else
+    export SOURCE_GIT_COMMIT_SHORT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "")
+fi
 
 # Get git tag
-export SOURCE_GIT_TAG=$(git describe --always --tags --abbrev=7 \
-    --match '[0-9]*.[0-9]*.[0-9]*' \
-    --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null \
-    || echo "v0.0.0-unknown-${SOURCE_GIT_COMMIT_SHORT}")
+# If SOURCE_GIT_TAG is already set (from build args), use it
+if [ -z "$SOURCE_GIT_TAG" ]; then
+    export SOURCE_GIT_TAG=$(git describe --always --tags --abbrev=7 \
+        --match '[0-9]*.[0-9]*.[0-9]*' \
+        --match 'v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null \
+        || echo "v0.0.0-${SOURCE_GIT_COMMIT_SHORT}")
+fi
 
 # Get git tree state
 if [ ! -d ".git/" ] || git diff --quiet 2>/dev/null; then


### PR DESCRIPTION
This is done in order to allow using the variables provided by konflux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build accepts explicit git commit and tag values while falling back to git-derived values when not provided.
  * Build emits a structured build-info block during the build that prints version, short commit, tag, semantic parts, and linker flags.
  * Build adds an extra step to fetch and include policy files during the build, before producing the final runtime image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->