### PR TITLE
ECOPROJECT-3440 | feat: HTTP servers should be gracefully shut down in case of an error

### DIFF
--- a/internal/api_server/agentserver/server.go
+++ b/internal/api_server/agentserver/server.go
@@ -98,6 +98,7 @@ func (s *AgentServer) Run(ctx context.Context) error {
 
 		srv.SetKeepAlivesEnabled(false)
 		_ = srv.Shutdown(ctxTimeout)
+		zap.S().Named("agent_server").Info("agent server terminated")
 	}()
 
 	zap.S().Named("agent_server").Infof("Listening on %s...", s.listener.Addr().String())

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -96,6 +96,7 @@ func (s *ImageServer) Run(ctx context.Context) error {
 
 		srv.SetKeepAlivesEnabled(false)
 		_ = srv.Shutdown(ctxTimeout)
+		zap.S().Named("image_server").Info("image server terminated")
 	}()
 
 	zap.S().Named("image_server").Infof("Listening on %s...", s.listener.Addr().String())

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -121,6 +121,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		srv.SetKeepAlivesEnabled(false)
 		_ = srv.Shutdown(ctxTimeout)
+		zap.S().Named("api_server").Info("api server terminated")
 	}()
 
 	zap.S().Named("api_server").Infof("Listening on %s...", s.listener.Addr().String())


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized server startup/shutdown for consistent, coordinated lifecycle handling and graceful stop sequencing.
  * Startup errors are now logged per-server without forcing process termination, improving resilience.
  * Each server emits clear termination messages and a final "Service stopped gracefully" info log for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->