### PR TITLE
NO-JIRA | fix: staging-debug-tool: resolve npm peer dependency conflict

### DIFF
--- a/hack/staging-debug-tool/auth_local/Dockerfile.ui-local
+++ b/hack/staging-debug-tool/auth_local/Dockerfile.ui-local
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (using --legacy-peer-deps for PatternFly v6 compatibility)
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .

--- a/hack/staging-debug-tool/auth_none/Dockerfile.ui
+++ b/hack/staging-debug-tool/auth_none/Dockerfile.ui
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (using --legacy-peer-deps for PatternFly v6 compatibility)
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Replace `npm ci` with `npm install --legacy-peer-deps` in UI Dockerfiles
to resolve PatternFly v5/v6 peer dependency conflict with @migration-planner-ui/ioc.

This aligns the Docker build with local development behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm dependency installation configuration in Docker build files. The revised installation method now uses an alternative approach to resolve and install packages more flexibly during builds. This improves handling of dependencies across different environments and system configurations, ensuring consistent and reliable installation behavior without manual intervention, while maintaining reproducible builds for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->