### PR TITLE
ECOPROJECT-3514 | feat: Decouple inventory in db from api

### DIFF
--- a/internal/handlers/v1alpha1/agent.go
+++ b/internal/handlers/v1alpha1/agent.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 
 	v1alpha1 "github.com/kubev2v/migration-planner/api/v1alpha1/agent"
 	agentServer "github.com/kubev2v/migration-planner/internal/api/server/agent"
@@ -29,10 +30,16 @@ func (h *AgentHandler) UpdateSourceInventory(ctx context.Context, request agentS
 		return agentServer.UpdateSourceInventory400JSONResponse{Message: "empty body"}, nil
 	}
 
+	data, err := json.Marshal(request.Body.Inventory)
+	if err != nil {
+		return agentServer.UpdateSourceInventory500JSONResponse{Message: err.Error()}, nil
+	}
+
 	updatedSource, err := h.srv.UpdateSourceInventory(ctx, mappers.InventoryUpdateForm{
 		SourceID:  request.Id,
-		AgentId:   request.Body.AgentId,
-		Inventory: request.Body.Inventory,
+		AgentID:   request.Body.AgentId,
+		Inventory: data,
+		VCenterID: request.Body.Inventory.Vcenter.Id,
 	})
 	if err != nil {
 		switch err.(type) {

--- a/internal/handlers/v1alpha1/agent_test.go
+++ b/internal/handlers/v1alpha1/agent_test.go
@@ -2,6 +2,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -232,7 +233,11 @@ var _ = Describe("agent service", Ordered, func() {
 			// the source should have the agent associated
 			source, err := s.Source().Get(ctx, sourceID)
 			Expect(err).To(BeNil())
-			Expect(source.Inventory.Data.Vcenter.Id).To(Equal("vcenter"))
+
+			var inventory v1alpha1.Inventory
+			err = json.Unmarshal(source.Inventory, &inventory)
+			Expect(err).To(BeNil())
+			Expect(inventory.Vcenter.Id).To(Equal("vcenter"))
 		})
 
 		It("successfully updates the source - two agents", func() {
@@ -273,7 +278,11 @@ var _ = Describe("agent service", Ordered, func() {
 			// the source should have the agent associated
 			source, err := s.Source().Get(ctx, sourceID)
 			Expect(err).To(BeNil())
-			Expect(source.Inventory.Data.Vcenter.Id).To(Equal("vcenter"))
+
+			var inventory v1alpha1.Inventory
+			err = json.Unmarshal(source.Inventory, &inventory)
+			Expect(err).To(BeNil())
+			Expect(inventory.Vcenter.Id).To(Equal("vcenter"))
 
 			// second agent request
 			resp, err = srv.UpdateSourceInventory(ctx, server.UpdateSourceInventoryRequestObject{

--- a/internal/handlers/v1alpha1/assessment.go
+++ b/internal/handlers/v1alpha1/assessment.go
@@ -34,7 +34,13 @@ func (h *ServiceHandler) ListAssessments(ctx context.Context, request server.Lis
 	}
 
 	logger.Success().WithInt("count", len(assessments)).Log()
-	return server.ListAssessments200JSONResponse(mappers.AssessmentListToApi(assessments)), nil
+
+	apiAssessments, err := mappers.AssessmentListToApi(assessments)
+	if err != nil {
+		return server.ListAssessments500JSONResponse{Message: fmt.Sprintf("failed to list assessments: %v", err), RequestId: requestid.FromContextPtr(ctx)}, nil
+	}
+
+	return server.ListAssessments200JSONResponse(apiAssessments), nil
 }
 
 // (POST /api/v1/assessments)
@@ -115,7 +121,13 @@ func (h *ServiceHandler) CreateAssessment(ctx context.Context, request server.Cr
 		WithString("assessment_name", assessment.Name).
 		WithString("source_type", assessment.SourceType).
 		Log()
-	return server.CreateAssessment201JSONResponse(mappers.AssessmentToApi(*assessment)), nil
+
+	apiAssessment, err := mappers.AssessmentToApi(*assessment)
+	if err != nil {
+		return server.CreateAssessment500JSONResponse{Message: err.Error(), RequestId: requestid.FromContextPtr(ctx)}, nil
+	}
+
+	return server.CreateAssessment201JSONResponse(apiAssessment), nil
 }
 
 // (GET /api/v1/assessments/{id})
@@ -151,7 +163,13 @@ func (h *ServiceHandler) GetAssessment(ctx context.Context, request server.GetAs
 
 	logger.Step("authorization_check_passed").Log()
 	logger.Success().WithString("source_type", assessment.SourceType).Log()
-	return server.GetAssessment200JSONResponse(mappers.AssessmentToApi(*assessment)), nil
+
+	apiAssessment, err := mappers.AssessmentToApi(*assessment)
+	if err != nil {
+		return server.GetAssessment500JSONResponse{Message: fmt.Sprintf("failed to get assessment: %v", err), RequestId: requestid.FromContextPtr(ctx)}, nil
+	}
+
+	return server.GetAssessment200JSONResponse(apiAssessment), nil
 }
 
 // (PUT /api/v1/assessments/{id})
@@ -215,7 +233,13 @@ func (h *ServiceHandler) UpdateAssessment(ctx context.Context, request server.Up
 		WithString("updated_name", updatedAssessment.Name).
 		WithString("source_type", updatedAssessment.SourceType).
 		Log()
-	return server.UpdateAssessment200JSONResponse(mappers.AssessmentToApi(*updatedAssessment)), nil
+
+	apiAssessment, err := mappers.AssessmentToApi(*updatedAssessment)
+	if err != nil {
+		return server.UpdateAssessment500JSONResponse{Message: fmt.Sprintf("failed to update assessment: %v", err), RequestId: requestid.FromContextPtr(ctx)}, nil
+	}
+
+	return server.UpdateAssessment200JSONResponse(apiAssessment), nil
 }
 
 // (DELETE /api/v1/assessments/{id})

--- a/internal/handlers/v1alpha1/assessment_test.go
+++ b/internal/handlers/v1alpha1/assessment_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	insertAssessmentStm = "INSERT INTO assessments (id, created_at, name, username, org_id, owner_first_name, owner_last_name, source_type, source_id) VALUES ('%s', now(), '%s', '%s', '%s', '%s', '%s', '%s', %s);"
-	insertSnapshotStm   = "INSERT INTO snapshots (created_at, inventory, assessment_id) VALUES (now(), '%s', '%s');"
+	insertSnapshotStm   = "INSERT INTO snapshots (created_at, inventory, assessment_id) VALUES (now(), '%s'::jsonb, '%s');"
 )
 
 var _ = Describe("assessment handler", Ordered, func() {
@@ -58,12 +58,12 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			// Create snapshots for assessments
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID1.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID1.String()))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID2.String()))
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID2.String()))
 			Expect(tx.Error).To(BeNil())
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID3.String()))
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID3.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -203,8 +203,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			// Add inventory to the source
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventory, sourceID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventoryJSON, sourceID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -478,8 +478,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 				tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID.String(), "admin", "admin"))
 				Expect(tx.Error).To(BeNil())
 
