### PR TITLE
ECOPROJECT-3539 | Fix bug when public key is not found

### DIFF
--- a/internal/auth/agent_authenticator.go
+++ b/internal/auth/agent_authenticator.go
@@ -88,17 +88,12 @@ func (aa *AgentAuthenticator) Authenticate(token string) (AgentJWT, error) {
 			return nil, errors.New("kid not found")
 		}
 
-		publicKeys, err := aa.store.PrivateKey().GetPublicKeys(context.Background())
+		publicKey, err := aa.store.PrivateKey().GetPublicKey(context.Background(), kid)
 		if err != nil {
-			return nil, err
-		}
-
-		pb, found := publicKeys[kid]
-		if !found {
 			return nil, fmt.Errorf("public key not found with id: %s", kid)
 		}
 
-		rsaPublicKey := pb.(rsa.PublicKey)
+		rsaPublicKey := publicKey.(rsa.PublicKey)
 		return &rsaPublicKey, nil
 	})
 	if err != nil {

--- a/internal/store/cache_key_test.go
+++ b/internal/store/cache_key_test.go
@@ -1,0 +1,274 @@
+package store_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/internal/store"
+	"github.com/kubev2v/migration-planner/internal/store/model"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+var _ = Describe("cache key store", Ordered, func() {
+	var (
+		s      store.Store
+		gormdb *gorm.DB
+	)
+
+	BeforeAll(func() {
+		cfg, err := config.New()
+		Expect(err).To(BeNil())
+		db, err := store.InitDB(cfg)
+		Expect(err).To(BeNil())
+
+		s = store.NewStore(db)
+		gormdb = db
+		schema.RegisterSerializer("key_serializer", model.KeySerializer{})
+	})
+
+	AfterAll(func() {
+		s.Close()
+	})
+
+	Context("GetPublicKey", func() {
+		It("successfully retrieves a public key from database", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id1", "org_id", string(pemdata)))
+			Expect(tx.Error).To(BeNil())
+
+			pb, err := s.PrivateKey().GetPublicKey(context.TODO(), "id1")
+			Expect(err).To(BeNil())
+			Expect(pb).NotTo(BeNil())
+		})
+
+		It("successfully retrieves a public key from cache on second call", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id2", "org_id", string(pemdata)))
+			Expect(tx.Error).To(BeNil())
+
+			// First call - should fetch from database
+			pb1, err := s.PrivateKey().GetPublicKey(context.TODO(), "id2")
+			Expect(err).To(BeNil())
+			Expect(pb1).NotTo(BeNil())
+
+			// Second call - should fetch from cache
+			pb2, err := s.PrivateKey().GetPublicKey(context.TODO(), "id2")
+			Expect(err).To(BeNil())
+			Expect(pb2).NotTo(BeNil())
+
+			// Both should be the same
+			Expect(pb1).To(Equal(pb2))
+		})
+
+		It("returns error when public key not found", func() {
+			pb, err := s.PrivateKey().GetPublicKey(context.TODO(), "non-existent-id")
+			Expect(err).ToNot(BeNil())
+			Expect(pb).To(BeNil())
+		})
+
+		It("successfully retrieves different public keys by id", func() {
+			privateKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata1 := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey1),
+				},
+			)
+
+			privateKey2, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata2 := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey2),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id3", "org_id_1", string(pemdata1)))
+			Expect(tx.Error).To(BeNil())
+
+			tx = gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id4", "org_id_2", string(pemdata2)))
+			Expect(tx.Error).To(BeNil())
+
+			pb1, err := s.PrivateKey().GetPublicKey(context.TODO(), "id3")
+			Expect(err).To(BeNil())
+			Expect(pb1).NotTo(BeNil())
+
+			pb2, err := s.PrivateKey().GetPublicKey(context.TODO(), "id4")
+			Expect(err).To(BeNil())
+			Expect(pb2).NotTo(BeNil())
+
+			Expect(pb1).ToNot(Equal(pb2))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE from keys;")
+		})
+	})
+
+	Context("Create", func() {
+		It("successfully creates a key through cache layer", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			_, err = s.PrivateKey().Create(context.TODO(), model.Key{
+				ID:         "id5",
+				OrgID:      "org_id",
+				PrivateKey: privateKey,
+			})
+			Expect(err).To(BeNil())
+
+			var count int
+			tx := gormdb.Raw("SELECT COUNT(*) FROM keys;").Scan(&count)
+			Expect(tx.Error).To(BeNil())
+			Expect(count).To(Equal(1))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE from keys;")
+		})
+	})
+
+	Context("Get", func() {
+		It("successfully gets a key by org_id through cache layer", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id6", "org_id", string(pemdata)))
+			Expect(tx.Error).To(BeNil())
+
+			key, err := s.PrivateKey().Get(context.TODO(), "org_id")
+			Expect(err).To(BeNil())
+			Expect(key).NotTo(BeNil())
+			Expect(key.OrgID).To(Equal("org_id"))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE from keys;")
+		})
+	})
+
+	Context("Delete", func() {
+		It("successfully deletes a key and clears cache", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id7", "org_id", string(pemdata)))
+			Expect(tx.Error).To(BeNil())
+
+			// First, populate the cache by getting the public key
+			pb, err := s.PrivateKey().GetPublicKey(context.TODO(), "id7")
+			Expect(err).To(BeNil())
+			Expect(pb).NotTo(BeNil())
+
+			// Delete the key
+			err = s.PrivateKey().Delete(context.TODO(), "org_id")
+			Expect(err).To(BeNil())
+
+			// Verify it's deleted from database
+			count := 1
+			tx = gormdb.Raw("SELECT COUNT(*) FROM keys;").Scan(&count)
+			Expect(tx.Error).To(BeNil())
+			Expect(count).To(Equal(0))
+		})
+
+		It("successfully clears cache on delete even with multiple keys cached", func() {
+			privateKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata1 := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey1),
+				},
+			)
+
+			privateKey2, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).To(BeNil())
+
+			pemdata2 := pem.EncodeToMemory(
+				&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privateKey2),
+				},
+			)
+
+			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id8", "org_id_1", string(pemdata1)))
+			Expect(tx.Error).To(BeNil())
+
+			tx = gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id9", "org_id_2", string(pemdata2)))
+			Expect(tx.Error).To(BeNil())
+
+			// Populate cache with both keys
+			pb1, err := s.PrivateKey().GetPublicKey(context.TODO(), "id8")
+			Expect(err).To(BeNil())
+			Expect(pb1).NotTo(BeNil())
+
+			pb2, err := s.PrivateKey().GetPublicKey(context.TODO(), "id9")
+			Expect(err).To(BeNil())
+			Expect(pb2).NotTo(BeNil())
+
+			// Delete one key - this should clear entire cache
+			err = s.PrivateKey().Delete(context.TODO(), "org_id_1")
+			Expect(err).To(BeNil())
+
+			// Verify first key is deleted
+			count := 0
+			tx = gormdb.Raw("SELECT COUNT(*) FROM keys WHERE org_id = 'org_id_1';").Scan(&count)
+			Expect(tx.Error).To(BeNil())
+			Expect(count).To(Equal(0))
+
+			// Second key should still exist in database
+			tx = gormdb.Raw("SELECT COUNT(*) FROM keys WHERE org_id = 'org_id_2';").Scan(&count)
+			Expect(tx.Error).To(BeNil())
+			Expect(count).To(Equal(1))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE from keys;")
+		})
+	})
+})

