### PR TITLE
ECOPROJECT-3410 | feat: [BE] Add VMs count per Network segment

### DIFF
--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -163,7 +163,7 @@ func (c *Collector) run(ctx context.Context) {
 
 	infraData := service.InfrastructureData{
 		Datastores:            getDatastores(hosts, collector),
-		Networks:              getNetworks(collector, countVmsByNetwork(*vms)),
+		Networks:              getNetworks(collector, CountVmsByNetwork(*vms)),
 		HostPowerStates:       getHostPowerStates(*hosts),
 		Hosts:                 getHosts(hosts),
 		HostsPerCluster:       getHostsPerCluster(*clusters),
@@ -429,7 +429,7 @@ func getSecret(creds config.Credentials) *core.Secret {
 	}
 }
 
-func countVmsByNetwork(vms []vspheremodel.VM) map[string]int {
+func CountVmsByNetwork(vms []vspheremodel.VM) map[string]int {
 	vmsPerNetwork := make(map[string]int)
 	for _, vm := range vms {
 		for _, network := range vm.Networks {

--- a/internal/rvtools/parser.go
+++ b/internal/rvtools/parser.go
@@ -110,7 +110,7 @@ func ParseRVTools(ctx context.Context, rvtoolsContent []byte, opaValidator *opa.
 	dvswitchRows := readSheet(excelFile, sheets, "dvSwitch")
 	dvportRows := readSheet(excelFile, sheets, "dvPort")
 
-	networks := ExtractNetworks(dvswitchRows, dvportRows)
+	networks := ExtractNetworks(dvswitchRows, dvportRows, vms)
 
 	zap.S().Named("rvtools").Infof("Create Basic Inventory")
 	infraData := service.InfrastructureData{
@@ -286,7 +286,7 @@ func ExtractVmsPerCluster(rows [][]string) []int {
 	return calculateVMsPerCluster(clusterToVMs)
 }
 
-func ExtractNetworks(dvswitchRows, dvportRows [][]string) []api.Network {
+func ExtractNetworks(dvswitchRows, dvportRows [][]string, vms []vsphere.VM) []api.Network {
 	networks := []api.Network{}
 
 	if len(dvswitchRows) == 0 && len(dvportRows) == 0 {
@@ -295,7 +295,7 @@ func ExtractNetworks(dvswitchRows, dvportRows [][]string) []api.Network {
 	}
 
 	tempInventory := &api.Inventory{Infra: api.Infra{}}
-	if err := processNetworkInfo(dvswitchRows, dvportRows, tempInventory); err == nil {
+	if err := processNetworkInfo(dvswitchRows, dvportRows, tempInventory, vms); err == nil {
 		networks = tempInventory.Infra.Networks
 	}
 


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network entries now include VM counts (VmsCount) so each network shows how many VMs are attached.
* **Chores**
  * Network extraction interfaces updated to accept VM data; callers adjusted accordingly (integration may require client updates).
* **Tests**
  * Network parsing tests updated to provide VM data and validate VM counts and network association behavior.
* **Bug Fix / Behavior**
  * Parser now returns an empty networks list with a clear log when no network data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->