### PR TITLE
ECOPROJECT-3478 | feat: Add spicedb to github workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ test: $(GINKGO)
 	@echo "✅ All Unit tests passed successfully."
 
 # Full unit test cycle: build, prepare DB, run tests, and clean up
-unit-test: build kill-db deploy-db migrate test kill-db
+unit-test: build deploy-db deploy-spicedb migrate test kill-spicedb kill-db
 
 # Run integration tests using ginkgo
 integration-test: $(GINKGO) build

--- a/deploy/deploy.mk
+++ b/deploy/deploy.mk
@@ -8,11 +8,57 @@ deploy-db:
 	test/scripts/wait_for_postgres.sh podman
 	podman exec -it planner-db psql -c 'ALTER ROLE admin WITH SUPERUSER'
 	podman exec -it planner-db createdb admin || true
+	podman exec -it planner-db createdb spicedb || true
 	@echo "✅ DB was deployed successfully on podman."
+
+deploy-spicedb:
+	@echo "Deploy spicedb on podman..."
+	@echo "Running SpiceDB migration..."
+	podman run --rm \
+		--network podman_planner-network \
+		--name spicedb-migrate \
+		-e SPICEDB_DATASTORE_ENGINE=postgres \
+		-e SPICEDB_DATASTORE_CONN_URI="postgres://admin:adminpass@planner-db:5432/spicedb?sslmode=disable" \
+		docker.io/authzed/spicedb \
+		migrate head
+	@echo "Starting SpiceDB service..."
+	podman run -d \
+		--network podman_planner-network \
+		--name spicedb-service \
+		-p 50051:50051 \
+		-p 7070:9090 \
+		--restart always \
+		docker.io/authzed/spicedb \
+		serve \
+		--grpc-preshared-key foobar \
+		--datastore-engine postgres \
+		--datastore-conn-uri "postgres://admin:adminpass@planner-db:5432/spicedb?sslmode=disable" \
+		--telemetry-endpoint=""
+	@echo "Writing schema to SpiceDB..."
+	@count=0; \
+	until podman run --rm \
+		--network podman_planner-network \
+		-v $(CURDIR)/deploy/spicedb/schema.zed:/schema.zed:ro \
+		docker.io/authzed/zed:latest \
+		schema write --endpoint=spicedb-service:50051 --insecure=true --token=foobar /schema.zed 2>/dev/null || [ $$count -eq 30 ]; do \
+		count=$$((count+1)); \
+		if [ $$count -ge 30 ]; then \
+			echo "spicedb schema write time out"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+	@echo "SpiceDB deployed successfully on podman."
+
+kill-spicedb:
+	@echo "Remove spicedb..."
+	podman rm -f spicedb-service || true
+	podman rm -f spicedb-migrate || true
+	@echo "SpiceDB removed successfully from podman."
 
 kill-db:
 	@echo "🗑️ Remove DB instance from podman..."
 	podman-compose -f $(COMPOSE_FILE) down planner-db
 	@echo "✅ DB instance was removed successfully from podman."
 
-.PHONY: deploy-db kill-db
+.PHONY: deploy-db kill-db deploy-spicedb kill-spicedb

--- a/deploy/spicedb/schema.zed
+++ b/deploy/spicedb/schema.zed
@@ -1,0 +1,95 @@
+/**
+ * User Definition
+ * 
+ * Represents any authenticated user in the system.
+ * This is the base type for all user-related relationships.
+ */
+definition user {}
+
+/**
+ * Platform Definition
+ * 
+ * Represents the top-level tenant in the multi-tenant architecture.
+ * Platforms have administrative controls that cascade down to assessments.
+ * 
+ * Relations:
+ * - admin: Users with full administrative privileges across the platform
+ * - viewer: Users with read-only access across all platform resources
+ * - editor: Users with edit access across all platform resources
+ * 
+ * Permissions:
+ * - super_admin: Full control over all platform resources
+ * - view: Read access to platform resources
+ * - edit: Modify access to platform resources
+ */
+definition platform {
+	relation admin: user
+	relation viewer: user
+	relation editor: user
+	permission super_admin = admin
+	permission view = viewer
+	permission edit = editor
+}
+
+/**
+ * Organization Definition
+ * 
+ * Represents a group or team of users within the platform.
+ * Organizations provide a way to group users and share resources among them.
+ * 
+ * Relations:
+ * - member: Users who belong to this organization
+ * 
+ * Permissions:
+ * - org_member: Derived permission for organization membership
+ */
+definition org {
+	relation member: user
+	permission org_member = member
+}
+
+/**
+ * Assessment Definition
+ * 
+ * Represents a migration assessment resource - the core entity in the system.
+ * Assessments are scoped to both a platform and an organization, with flexible
+ * permission controls based on ownership, organization membership, and platform roles.
+ * 
+ * Relations:
+ * - parent: The platform this assessment belongs to
+ * - org: The organization this assessment is associated with
+ * - owner: The user who created or owns this assessment
+ * - editor: Users explicitly granted edit access to this assessment
+ * - viewer: Users explicitly granted read-only access to this assessment
+ * 
+ * Permissions:
+ * - read: Can view the assessment. Granted to:
+ * * Users explicitly added as readers
+ * * All members of the associated organization
+ * * Platform super admins, viewers, and editors
+ * 
+ * - edit: Can modify the assessment. Granted to:
+ * * The assessment owner
+ * * All members of the associated organization
+ * * Platform super admins and editors
+ * 
+ * - share: Can grant access to other users. Granted to:
+ * * The assessment owner
+ * * All members of the associated organization
+ * * Platform super admins
+ * 
+ * - delete: Can delete the assessment. Granted to:
+ * * The assessment owner
+ * * Platform super admins
+ */
+definition assessment {
+	relation parent: platform
+	relation org: org
+	relation owner: user
+	relation editor: user
+	relation viewer: user
+	permission read = owner + viewer + editor + org->org_member + parent->super_admin + parent->view + parent->edit
+	permission edit = owner + org->org_member + parent->super_admin + parent->edit + editor
+	permission share = owner + org->org_member + parent->super_admin
+	permission delete = owner + parent->super_admin
+}


### PR DESCRIPTION
This PR adds spicedb to github workflow to run unit tests for "share assessment" feature.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-tenant access-control model for assessments, organizations, and platform roles with explicit permission inheritance and propagation.

* **Chores**
  * Test and deployment orchestration updated to deploy and initialize the authorization service before migrations and to stop/clean it up after unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->