### PR TITLE
ECOPROJECT-3419 | Creating an assessment with the same name returns a 500 error

### DIFF
--- a/internal/handlers/v1alpha1/assessment.go
+++ b/internal/handlers/v1alpha1/assessment.go
@@ -98,6 +98,9 @@ func (h *ServiceHandler) CreateAssessment(ctx context.Context, request server.Cr
 		case *service.ErrSourceHasNoInventory:
 			logger.Error(err).WithString("step", "inventory_check").Log()
 			return server.CreateAssessment400JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
+		case *service.ErrDuplicateKey:
+			logger.Error(err).WithString("step", "validate_input").Log()
+			return server.CreateAssessment400JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
 		case *service.ErrFileCorrupted:
 			logger.Error(err).WithString("step", "file_validation").Log()
 			return server.CreateAssessment400JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil

--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -148,6 +148,11 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 	createdAssessment, err := as.store.Assessment().Create(ctx, assessment, inventory)
 	if err != nil {
 		_, _ = store.Rollback(ctx)
+
+		if errors.Is(err, store.ErrDuplicateKey) {
+			return nil, NewErrAssessmentDuplicateName(assessment.Name)
+		}
+
 		return nil, fmt.Errorf("failed to create assessment: %w", err)
 	}
 

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -69,3 +69,15 @@ type ErrSourceHasNoInventory struct {
 func NewErrSourceHasNoInventory(sourceID uuid.UUID) *ErrSourceHasNoInventory {
 	return &ErrSourceHasNoInventory{fmt.Errorf("source has no inventory: %s", sourceID)}
 }
+
+type ErrDuplicateKey struct {
+	error
+}
+
+func NewErrDuplicateKey(resourceType, key string) *ErrDuplicateKey {
+	return &ErrDuplicateKey{fmt.Errorf("%s with %s already exists", resourceType, key)}
+}
+
+func NewErrAssessmentDuplicateName(name string) *ErrDuplicateKey {
+	return NewErrDuplicateKey("assessment", fmt.Sprintf("name '%s'", name))
+}

--- a/internal/store/assessment.go
+++ b/internal/store/assessment.go
@@ -69,6 +69,9 @@ func (a *AssessmentStore) Create(ctx context.Context, assessment model.Assessmen
 	// Create the assessment first
 	result := a.getDB(ctx).Clauses(clause.Returning{}).Create(&assessment)
 	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrDuplicatedKey) {
+			return nil, ErrDuplicateKey
+		}
 		return nil, result.Error
 	}
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -1,0 +1,8 @@
+package store
+
+import "errors"
+
+var (
+	ErrRecordNotFound = errors.New("record not found")
+	ErrDuplicateKey   = errors.New("already exists")
+)

--- a/internal/store/source.go
+++ b/internal/store/source.go
@@ -11,10 +11,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-var (
-	ErrRecordNotFound error = errors.New("record not found")
-)
-
 type Source interface {
 	List(ctx context.Context, filter *SourceQueryFilter) (model.SourceList, error)
 	Create(ctx context.Context, source model.Source) (*model.Source, error)


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

We should fix the tests in [this PR](https://github.com/kubev2v/migration-planner/pull/704): 
Expect 400 in case of creating an assessment with the same name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creating an assessment with a duplicate name now returns a clear 400 validation error instead of a generic failure.
  * Duplicate-key conditions are detected and reported with a specific error instead of a generic server error.

* **Refactor**
  * Streamlined error mapping so duplicate-records are consistently translated into user-facing validation errors.

* **Tests**
  * Added a test to verify duplicate-assessment name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->