### PR TITLE
ECOPROJECT-3504 | fix: make assessments private

### DIFF
--- a/internal/handlers/v1alpha1/assessment.go
+++ b/internal/handlers/v1alpha1/assessment.go
@@ -25,7 +25,7 @@ func (h *ServiceHandler) ListAssessments(ctx context.Context, request server.Lis
 	user := auth.MustHaveUser(ctx)
 	logger.Step("extract_user").WithString("org_id", user.Organization).WithString("username", user.Username).Log()
 
-	filter := service.NewAssessmentFilter(user.Organization)
+	filter := service.NewAssessmentFilter(user.Username, user.Organization)
 
 	assessments, err := h.assessmentSrv.ListAssessments(ctx, filter)
 	if err != nil {
@@ -143,9 +143,9 @@ func (h *ServiceHandler) GetAssessment(ctx context.Context, request server.GetAs
 	logger.Step("assessment_retrieved").WithString("assessment_name", assessment.Name).Log()
 
 	user := auth.MustHaveUser(ctx)
-	if user.Organization != assessment.OrgID {
-		message := fmt.Sprintf("forbidden to access assessment %s by user with org_id %s", assessmentID, user.Organization)
-		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("user_org", user.Organization).WithString("assessment_org", assessment.OrgID).Log()
+	if user.Username != assessment.Username || user.Organization != assessment.OrgID {
+		message := fmt.Sprintf("forbidden to access assessment %s by user %s", assessmentID, user.Username)
+		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("user", user.Username).WithString("assessment_username", assessment.Username).Log()
 		return server.GetAssessment403JSONResponse{Message: message, RequestId: requestid.FromContextPtr(ctx)}, nil
 	}
 
@@ -188,9 +188,9 @@ func (h *ServiceHandler) UpdateAssessment(ctx context.Context, request server.Up
 
 	logger.Step("assessment_retrieved_for_update").WithString("current_name", assessment.Name).Log()
 
-	if user.Organization != assessment.OrgID {
-		message := fmt.Sprintf("forbidden to update assessment %s by user with org_id %s", assessmentID, user.Organization)
-		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("user_org", user.Organization).WithString("assessment_org", assessment.OrgID).Log()
+	if user.Username != assessment.Username || user.Organization != assessment.OrgID {
+		message := fmt.Sprintf("forbidden to update assessment %s by user %s", assessmentID, user.Username)
+		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("username", user.Username).WithString("assessment_username", assessment.Username).Log()
 		return server.UpdateAssessment403JSONResponse{Message: message, RequestId: requestid.FromContextPtr(ctx)}, nil
 	}
 
@@ -246,9 +246,9 @@ func (h *ServiceHandler) DeleteAssessment(ctx context.Context, request server.De
 
 	logger.Step("assessment_retrieved_for_delete").WithString("assessment_name", assessment.Name).Log()
 
-	if user.Organization != assessment.OrgID {
-		message := fmt.Sprintf("forbidden to delete assessment %s by user with org_id %s", assessmentID, user.Organization)
-		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("user_org", user.Organization).WithString("assessment_org", assessment.OrgID).Log()
+	if user.Username != assessment.Username || user.Organization != assessment.OrgID {
+		message := fmt.Sprintf("forbidden to delete assessment %s by user with %s", assessmentID, user.Username)
+		logger.Error(fmt.Errorf("authorization failed: %s", message)).WithUUID("assessment_id", assessmentID).WithString("username", user.Username).WithString("assessment_username", assessment.Username).Log()
 		return server.DeleteAssessment403JSONResponse{Message: message, RequestId: requestid.FromContextPtr(ctx)}, nil
 	}
 

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -37,7 +37,7 @@ func validateSourceData(data interface{}) error {
 func (s *ServiceHandler) ListSources(ctx context.Context, request apiServer.ListSourcesRequestObject) (apiServer.ListSourcesResponseObject, error) {
 	user := auth.MustHaveUser(ctx)
 
-	filter := service.NewSourceFilter(service.WithOrgID(user.Organization))
+	filter := service.NewSourceFilter(service.WithUsername(user.Username), service.WithOrgID(user.Organization))
 
 	sources, err := s.sourceSrv.ListSources(ctx, filter)
 	if err != nil {
@@ -94,7 +94,7 @@ func (s *ServiceHandler) DeleteSource(ctx context.Context, request apiServer.Del
 	}
 
 	user := auth.MustHaveUser(ctx)
-	if user.Organization != source.OrgID {
+	if user.Username != source.Username || user.Organization != source.OrgID {
 		message := fmt.Sprintf("forbidden to delete source %s by user with org_id %s", request.Id, user.Organization)
 		return server.DeleteSource403JSONResponse{Message: message}, nil
 	}
@@ -119,8 +119,8 @@ func (s *ServiceHandler) GetSource(ctx context.Context, request apiServer.GetSou
 	}
 
 	user := auth.MustHaveUser(ctx)
-	if user.Organization != source.OrgID {
-		message := fmt.Sprintf("forbidden to access source %s by user with org_id %s", request.Id, user.Organization)
+	if user.Username != source.Username || user.Organization != source.OrgID {
+		message := fmt.Sprintf("forbidden to access source %s by user %s", request.Id, user.Username)
 		return server.GetSource403JSONResponse{Message: message}, nil
 	}
 
@@ -148,8 +148,8 @@ func (s *ServiceHandler) UpdateSource(ctx context.Context, request apiServer.Upd
 	}
 
 	user := auth.MustHaveUser(ctx)
-	if user.Organization != source.OrgID {
-		message := fmt.Sprintf("forbidden to update source %s by user with org_id %s", request.Id, user.Organization)
+	if user.Username != source.Username || user.Organization != source.OrgID {
+		message := fmt.Sprintf("forbidden to update source %s by user %s", request.Id, user.Username)
 		return server.UpdateSource403JSONResponse{Message: message}, nil
 	}
 
@@ -186,8 +186,8 @@ func (s *ServiceHandler) UpdateInventory(ctx context.Context, request apiServer.
 	}
 
 	user := auth.MustHaveUser(ctx)
-	if user.Organization != source.OrgID {
-		message := fmt.Sprintf("forbidden to update inventory for source %s by user with org_id %s", request.Id, user.Organization)
+	if user.Organization != source.OrgID || user.Username != source.Username {
+		message := fmt.Sprintf("forbidden to update inventory for source %s by user %s with org_id %s", request.Id, user.Username, user.Organization)
 		return server.UpdateInventory403JSONResponse{Message: message}, nil
 	}
 

--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -40,6 +40,7 @@ func NewAssessmentService(store store.Store, opaValidator *opa.Validator) *Asses
 func (as *AssessmentService) ListAssessments(ctx context.Context, filter *AssessmentFilter) ([]model.Assessment, error) {
 	logger := as.logger.WithContext(ctx)
 	tracer := logger.Operation("list_assessments").
+		WithString("username", filter.Username).
 		WithString("org_id", filter.OrgID).
 		WithString("source", filter.Source).
 		WithString("source_id", filter.SourceID).
@@ -48,7 +49,7 @@ func (as *AssessmentService) ListAssessments(ctx context.Context, filter *Assess
 		WithInt("offset", filter.Offset).
 		Build()
 
-	storeFilter := store.NewAssessmentQueryFilter().WithOrgID(filter.OrgID)
+	storeFilter := store.NewAssessmentQueryFilter().WithUsername(filter.Username).WithOrgID(filter.OrgID)
 
 	if filter.Source != "" {
 		storeFilter = storeFilter.WithSourceType(filter.Source)
@@ -112,7 +113,7 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 		if err != nil {
 			return nil, err
 		}
-		if source.OrgID != assessment.OrgID {
+		if source.OrgID != assessment.OrgID || source.Username != assessment.Username {
 			return nil, NewErrAssessmentCreationForbidden(source.ID)
 		}
 		if source.Inventory == nil {
@@ -265,6 +266,7 @@ func (as *AssessmentService) DeleteAssessment(ctx context.Context, id uuid.UUID)
 // AssessmentFilter represents filtering options for listing assessments
 type AssessmentFilter struct {
 	OrgID    string
+	Username string
 	Source   string
 	SourceID string
 	NameLike string
@@ -272,9 +274,10 @@ type AssessmentFilter struct {
 	Offset   int
 }
 
-func NewAssessmentFilter(orgID string) *AssessmentFilter {
+func NewAssessmentFilter(username, orgID string) *AssessmentFilter {
 	return &AssessmentFilter{
-		OrgID: orgID,
+		Username: username,
+		OrgID:    orgID,
 	}
 }
 

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -48,7 +48,7 @@ func (s *SourceService) GetSourceDownloadURL(ctx context.Context, id uuid.UUID) 
 }
 
 func (s *SourceService) ListSources(ctx context.Context, filter *SourceFilter) ([]model.Source, error) {
-	storeFilter := store.NewSourceQueryFilter().ByOrgID(filter.OrgID)
+	storeFilter := store.NewSourceQueryFilter().ByUsername(filter.Username).ByOrgID(filter.OrgID)
 
 	userResult, err := s.store.Source().List(ctx, storeFilter)
 	if err != nil {
@@ -220,8 +220,9 @@ func (s *SourceService) UpdateInventory(ctx context.Context, form mappers.Invent
 type SourceFilterFunc func(s *SourceFilter)
 
 type SourceFilter struct {
-	OrgID string
-	ID    uuid.UUID
+	Username string
+	OrgID    string
+	ID       uuid.UUID
 }
 
 func NewSourceFilter(filters ...SourceFilterFunc) *SourceFilter {
@@ -235,6 +236,12 @@ func NewSourceFilter(filters ...SourceFilterFunc) *SourceFilter {
 func (s *SourceFilter) WithOption(o SourceFilterFunc) *SourceFilter {
 	o(s)
 	return s
+}
+
+func WithUsername(username string) SourceFilterFunc {
+	return func(s *SourceFilter) {
+		s.Username = username
+	}
 }
 
 func WithSourceID(id uuid.UUID) SourceFilterFunc {

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -64,7 +64,7 @@ var _ = Describe("source handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			srv := service.NewSourceService(s, nil)
-			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithOrgID("batman")))
+			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithUsername("batman"), service.WithOrgID("batman")))
 			Expect(err).To(BeNil())
 			Expect(resp).To(HaveLen(1))
 		})
@@ -83,7 +83,7 @@ var _ = Describe("source handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			srv := service.NewSourceService(s, nil)
-			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithOrgID("admin")))
+			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithUsername("admin"), service.WithOrgID("admin")))
 			Expect(err).To(BeNil())
 			Expect(resp).To(HaveLen(2))
 
@@ -514,7 +514,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 
 		It("returns 403 if user not authorized", func() {
 			sourceID := uuid.NewString()
-			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "owner-org", "owner-org"))
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "owner-user", "owner-org"))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -608,9 +608,9 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 	})
 
 	Context("source filter", func() {
-		It("filter has orgID set properlly", func() {
-			f := service.NewSourceFilter(service.WithOrgID("test"))
-			Expect(f.OrgID).To(Equal("test"))
+		It("filter has username set properlly", func() {
+			f := service.NewSourceFilter(service.WithUsername("test"))
+			Expect(f.Username).To(Equal("test"))
 		})
 		It("filter has id set properlly", func() {
 			id := uuid.New()

--- a/internal/store/options.go
+++ b/internal/store/options.go
@@ -96,6 +96,14 @@ func NewAssessmentQueryOptions() *AssessmentQueryOptions {
 	return &AssessmentQueryOptions{}
 }
 
+// Filter by username
+func (f *AssessmentQueryFilter) WithUsername(username string) *AssessmentQueryFilter {
+	f.QueryFn = append(f.QueryFn, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("username = ?", username)
+	})
+	return f
+}
+
 // Filter by organization ID
 func (f *AssessmentQueryFilter) WithOrgID(orgID string) *AssessmentQueryFilter {
 	f.QueryFn = append(f.QueryFn, func(tx *gorm.DB) *gorm.DB {

--- a/test/e2e/e2e_multiple_users_test.go
+++ b/test/e2e/e2e_multiple_users_test.go
@@ -54,7 +54,7 @@ var _ = Describe("e2e-multiple-users", func() {
 	})
 
 	Context("Multiple Users", func() {
-		It("Users should see only organizational sources", func() {
+		It("Users should see their sources", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
 			// Verify that each user sees only the sources created by their own organization
@@ -63,7 +63,7 @@ var _ = Describe("e2e-multiple-users", func() {
 					key := fmt.Sprintf("%s|%s", org, user)
 					visibleSources, err := serviceInstances[key].GetSources()
 					Expect(err).To(BeNil())
-					Expect(*visibleSources).To(HaveLen(len(users)))
+					Expect(*visibleSources).To(HaveLen(1))
 					for _, source := range *visibleSources {
 						Expect(strings.Split(source.Name, "-")[0]).To(Equal(org))
 					}


### PR DESCRIPTION
This PR removes sharing assessments inside the user's org and makes the assessments private by default.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Assessments and sources are now scoped to individual user ownership; listings, filters, logs and traces include username alongside organization.
* **Bug Fixes**
  * Authorization checks tightened to require matching username plus organization; error messages updated to reference the requesting user.
* **Tests**
  * Unit and E2E tests updated for per-user ownership, username-based filtering, and adjusted expectations and descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->