### PR TITLE
ECOPROJECT-3292 | fix: Process RVTools parsing outside transaction co…

### DIFF
--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -100,14 +100,6 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 		WithUUIDPtr("source_id", createForm.SourceID).
 		Build()
 
-	ctx, err := as.store.NewTransactionContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_, _ = store.Rollback(ctx)
-	}()
-
 	assessment := createForm.ToModel()
 	tracer.Step("convert_form_to_model").WithUUID("assessment_id", assessment.ID).Log()
 
@@ -144,6 +136,14 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 		inventory = *rvtoolInventory
 		tracer.Step("parsed_rvtools_inventory").Log()
 	}
+
+	ctx, err := as.store.NewTransactionContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_, _ = store.Rollback(ctx)
+	}()
 
 	createdAssessment, err := as.store.Assessment().Create(ctx, assessment, inventory)
 	if err != nil {


### PR DESCRIPTION
…ntext

Move RVTools and Inventory processing before transaction context creation to avoid holding database connections during file parsing operations. Refactor switch statement to if-else for improved code flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of the assessment creation workflow to improve reliability of create operations; transaction handling adjusted to ensure proper rollback on failure paths. No changes to public APIs or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->