### PR TITLE
ECOPROJECT-3432 | fix: Creating an assessment with invalid Rvtools file returns a 500 error

### DIFF
--- a/internal/handlers/v1alpha1/assessment.go
+++ b/internal/handlers/v1alpha1/assessment.go
@@ -98,9 +98,12 @@ func (h *ServiceHandler) CreateAssessment(ctx context.Context, request server.Cr
 		case *service.ErrSourceHasNoInventory:
 			logger.Error(err).WithString("step", "inventory_check").Log()
 			return server.CreateAssessment400JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
+		case *service.ErrFileCorrupted:
+			logger.Error(err).WithString("step", "file_validation").Log()
+			return server.CreateAssessment400JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
 		default:
 			logger.Error(err).Log()
-			return server.CreateAssessment500JSONResponse{Message: fmt.Sprintf("failed to create assessment: %v", err), RequestId: requestid.FromContextPtr(ctx)}, nil
+			return server.CreateAssessment500JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
 		}
 	}
 

--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -131,7 +131,7 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 		tracer.Step("read_rvtools_file").WithInt("file_size", len(content)).Log()
 		rvtoolInventory, err := rvtools.ParseRVTools(ctx, content, as.opaValidator)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing RVTools file: %v", err)
+			return nil, NewErrRVToolsFileCorrupted(fmt.Sprintf("error parsing RVTools file: %v", err))
 		}
 		inventory = *rvtoolInventory
 		tracer.Step("parsed_rvtools_inventory").Log()

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -31,12 +30,16 @@ func NewErrAgentNotFound(id uuid.UUID) *ErrResourceNotFound {
 	return NewErrResourceNotFound(id, "agent")
 }
 
-type ErrExcelFileNotValid struct {
+type ErrFileCorrupted struct {
 	error
 }
 
-func NewErrExcelFileNotValid() *ErrExcelFileNotValid {
-	return &ErrExcelFileNotValid{errors.New("the uploaded file is not a valid Excel (.xlsx) file. Please upload an RVTools export in Excel format.")}
+func NewErrFileCorrupted(message string) *ErrFileCorrupted {
+	return &ErrFileCorrupted{fmt.Errorf("bad request: %s", message)}
+}
+
+func NewErrRVToolsFileCorrupted(message string) *ErrFileCorrupted {
+	return NewErrFileCorrupted(fmt.Sprintf("The provided RVTools file is corrupted: %s", message))
 }
 
 type ErrAgentUpdateForbidden struct {


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

We should fix the tests in [this PR](https://github.com/kubev2v/migration-planner/pull/704): 
Expect 400 in case of Creating an assessment with invalid Rvtools:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file validation and parsing error handling to return clearer, client-friendly messages for corrupted or unparsable files.

* **Removals**
  * Removed the RVTools file upload pathway from the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->