-				inventory := `{"vcenter": {"id": "test-vcenter"}}`
-				tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventory, sourceID.String()))
+				inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+				tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventoryJSON, sourceID.String()))
 				Expect(tx.Error).To(BeNil())
 
 				resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
@@ -590,8 +590,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 				tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID.String(), "admin", "admin"))
 				Expect(tx.Error).To(BeNil())
 
-				inventory := `{"vcenter": {"id": "test-vcenter"}}`
-				tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventory, sourceID.String()))
+				inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+				tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventoryJSON, sourceID.String()))
 				Expect(tx.Error).To(BeNil())
 
 				resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
@@ -619,8 +619,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", "admin", "John", "Doe", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -662,8 +662,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batman", "Bruce", "Wayne", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -691,8 +691,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "original-name", "admin", "admin", "John", "Doe", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -766,8 +766,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batman", "Bruce", "Wayne", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -794,8 +794,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "inventory-assessment", "admin", "admin", "John", "Doe", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -830,8 +830,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "rvtools-assessment", "admin", "admin", "John", "Doe", service.SourceTypeRvtools, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -865,8 +865,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			// Add inventory to the source
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventory, sourceID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET inventory = '%s' WHERE id = '%s';", inventoryJSON, sourceID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			// Create assessment with agent sourceType
@@ -876,7 +876,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			// Create initial snapshot
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -916,8 +916,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "test-assessment", "admin", "admin", "John", "Doe", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{
@@ -965,8 +965,8 @@ var _ = Describe("assessment handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertAssessmentStm, assessmentID.String(), "batman-assessment", "batman", "batman", "Bruce", "Wayne", service.SourceTypeInventory, "NULL"))
 			Expect(tx.Error).To(BeNil())
 
-			inventory := `{"vcenter": {"id": "test-vcenter"}}`
-			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventory, assessmentID.String()))
+			inventoryJSON := `{"vcenter": {"id": "test-vcenter"}}`
+			tx = gormdb.Exec(fmt.Sprintf(insertSnapshotStm, inventoryJSON, assessmentID.String()))
 			Expect(tx.Error).To(BeNil())
 
 			user := auth.User{

--- a/internal/handlers/v1alpha1/mappers/inbound.go
+++ b/internal/handlers/v1alpha1/mappers/inbound.go
@@ -2,11 +2,13 @@ package mappers
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
 
 	"github.com/google/uuid"
+
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/service"
@@ -143,7 +145,8 @@ func AssessmentFormToCreateForm(resource v1alpha1.AssessmentForm, user auth.User
 
 	// Set inventory if provided
 	if resource.Inventory != nil {
-		form.Inventory = *resource.Inventory
+		data, _ := json.Marshal(resource.Inventory) // cannot fail. it has been already validated
+		form.Inventory = data
 	}
 
 	return form
@@ -207,7 +210,7 @@ func AssessmentCreateFormFromMultipart(multipartBody *multipart.Reader, user aut
 
 	// For RVTools, we'll set an empty inventory initially
 	// The service layer should process the RVToolsFile to populate inventory
-	form.Inventory = v1alpha1.Inventory{}
+	form.Inventory = []byte{}
 
 	return form, nil
 }

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
@@ -191,10 +192,16 @@ func (s *ServiceHandler) UpdateInventory(ctx context.Context, request apiServer.
 		return server.UpdateInventory403JSONResponse{Message: message}, nil
 	}
 
+	data, err := json.Marshal(request.Body.Inventory)
+	if err != nil {
+		return apiServer.UpdateInventory500JSONResponse{Message: fmt.Sprintf("failed to update source inventory %s: %v", request.Id, err)}, nil
+	}
+
 	updatedSource, err := s.sourceSrv.UpdateInventory(ctx, srvMappers.InventoryUpdateForm{
-		AgentId:   request.Body.AgentId,
+		AgentID:   request.Body.AgentId,
 		SourceID:  request.Id,
-		Inventory: request.Body.Inventory,
+		Inventory: data,
+		VCenterID: request.Body.Inventory.Vcenter.Id,
 	})
 	if err != nil {
 		switch err.(type) {

--- a/internal/rvtools/parser.go
+++ b/internal/rvtools/parser.go
@@ -3,19 +3,21 @@ package rvtools
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 
 	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	"github.com/xuri/excelize/v2"
+	"go.uber.org/zap"
+
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	collector "github.com/kubev2v/migration-planner/internal/agent/collector"
 	"github.com/kubev2v/migration-planner/internal/agent/service"
 	"github.com/kubev2v/migration-planner/internal/opa"
-	"github.com/xuri/excelize/v2"
-	"go.uber.org/zap"
 )
 
-func ParseRVTools(ctx context.Context, rvtoolsContent []byte, opaValidator *opa.Validator) (*service.ClusteredInventoryResponse, error) {
+func ParseRVTools(ctx context.Context, rvtoolsContent []byte, opaValidator *opa.Validator) ([]byte, error) {
 	excelFile, err := excelize.OpenReader(bytes.NewReader(rvtoolsContent))
 	if err != nil {
 		return nil, fmt.Errorf("error opening Excel file: %v", err)
@@ -171,7 +173,12 @@ func ParseRVTools(ctx context.Context, rvtoolsContent []byte, opaValidator *opa.
 			VCenter:   vcenterInventory,
 		}
 
-		return response, nil
+		data, err := json.Marshal(response.VCenter)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		return data, nil
 	}
 
 	// If vInfo doesn't exist, fail with error

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -45,26 +45,26 @@ func (as *AgentService) UpdateSourceInventory(ctx context.Context, updateForm ma
 		return nil, fmt.Errorf("failed to fetch source: %s", err)
 	}
 
-	agent, err := as.store.Agent().Get(ctx, updateForm.AgentId)
+	agent, err := as.store.Agent().Get(ctx, updateForm.AgentID)
 	if err != nil && !errors.Is(err, store.ErrRecordNotFound) {
-		return nil, NewErrAgentNotFound(updateForm.AgentId)
+		return nil, NewErrAgentNotFound(updateForm.AgentID)
 	}
 
 	if agent == nil {
-		return nil, NewErrAgentNotFound(updateForm.AgentId)
+		return nil, NewErrAgentNotFound(updateForm.AgentID)
 	}
 
 	// don't allow updates of sources not associated with this agent
 	if updateForm.SourceID != agent.SourceID {
-		return nil, NewErrAgentUpdateForbidden(updateForm.SourceID, updateForm.AgentId)
+		return nil, NewErrAgentUpdateForbidden(updateForm.SourceID, updateForm.AgentID)
 	}
 
 	// if source has already a vCenter check if it's the same
-	if source.VCenterID != "" && source.VCenterID != updateForm.Inventory.Vcenter.Id {
-		return nil, NewErrInvalidVCenterID(updateForm.SourceID, updateForm.Inventory.Vcenter.Id)
+	if source.VCenterID != "" && source.VCenterID != updateForm.VCenterID {
+		return nil, NewErrInvalidVCenterID(updateForm.SourceID, updateForm.VCenterID)
 	}
 
-	source = mappers.UpdateSourceFromApi(source, updateForm.Inventory)
+	source = mappers.UpdateSourceFromApi(source, updateForm.VCenterID, updateForm.Inventory)
 	updatedSource, err := as.store.Source().Update(ctx, *source)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update source: %s", err)

--- a/internal/service/assessment_test.go
+++ b/internal/service/assessment_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -131,11 +132,11 @@ var _ = Describe("assessment service", Ordered, func() {
 	Context("CreateAssessment", func() {
 		Context("with inventory source", func() {
 			It("successfully creates assessment with inventory", func() {
-				inventory := v1alpha1.Inventory{
+				inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
 					Vcenter: v1alpha1.VCenter{Id: "test-vcenter"},
 					Vms:     v1alpha1.VMs{Total: 10},
 					Infra:   v1alpha1.Infra{TotalHosts: 5},
-				}
+				})
 
 				testAssessmentID := uuid.New()
 				ownerFirstName := "Alice"
@@ -148,7 +149,7 @@ var _ = Describe("assessment service", Ordered, func() {
 					OwnerFirstName: &ownerFirstName,
 					OwnerLastName:  &ownerLastName,
 					Source:         service.SourceTypeInventory,
-					Inventory:      inventory,
+					Inventory:      inventoryJSON,
 				}
 
 				assessment, err := svc.CreateAssessment(context.TODO(), createForm)
@@ -169,11 +170,11 @@ var _ = Describe("assessment service", Ordered, func() {
 			})
 
 			It("successfully creates assessment without owner fields (nil values)", func() {
-				inventory := v1alpha1.Inventory{
+				inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
 					Vcenter: v1alpha1.VCenter{Id: "test-vcenter"},
 					Vms:     v1alpha1.VMs{Total: 10},
 					Infra:   v1alpha1.Infra{TotalHosts: 5},
-				}
+				})
 
 				testAssessmentID := uuid.New()
 				createForm := mappers.AssessmentCreateForm{
@@ -184,7 +185,7 @@ var _ = Describe("assessment service", Ordered, func() {
 					OwnerFirstName: nil, // Test nil values
 					OwnerLastName:  nil,
 					Source:         service.SourceTypeInventory,
-					Inventory:      inventory,
+					Inventory:      inventoryJSON,
 				}
 
 				assessment, err := svc.CreateAssessment(context.TODO(), createForm)
@@ -199,11 +200,11 @@ var _ = Describe("assessment service", Ordered, func() {
 			})
 
 			It("fails to create assessment when name already exists (duplicate key constraint)", func() {
-				inventory := v1alpha1.Inventory{
+				inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
 					Vcenter: v1alpha1.VCenter{Id: "test-vcenter"},
 					Vms:     v1alpha1.VMs{Total: 10},
 					Infra:   v1alpha1.Infra{TotalHosts: 5},
-				}
+				})
 
 				name := "Duplicate Assessment"
 				// Insert first assessment directly via DB
@@ -218,7 +219,7 @@ var _ = Describe("assessment service", Ordered, func() {
 					OrgID:     "org1",
 					Username:  "user1",
 					Source:    service.SourceTypeInventory,
-					Inventory: inventory,
+					Inventory: inventoryJSON,
 				}
 
 				secondAssessment, secondErr := svc.CreateAssessment(context.TODO(), secondForm)

--- a/internal/service/mappers/inbound.go
+++ b/internal/service/mappers/inbound.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
-	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/store/model"
 )
 
@@ -70,8 +69,9 @@ func (s SourceCreateForm) ToSource() model.Source {
 
 type InventoryUpdateForm struct {
 	SourceID  uuid.UUID
-	AgentId   uuid.UUID
-	Inventory v1alpha1.Inventory // TODO: think about versioning. This is bound to v1alpha1 currently.
+	AgentID   uuid.UUID
+	VCenterID string
+	Inventory []byte
 }
 
 type AgentUpdateForm struct {
@@ -94,9 +94,9 @@ func (f *AgentUpdateForm) ToModel() model.Agent {
 	}
 }
 
-func UpdateSourceFromApi(m *model.Source, inventory api.Inventory) *model.Source {
-	m.Inventory = model.MakeJSONField(inventory)
-	m.VCenterID = inventory.Vcenter.Id
+func UpdateSourceFromApi(m *model.Source, vCenterID string, inventory []byte) *model.Source {
+	m.Inventory = inventory
+	m.VCenterID = vCenterID
 	return m
 }
 
@@ -169,7 +169,7 @@ type AssessmentCreateForm struct {
 	OwnerLastName  *string
 	Source         string
 	SourceID       *uuid.UUID
-	Inventory      v1alpha1.Inventory
+	Inventory      []byte
 	RVToolsFile    io.Reader
 }
 
@@ -194,5 +194,5 @@ type AssessmentUpdateForm struct {
 	Name           *string
 	OwnerFirstName *string
 	OwnerLastName  *string
-	Inventory      v1alpha1.Inventory
+	Inventory      []byte
 }

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -183,7 +183,7 @@ func (s *SourceService) UpdateInventory(ctx context.Context, form mappers.Invent
 	// create the agent if missing
 	var agent *model.Agent
 	for _, a := range source.Agents {
-		if a.ID == form.AgentId {
+		if a.ID == form.AgentID {
 			agent = &a
 			break
 		}
@@ -196,14 +196,14 @@ func (s *SourceService) UpdateInventory(ctx context.Context, form mappers.Invent
 		}
 	}
 
-	if source.VCenterID != "" && source.VCenterID != form.Inventory.Vcenter.Id {
+	if source.VCenterID != "" && source.VCenterID != form.VCenterID {
 		_, _ = store.Rollback(ctx)
-		return model.Source{}, NewErrInvalidVCenterID(form.SourceID, form.Inventory.Vcenter.Id)
+		return model.Source{}, NewErrInvalidVCenterID(form.SourceID, form.VCenterID)
 	}
 
 	source.OnPremises = true
-	source.VCenterID = form.Inventory.Vcenter.Id
-	source.Inventory = model.MakeJSONField(form.Inventory)
+	source.VCenterID = form.VCenterID
+	source.Inventory = form.Inventory
 
 	if _, err = s.store.Source().Update(ctx, *source); err != nil {
 		_, _ = store.Rollback(ctx)

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -308,15 +309,18 @@ var _ = Describe("source handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, firstSourceID, "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 
+			inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+				Vcenter: v1alpha1.VCenter{
+					Id: "vcenter",
+				},
+			})
+
 			srv := service.NewSourceService(s, nil)
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
-				SourceID: firstSourceID,
-				AgentId:  uuid.New(),
-				Inventory: v1alpha1.Inventory{
-					Vcenter: v1alpha1.VCenter{
-						Id: "vcenter",
-					},
-				},
+				SourceID:  firstSourceID,
+				AgentID:   uuid.New(),
+				VCenterID: "vcenter",
+				Inventory: inventoryJSON,
 			})
 			Expect(err).To(BeNil())
 
@@ -342,15 +346,18 @@ var _ = Describe("source handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, firstSourceID, "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 
+			inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+				Vcenter: v1alpha1.VCenter{
+					Id: "vcenter",
+				},
+			})
+
 			srv := service.NewSourceService(s, nil)
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
-				SourceID: firstSourceID,
-				AgentId:  uuid.New(),
-				Inventory: v1alpha1.Inventory{
-					Vcenter: v1alpha1.VCenter{
-						Id: "vcenter",
-					},
-				},
+				SourceID:  firstSourceID,
+				AgentID:   uuid.New(),
+				VCenterID: "vcenter",
+				Inventory: inventoryJSON,
 			})
 			Expect(err).To(BeNil())
 
@@ -365,13 +372,10 @@ var _ = Describe("source handler", Ordered, func() {
 			Expect(onPrem).To(BeTrue())
 
 			_, err = srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
-				SourceID: firstSourceID,
-				AgentId:  uuid.New(),
-				Inventory: v1alpha1.Inventory{
-					Vcenter: v1alpha1.VCenter{
-						Id: "vcenter",
-					},
-				},
+				SourceID:  firstSourceID,
+				AgentID:   uuid.New(),
+				VCenterID: "vcenter",
+				Inventory: inventoryJSON,
 			})
 			Expect(err).To(BeNil())
 		})
@@ -381,27 +385,33 @@ var _ = Describe("source handler", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, firstSourceID, "admin", "admin"))
 			Expect(tx.Error).To(BeNil())
 
+			inventory1JSON, _ := json.Marshal(v1alpha1.Inventory{
+				Vcenter: v1alpha1.VCenter{
+					Id: "vcenter",
+				},
+			})
+
 			srv := service.NewSourceService(s, nil)
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
-				SourceID: firstSourceID,
-				AgentId:  uuid.New(),
-				Inventory: v1alpha1.Inventory{
-					Vcenter: v1alpha1.VCenter{
-						Id: "vcenter",
-					},
-				},
+				SourceID:  firstSourceID,
+				AgentID:   uuid.New(),
+				VCenterID: "vcenter",
+				Inventory: inventory1JSON,
 			})
 			Expect(err).To(BeNil())
 
+			inventory2JSON, _ := json.Marshal(v1alpha1.Inventory{
+				Vcenter: v1alpha1.VCenter{
+					Id: "another-vcenter-id",
+				},
+			})
+
 			// Now try to update with a different vCenter ID
 			_, err = srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
-				SourceID: firstSourceID,
-				AgentId:  uuid.New(),
-				Inventory: v1alpha1.Inventory{
-					Vcenter: v1alpha1.VCenter{
-						Id: "another-vcenter-id",
-					},
-				},
+				SourceID:  firstSourceID,
+				AgentID:   uuid.New(),
+				VCenterID: "another-vcenter-id",
+				Inventory: inventory2JSON,
 			})
 			Expect(err).ToNot(BeNil())
 			_, ok := err.(*service.ErrInvalidVCenterID)

--- a/internal/store/assessment_test.go
+++ b/internal/store/assessment_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
@@ -192,11 +191,7 @@ var _ = Describe("assessment store", Ordered, func() {
 	Context("create", func() {
 		It("successfully creates an assessment with inventory", func() {
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -205,7 +200,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			created, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			created, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 			Expect(created).ToNot(BeNil())
 			Expect(created.ID).To(Equal(assessmentID))
@@ -225,11 +220,7 @@ var _ = Describe("assessment store", Ordered, func() {
 
 		It("successfully creates an assessment with owner fields", func() {
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			ownerFirstName := "Alice"
 			ownerLastName := "Johnson"
@@ -243,7 +234,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType:     "inventory",
 			}
 
-			created, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			created, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 			Expect(created).ToNot(BeNil())
 			Expect(created.ID).To(Equal(assessmentID))
@@ -271,11 +262,7 @@ var _ = Describe("assessment store", Ordered, func() {
 			Expect(tx.Error).To(BeNil())
 
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -285,7 +272,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceID:   &sourceID,
 			}
 
-			created, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			created, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 			Expect(created).ToNot(BeNil())
 			Expect(created.ID).To(Equal(assessmentID))
@@ -296,11 +283,7 @@ var _ = Describe("assessment store", Ordered, func() {
 		It("fails to create assessment with non-existent source_id", func() {
 			nonExistentSourceID := uuid.New()
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -310,7 +293,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceID:   &nonExistentSourceID,
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			_, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("foreign key constraint"))
 		})
@@ -318,11 +301,7 @@ var _ = Describe("assessment store", Ordered, func() {
 		It("fails to create assessment with duplicate name in same org", func() {
 			assessmentID1 := uuid.New()
 			assessmentID2 := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment1 := model.Assessment{
 				ID:         assessmentID1,
@@ -331,7 +310,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment1, inventory)
+			_, err := s.Assessment().Create(context.TODO(), assessment1, inventoryJSON)
 			Expect(err).To(BeNil())
 
 			// Try to create another assessment with same name in same org
@@ -342,18 +321,14 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "rvtools",
 			}
 
-			_, err = s.Assessment().Create(context.TODO(), assessment2, inventory)
+			_, err = s.Assessment().Create(context.TODO(), assessment2, inventoryJSON)
 			Expect(err).ToNot(BeNil())
 		})
 
 		It("successfully creates assessments with same name in different orgs", func() {
 			assessmentID1 := uuid.New()
 			assessmentID2 := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment1 := model.Assessment{
 				ID:         assessmentID1,
@@ -362,7 +337,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment1, inventory)
+			_, err := s.Assessment().Create(context.TODO(), assessment1, inventoryJSON)
 			Expect(err).To(BeNil())
 
 			// Create assessment with same name but different org
@@ -373,7 +348,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "rvtools",
 			}
 
-			_, err = s.Assessment().Create(context.TODO(), assessment2, inventory)
+			_, err = s.Assessment().Create(context.TODO(), assessment2, inventoryJSON)
 			Expect(err).To(BeNil())
 
 			var count int
@@ -398,11 +373,7 @@ var _ = Describe("assessment store", Ordered, func() {
 
 			// Create an assessment with this source_id
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -412,7 +383,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceID:   &sourceID,
 			}
 
-			created, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			created, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 			Expect(created.SourceID).ToNot(BeNil())
 			Expect(created.SourceID.String()).To(Equal(sourceID.String()))
@@ -437,11 +408,7 @@ var _ = Describe("assessment store", Ordered, func() {
 	Context("update", func() {
 		It("successfully updates assessment name", func() {
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -450,7 +417,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			_, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 
 			newName := "updated-name"
@@ -463,11 +430,7 @@ var _ = Describe("assessment store", Ordered, func() {
 
 		It("successfully adds new snapshot to assessment", func() {
 			assessmentID := uuid.New()
-			inventory1 := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter-1"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventory1JSON := []byte(`{"vcenter":{"id":"test-vcenter-1"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -476,18 +439,14 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			created, err := s.Assessment().Create(context.TODO(), assessment, inventory1)
+			created, err := s.Assessment().Create(context.TODO(), assessment, inventory1JSON)
 			Expect(err).To(BeNil())
 			Expect(created.Snapshots).To(HaveLen(1))
 
 			// Add new snapshot
-			inventory2 := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter-2"},
-				Vms:     api.VMs{Total: 15},
-				Infra:   api.Infra{TotalHosts: 7},
-			}
+			inventory2JSON := []byte(`{"vcenter":{"id":"test-vcenter-2"},"vms":{"total":15},"infra":{"totalHosts":7}}`)
 
-			updated, err := s.Assessment().Update(context.TODO(), assessmentID, nil, &inventory2)
+			updated, err := s.Assessment().Update(context.TODO(), assessmentID, nil, inventory2JSON)
 			Expect(err).To(BeNil())
 			Expect(updated).ToNot(BeNil())
 
@@ -500,11 +459,7 @@ var _ = Describe("assessment store", Ordered, func() {
 
 		It("successfully updates both name and adds snapshot", func() {
 			assessmentID := uuid.New()
-			inventory1 := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter-1"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventory1JSON := []byte(`{"vcenter":{"id":"test-vcenter-1"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -513,18 +468,14 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment, inventory1)
+			_, err := s.Assessment().Create(context.TODO(), assessment, inventory1JSON)
 			Expect(err).To(BeNil())
 
 			// Update both name and add snapshot
 			newName := "updated-name"
-			inventory2 := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter-2"},
-				Vms:     api.VMs{Total: 15},
-				Infra:   api.Infra{TotalHosts: 7},
-			}
+			inventory2JSON := []byte(`{"vcenter":{"id":"test-vcenter-2"},"vms":{"total":15},"infra":{"totalHosts":7}}`)
 
-			updated, err := s.Assessment().Update(context.TODO(), assessmentID, &newName, &inventory2)
+			updated, err := s.Assessment().Update(context.TODO(), assessmentID, &newName, inventory2JSON)
 			Expect(err).To(BeNil())
 			Expect(updated).ToNot(BeNil())
 			Expect(updated.Name).To(Equal("updated-name"))
@@ -556,11 +507,7 @@ var _ = Describe("assessment store", Ordered, func() {
 	Context("delete", func() {
 		It("successfully deletes an assessment", func() {
 			assessmentID := uuid.New()
-			inventory := api.Inventory{
-				Vcenter: api.VCenter{Id: "test-vcenter"},
-				Vms:     api.VMs{Total: 10},
-				Infra:   api.Infra{TotalHosts: 5},
-			}
+			inventoryJSON := []byte(`{"vcenter":{"id":"test-vcenter"},"vms":{"total":10},"infra":{"totalHosts":5}}`)
 
 			assessment := model.Assessment{
 				ID:         assessmentID,
@@ -569,7 +516,7 @@ var _ = Describe("assessment store", Ordered, func() {
 				SourceType: "inventory",
 			}
 
-			_, err := s.Assessment().Create(context.TODO(), assessment, inventory)
+			_, err := s.Assessment().Create(context.TODO(), assessment, inventoryJSON)
 			Expect(err).To(BeNil())
 
 			// Verify assessment and snapshot exist

--- a/internal/store/model/assessment.go
+++ b/internal/store/model/assessment.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 )
 
 type Assessment struct {
@@ -24,10 +22,10 @@ type Assessment struct {
 }
 
 type Snapshot struct {
-	ID           uint                      `gorm:"primaryKey;autoIncrement"`
-	CreatedAt    time.Time                 `gorm:"not null;default:now()"`
-	Inventory    *JSONField[api.Inventory] `gorm:"type:jsonb;not null"`
-	AssessmentID uuid.UUID                 `gorm:"not null;type:VARCHAR(255);"`
+	ID           uint      `gorm:"primaryKey;autoIncrement"`
+	CreatedAt    time.Time `gorm:"not null;default:now()"`
+	Inventory    []byte    `gorm:"type:jsonb;not null"`
+	AssessmentID uuid.UUID `gorm:"not null;type:VARCHAR(255);"`
 }
 
 type AssessmentList []Assessment

--- a/internal/store/model/source.go
+++ b/internal/store/model/source.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/google/uuid"
-	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	"gorm.io/gorm"
 )
 
@@ -20,8 +19,8 @@ type Source struct {
 	Name        string    `gorm:"uniqueIndex:name_org_id;not null"`
 	VCenterID   string
 	Username    string
-	OrgID       string                    `gorm:"uniqueIndex:name_org_id;not null"`
-	Inventory   *JSONField[api.Inventory] `gorm:"type:jsonb"`
+	OrgID       string `gorm:"uniqueIndex:name_org_id;not null"`
+	Inventory   []byte `gorm:"type:jsonb"`
 	OnPremises  bool
 	Agents      []Agent    `gorm:"constraint:OnDelete:CASCADE;"`
 	ImageInfra  ImageInfra `gorm:"constraint:OnDelete:CASCADE;"`


### PR DESCRIPTION
This PR decouples the inventory stored as []byte from api.Inventory. The inventory is marshalled into []byte at handlers layer and passed through layers as []byte{}.

This is the first step towards inventory v2.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for mapping and JSON processing to reduce silent failures and surface clearer 500 responses.

* **Improvements**
  * Inventory is consistently handled and transmitted as JSON bytes across uploads, imports and storage.
  * Stricter vCenter identifier validation to prevent invalid inventory updates.
  * Outbound mapping now propagates mapping errors instead of assuming success.

* **Tests**
  * Updated tests to exercise JSON-based inventory flows and vCenter validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->