--- a/internal/store/key.go
+++ b/internal/store/key.go
@@ -15,7 +15,7 @@ type PrivateKey interface {
 	Create(ctx context.Context, privateKey model.Key) (*model.Key, error)
 	Get(ctx context.Context, orgID string) (*model.Key, error)
 	Delete(ctx context.Context, orgID string) error
-	GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error)
+	GetPublicKey(ctx context.Context, id string) (crypto.PublicKey, error)
 }
 
 type PrivateKeyStore struct {
@@ -56,18 +56,13 @@ func (p *PrivateKeyStore) Delete(ctx context.Context, orgID string) error {
 	return nil
 }
 
-func (p *PrivateKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
-	privateKeys := []model.Key{}
-	if err := p.getDB(ctx).Find(&privateKeys).Error; err != nil {
-		return make(map[string]crypto.PublicKey), err
+func (p *PrivateKeyStore) GetPublicKey(ctx context.Context, kid string) (crypto.PublicKey, error) {
+	key := model.Key{}
+	if err := p.getDB(ctx).Where("id = ?", kid).First(&key).Error; err != nil {
+		return nil, err
 	}
 
-	publicKeys := make(map[string]crypto.PublicKey)
-	for _, pk := range privateKeys {
-		publicKeys[pk.ID] = pk.PrivateKey.PublicKey
-	}
-
-	return publicKeys, nil
+	return key.PrivateKey.PublicKey, nil
 }
 
 func (p *PrivateKeyStore) getDB(ctx context.Context) *gorm.DB {

--- a/internal/store/key_test.go
+++ b/internal/store/key_test.go
@@ -143,7 +143,7 @@ var _ = Describe("key store", Ordered, func() {
 	})
 
 	Context("public keys", func() {
-		It("successfully gets a list of public keys", func() {
+		It("successfully retrieves the public key", func() {
 			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 			Expect(err).To(BeNil())
 
@@ -157,11 +157,10 @@ var _ = Describe("key store", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertPrivateKeyStm, "id", "org_id", string(pemdata)))
 			Expect(tx.Error).To(BeNil())
 
-			pb, err := s.PrivateKey().GetPublicKeys(context.TODO())
+			pb, err := s.PrivateKey().GetPublicKey(context.TODO(), "id")
 			Expect(err).To(BeNil())
 
-			Expect(pb).To(HaveLen(1))
-			Expect(pb["id"]).To(Not(BeNil()))
+			Expect(pb).NotTo(BeNil())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
This PR fixes a bug when the public key is not found in a multiple replica deployment environment (k8s).
The cache store first looks for the public key in its map; if not found, it tries to retrieve it from the actual store.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved authentication performance and reliability by switching from bulk key retrieval to per-key lookup with per-key caching, reducing load and making key operations more robust (including more precise cache invalidation on deletions).

* **Tests**
  * Added and updated tests to validate per-key caching, retrieval, creation, deletion, and error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->