### PR TITLE
ECOPROJECT-3162 | ci: trigger sync branch workflow on every push to main

### DIFF
--- a/.github/workflows/sync-main-to-branches.yml
+++ b/.github/workflows/sync-main-to-branches.yml
@@ -1,15 +1,12 @@
 name: Sync Main to Release Branches
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
 jobs:
   sync_to_side_branches:
-    # Only run this job if the pull request was merged
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized branch synchronization workflow to trigger directly on pushes to the main branch, streamlining the synchronization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->