### PR TITLE
ECOPROJECT-3516 | feat: Parse RVTools Excel and organize by cluster

### DIFF
--- a/internal/agent/service/cluster_filtering.go
+++ b/internal/agent/service/cluster_filtering.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	api "github.com/kubev2v/migration-planner/api/v1alpha1"
+)
+
+type ClusterIDMapping struct {
+	VMToClusterID   map[string]string // VM Name -> Cluster ID
+	HostToClusterID map[string]string // Host Object ID -> Cluster ID
+	ClusterIDs      []string          // List of unique cluster IDs (sorted)
+}
+
+type ClusteredInventoryResponse struct {
+	VCenterID string                    `json:"vcenter_id"`
+	Clusters  map[string]*api.Inventory `json:"clusters"` // Keys are cluster IDs
+	VCenter   *api.Inventory            `json:"vcenter"`  // Aggregated vcenter inventory
+}
+
+func FilterVMsByClusterID(vms []vsphere.VM, clusterID string, vmToClusterID map[string]string) []vsphere.VM {
+	// Count first to allocate exact capacity
+	count := 0
+	for _, vm := range vms {
+		if vmClusterID, exists := vmToClusterID[vm.Name]; exists && vmClusterID == clusterID {
+			count++
+		}
+	}
+
+	// Allocate with exact capacity
+	filtered := make([]vsphere.VM, 0, count)
+	for _, vm := range vms {
+		if vmClusterID, exists := vmToClusterID[vm.Name]; exists && vmClusterID == clusterID {
+			filtered = append(filtered, vm)
+		}
+	}
+
+	return filtered
+}
+
+func FilterHostsByClusterID(hosts []api.Host, clusterID string, hostToClusterID map[string]string) []api.Host {
+	// Count first to allocate exact capacity
+	count := 0
+	for _, host := range hosts {
+		if host.Id != nil {
+			if hostClusterID, exists := hostToClusterID[*host.Id]; exists && hostClusterID == clusterID {
+				count++
+			}
+		}
+	}
+
+	// Allocate with exact capacity
+	filtered := make([]api.Host, 0, count)
+	for _, host := range hosts {
+		if host.Id != nil {
+			if hostClusterID, exists := hostToClusterID[*host.Id]; exists && hostClusterID == clusterID {
+				filtered = append(filtered, host)
+			}
+		}
+	}
+
+	return filtered
+}
+
+func FilterInfraDataByClusterID(
+	infraData InfrastructureData,
+	clusterID string,
+	hostToClusterID map[string]string,
+	clusterVMs []vsphere.VM,
+	datastoreMapping map[string]string,
+	datastoreIndexToName map[int]string,
+	networkMapping map[string]string,
+	hostIDToPowerState map[string]string,
+) InfrastructureData {
+	// Guard against nil Hosts pointer to make this helper more robust for reuse
+	var baseHosts []api.Host
+	if infraData.Hosts != nil {
+		baseHosts = *infraData.Hosts
+	}
+	clusterHosts := FilterHostsByClusterID(baseHosts, clusterID, hostToClusterID)
+
+	clusterHostPowerStates := CalculateHostPowerStatesForCluster(clusterHosts, hostIDToPowerState)
+
+	clusterDatastores := FilterDatastoresByVMs(infraData.Datastores, clusterVMs, datastoreMapping, datastoreIndexToName)
+
+	clusterNetworks := FilterNetworksByVMs(infraData.Networks, clusterVMs, networkMapping)
+
+	return InfrastructureData{
+		Datastores:            clusterDatastores,
+		Networks:              clusterNetworks,
+		HostPowerStates:       clusterHostPowerStates,
+		Hosts:                 &clusterHosts,
+		HostsPerCluster:       []int{len(clusterHosts)},
+		ClustersPerDatacenter: []int{1}, // Single cluster
+		TotalHosts:            len(clusterHosts),
+		TotalClusters:         1,
+		TotalDatacenters:      1,
+		VmsPerCluster:         []int{len(clusterVMs)},
+	}
+}
+
+func CalculateHostPowerStatesForCluster(clusterHosts []api.Host, hostIDToPowerState map[string]string) map[string]int {
+	powerStates := make(map[string]int)
+
+	for _, host := range clusterHosts {
+		if host.Id == nil {
+			// If host ID is missing, default to green
+			powerStates["green"]++
+			continue
+		}
+
+		hostID := *host.Id
+		if powerState, exists := hostIDToPowerState[hostID]; exists {
+			powerStates[powerState]++
+		} else {
+			// If power state is not found in the map, default to green
+			powerStates["green"]++
+		}
+	}
+
+	// Ensure we return at least an empty green count if no hosts
+	if len(powerStates) == 0 {
+		powerStates["green"] = 0
+	}
+
+	return powerStates
+}
+
+func FilterDatastoresByVMs(
+	datastores []api.Datastore,
+	vms []vsphere.VM,
+	datastoreMapping map[string]string,
+	datastoreIndexToName map[int]string,
+) []api.Datastore {
+	// Collect datastore object IDs used by VMs
+	usedObjectIDs := make(map[string]struct{})
+	for _, vm := range vms {
+		for _, disk := range vm.Disks {
+			if disk.Datastore.ID != "" {
+				usedObjectIDs[disk.Datastore.ID] = struct{}{}
+			}
+		}
+	}
+
+	usedDatastoreNames := make(map[string]struct{})
+	for name, objID := range datastoreMapping {
+		if _, isUsed := usedObjectIDs[objID]; isUsed {
+			usedDatastoreNames[name] = struct{}{}
+		}
+	}
+
+	// Filter datastores by matching original names
+	filtered := make([]api.Datastore, 0, len(usedDatastoreNames))
+	for idx, ds := range datastores {
+		// Get the original name before NAA/path replacement
+		originalName, hasOriginalName := datastoreIndexToName[idx]
+
+		if hasOriginalName {
+			// Match against original name
+			if _, used := usedDatastoreNames[originalName]; used {
+				filtered = append(filtered, ds)
+			}
+		} else {
+			// Fallback: if we don't have the original name mapping, try exact match with DiskId
+			if _, used := usedDatastoreNames[ds.DiskId]; used {
+				filtered = append(filtered, ds)
+			}
+		}
+	}
+
+	return filtered
+}
+
+func FilterNetworksByVMs(networks []api.Network, vms []vsphere.VM, networkMapping map[string]string) []api.Network {
+	// Collect network object IDs used by VMs
+	networkObjectIDSet := make(map[string]struct{})
+	for _, vm := range vms {
+		for _, nic := range vm.NICs {
+			if nic.Network.ID != "" {
+				networkObjectIDSet[nic.Network.ID] = struct{}{}
+			}
+		}
+		for _, net := range vm.Networks {
+			if net.ID != "" {
+				networkObjectIDSet[net.ID] = struct{}{}
+			}
+		}
+	}
+
+	// Build set of network names used by this cluster
+	usedNetworkNames := make(map[string]struct{})
+	for objectID := range networkObjectIDSet {
+		if netName, exists := networkMapping[objectID]; exists {
+			usedNetworkNames[netName] = struct{}{}
+		}
+	}
+
+	// Filter networks by name
+	filtered := make([]api.Network, 0, len(usedNetworkNames))
+	for _, network := range networks {
+		if _, used := usedNetworkNames[network.Name]; used {
+			filtered = append(filtered, network)
+		}
+	}
+
+	return filtered
+}

--- a/internal/agent/service/cluster_filtering_test.go
+++ b/internal/agent/service/cluster_filtering_test.go
@@ -1,0 +1,741 @@
+package service
+
+import (
+	"testing"
+
+	vsphere "github.com/kubev2v/forklift/pkg/controller/provider/model/vsphere"
+	api "github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterDatastoresByVMs(t *testing.T) {
+	tests := []struct {
+		name                 string
+		datastores           []api.Datastore
+		vms                  []vsphere.VM
+		datastoreMapping     map[string]string
+		datastoreIndexToName map[int]string
+		expectedCount        int
+		expectedDiskIds      []string
+		description          string
+	}{
+		{
+			name: "exact name matches - datastores with original names preserved",
+			datastores: []api.Datastore{
+				{DiskId: "storage1"},
+				{DiskId: "storage2"},
+				{DiskId: "storage3"},
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-101"}},
+						{Datastore: vsphere.Ref{ID: "datastore-102"}},
+					},
+				},
+			},
+			datastoreMapping: map[string]string{
+				"storage1": "datastore-101",
+				"storage2": "datastore-102",
+				"storage3": "datastore-103",
+			},
+			datastoreIndexToName: map[int]string{
+				0: "storage1",
+				1: "storage2",
+				2: "storage3",
+			},
+			expectedCount:   2,
+			expectedDiskIds: []string{"storage1", "storage2"},
+			description:     "Should match exactly 2 datastores used by VMs",
+		},
+		{
+			name: "NAA identifier replacement - datastores with DiskId replaced by NAA",
+			datastores: []api.Datastore{
+				{DiskId: "naa.600a098038314648593f517773636465"}, // NAA replaced
+				{DiskId: "naa.624a9370a7b9f7ecc01e40f70001181f"}, // NAA replaced
+				{DiskId: "naa.600a0980383139544924583130316a78"}, // NAA replaced
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-201"}},
+						{Datastore: vsphere.Ref{ID: "datastore-202"}},
+					},
+				},
+			},
+			datastoreMapping: map[string]string{
+				"eco-iscsi-ds1": "datastore-201",
+				"eco-iscsi-ds2": "datastore-202",
+				"eco-iscsi-ds3": "datastore-203",
+			},
+			datastoreIndexToName: map[int]string{
+				0: "eco-iscsi-ds1", // Original name before NAA replacement
+				1: "eco-iscsi-ds2",
+				2: "eco-iscsi-ds3",
+			},
+			expectedCount: 2,
+			expectedDiskIds: []string{
+				"naa.600a098038314648593f517773636465",
+				"naa.624a9370a7b9f7ecc01e40f70001181f",
+			},
+			description: "Should match datastores by original name even after NAA replacement",
+		},
+		{
+			name: "mixed storage types - NFS, SAS, iSCSI",
+			datastores: []api.Datastore{
+				{DiskId: "N/A", Type: "NFS"},                     // NFS datastore
+				{DiskId: "mpx.vmhba0:C0:T1:L0", Type: "VMFS"},    // Local SAS
+				{DiskId: "naa.60002ac0000000000000182d00021f6b"}, // iSCSI
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-301"}}, // NFS
+						{Datastore: vsphere.Ref{ID: "datastore-302"}}, // Local SAS
+					},
+				},
+			},
+			datastoreMapping: map[string]string{
+				"nfs-storage":   "datastore-301",
+				"local-storage": "datastore-302",
+				"iscsi-storage": "datastore-303",
+			},
+			datastoreIndexToName: map[int]string{
+				0: "nfs-storage",
+				1: "local-storage",
+				2: "iscsi-storage",
+			},
+			expectedCount:   2,
+			expectedDiskIds: []string{"N/A", "mpx.vmhba0:C0:T1:L0"},
+			description:     "Should handle different storage protocol types correctly",
+		},
+		{
+			name: "no matching datastores - VMs use different datastores",
+			datastores: []api.Datastore{
+				{DiskId: "storage-a"},
+				{DiskId: "storage-b"},
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-999"}}, // Not in mapping
+					},
+				},
+			},
+			datastoreMapping: map[string]string{
+				"storage-a": "datastore-401",
+				"storage-b": "datastore-402",
+			},
+			datastoreIndexToName: map[int]string{
+				0: "storage-a",
+				1: "storage-b",
+			},
+			expectedCount:   0,
+			expectedDiskIds: []string{},
+			description:     "Should return empty list when no datastores match",
+		},
+		{
+			name: "substring names should not cause false positives",
+			datastores: []api.Datastore{
+				{DiskId: "prod"},
+				{DiskId: "production"},
+				{DiskId: "prod-backup"},
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-501"}}, // Only "prod"
+					},
+				},
+			},
+			datastoreMapping: map[string]string{
+				"prod":        "datastore-501",
+				"production":  "datastore-502",
+				"prod-backup": "datastore-503",
+			},
+			datastoreIndexToName: map[int]string{
+				0: "prod",
+				1: "production",
+				2: "prod-backup",
+			},
+			expectedCount:   1,
+			expectedDiskIds: []string{"prod"},
+			description:     "Should match only exact names, not substrings",
+		},
+		{
+			name: "empty inputs",
+			datastores: []api.Datastore{
+				{DiskId: "storage1"},
+			},
+			vms:                  []vsphere.VM{},
+			datastoreMapping:     map[string]string{"storage1": "datastore-601"},
+			datastoreIndexToName: map[int]string{0: "storage1"},
+			expectedCount:        0,
+			expectedDiskIds:      []string{},
+			description:          "Should return empty when no VMs provided",
+		},
+		{
+			name:       "no datastores",
+			datastores: []api.Datastore{},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-701"}},
+					},
+				},
+			},
+			datastoreMapping:     map[string]string{},
+			datastoreIndexToName: map[int]string{},
+			expectedCount:        0,
+			expectedDiskIds:      []string{},
+			description:          "Should return empty when no datastores provided",
+		},
+		{
+			name: "VMs with disks but no datastore IDs",
+			datastores: []api.Datastore{
+				{DiskId: "storage1"},
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: ""}}, // Empty ID
+					},
+				},
+			},
+			datastoreMapping:     map[string]string{"storage1": "datastore-801"},
+			datastoreIndexToName: map[int]string{0: "storage1"},
+			expectedCount:        0,
+			expectedDiskIds:      []string{},
+			description:          "Should handle VMs with empty datastore IDs",
+		},
+		{
+			name: "fallback to DiskId when no original name mapping",
+			datastores: []api.Datastore{
+				{DiskId: "storage-direct"},
+			},
+			vms: []vsphere.VM{
+				{
+					Disks: []vsphere.Disk{
+						{Datastore: vsphere.Ref{ID: "datastore-901"}},
+					},
+				},
+			},
+			datastoreMapping:     map[string]string{"storage-direct": "datastore-901"},
+			datastoreIndexToName: map[int]string{}, // No mapping available
+			expectedCount:        1,
+			expectedDiskIds:      []string{"storage-direct"},
+			description:          "Should fallback to exact DiskId match when no index mapping exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterDatastoresByVMs(
+				tt.datastores,
+				tt.vms,
+				tt.datastoreMapping,
+				tt.datastoreIndexToName,
+			)
+
+			assert.Equal(t, tt.expectedCount, len(result), tt.description)
+
+			if tt.expectedCount > 0 {
+				resultDiskIds := make([]string, len(result))
+				for i, ds := range result {
+					resultDiskIds[i] = ds.DiskId
+				}
+				assert.ElementsMatch(t, tt.expectedDiskIds, resultDiskIds,
+					"Expected DiskIds to match (order-independent)")
+			}
+		})
+	}
+}
+
+func TestFilterDatastoresByVMs_MultipleVMs(t *testing.T) {
+	datastores := []api.Datastore{
+		{DiskId: "ds1"},
+		{DiskId: "ds2"},
+		{DiskId: "ds3"},
+		{DiskId: "ds4"},
+	}
+
+	vms := []vsphere.VM{
+		{
+			Disks: []vsphere.Disk{
+				{Datastore: vsphere.Ref{ID: "datastore-1"}},
+				{Datastore: vsphere.Ref{ID: "datastore-2"}},
+			},
+		},
+		{
+			Disks: []vsphere.Disk{
+				{Datastore: vsphere.Ref{ID: "datastore-2"}}, // Same as VM1
+				{Datastore: vsphere.Ref{ID: "datastore-3"}},
+			},
+		},
+		{
+			Disks: []vsphere.Disk{
+				{Datastore: vsphere.Ref{ID: "datastore-1"}}, // Same as VM1
+			},
+		},
+	}
+
+	datastoreMapping := map[string]string{
+		"ds1": "datastore-1",
+		"ds2": "datastore-2",
+		"ds3": "datastore-3",
+		"ds4": "datastore-4",
+	}
+
+	datastoreIndexToName := map[int]string{
+		0: "ds1",
+		1: "ds2",
+		2: "ds3",
+		3: "ds4",
+	}
+
+	result := FilterDatastoresByVMs(datastores, vms, datastoreMapping, datastoreIndexToName)
+
+	assert.Equal(t, 3, len(result), "Should deduplicate and return 3 unique datastores")
+
+	resultDiskIds := make([]string, len(result))
+	for i, ds := range result {
+		resultDiskIds[i] = ds.DiskId
+	}
+	assert.ElementsMatch(t, []string{"ds1", "ds2", "ds3"}, resultDiskIds)
+}
+
+func TestFilterNetworksByVMs(t *testing.T) {
+	tests := []struct {
+		name             string
+		networks         []api.Network
+		vms              []vsphere.VM
+		networkMapping   map[string]string
+		expectedCount    int
+		expectedNetworks []string
+		description      string
+	}{
+		{
+			name: "NIC-based network IDs",
+			networks: []api.Network{
+				{Name: "network1"},
+				{Name: "network2"},
+				{Name: "network3"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-101"}},
+						{Network: vsphere.Ref{ID: "network-102"}},
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-101": "network1",
+				"network-102": "network2",
+				"network-103": "network3",
+			},
+			expectedCount:    2,
+			expectedNetworks: []string{"network1", "network2"},
+			description:      "Should match networks used by VM NICs",
+		},
+		{
+			name: "vm.Networks-based IDs",
+			networks: []api.Network{
+				{Name: "vlan10"},
+				{Name: "vlan20"},
+				{Name: "vlan30"},
+			},
+			vms: []vsphere.VM{
+				{
+					Networks: []vsphere.Ref{
+						{ID: "dvportgroup-201"},
+						{ID: "dvportgroup-202"},
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"dvportgroup-201": "vlan10",
+				"dvportgroup-202": "vlan20",
+				"dvportgroup-203": "vlan30",
+			},
+			expectedCount:    2,
+			expectedNetworks: []string{"vlan10", "vlan20"},
+			description:      "Should match networks from vm.Networks field",
+		},
+		{
+			name: "both NICs and vm.Networks",
+			networks: []api.Network{
+				{Name: "mgmt"},
+				{Name: "storage"},
+				{Name: "vmotion"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-301"}},
+					},
+					Networks: []vsphere.Ref{
+						{ID: "dvportgroup-302"},
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-301":     "mgmt",
+				"dvportgroup-302": "storage",
+				"network-303":     "vmotion",
+			},
+			expectedCount:    2,
+			expectedNetworks: []string{"mgmt", "storage"},
+			description:      "Should collect networks from both NICs and vm.Networks",
+		},
+		{
+			name: "networkMapping missing some IDs - graceful handling",
+			networks: []api.Network{
+				{Name: "known-network"},
+				{Name: "another-network"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-401"}}, // In mapping
+						{Network: vsphere.Ref{ID: "network-999"}}, // NOT in mapping
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-401": "known-network",
+				"network-402": "another-network",
+				// network-999 is missing from mapping
+			},
+			expectedCount:    1,
+			expectedNetworks: []string{"known-network"},
+			description:      "Should gracefully handle missing networkMapping entries",
+		},
+		{
+			name: "networks unused by VMs are excluded",
+			networks: []api.Network{
+				{Name: "prod-network"},
+				{Name: "dev-network"},
+				{Name: "test-network"},
+				{Name: "unused-network"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-501"}},
+						{Network: vsphere.Ref{ID: "network-502"}},
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-501": "prod-network",
+				"network-502": "dev-network",
+				"network-503": "test-network",
+				"network-504": "unused-network",
+			},
+			expectedCount:    2,
+			expectedNetworks: []string{"prod-network", "dev-network"},
+			description:      "Should exclude networks not used by any VM",
+		},
+		{
+			name: "empty network IDs are ignored",
+			networks: []api.Network{
+				{Name: "valid-network"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: ""}},            // Empty ID
+						{Network: vsphere.Ref{ID: "network-601"}}, // Valid
+					},
+					Networks: []vsphere.Ref{
+						{ID: ""}, // Empty ID
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-601": "valid-network",
+			},
+			expectedCount:    1,
+			expectedNetworks: []string{"valid-network"},
+			description:      "Should ignore empty network IDs",
+		},
+		{
+			name: "no matching networks",
+			networks: []api.Network{
+				{Name: "network-a"},
+				{Name: "network-b"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-999"}}, // Not in mapping
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-701": "network-a",
+				"network-702": "network-b",
+			},
+			expectedCount:    0,
+			expectedNetworks: []string{},
+			description:      "Should return empty when no networks match",
+		},
+		{
+			name:             "empty inputs",
+			networks:         []api.Network{{Name: "network1"}},
+			vms:              []vsphere.VM{},
+			networkMapping:   map[string]string{"network-801": "network1"},
+			expectedCount:    0,
+			expectedNetworks: []string{},
+			description:      "Should return empty when no VMs provided",
+		},
+		{
+			name: "VMs with no NICs or Networks",
+			networks: []api.Network{
+				{Name: "network1"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs:     []vsphere.NIC{},
+					Networks: []vsphere.Ref{},
+				},
+			},
+			networkMapping:   map[string]string{"network-901": "network1"},
+			expectedCount:    0,
+			expectedNetworks: []string{},
+			description:      "Should handle VMs with no network connections",
+		},
+		{
+			name: "duplicate network IDs across NICs and vm.Networks",
+			networks: []api.Network{
+				{Name: "shared-network"},
+				{Name: "other-network"},
+			},
+			vms: []vsphere.VM{
+				{
+					NICs: []vsphere.NIC{
+						{Network: vsphere.Ref{ID: "network-1001"}},
+						{Network: vsphere.Ref{ID: "network-1001"}}, // Duplicate
+					},
+					Networks: []vsphere.Ref{
+						{ID: "network-1001"}, // Same as NICs
+					},
+				},
+			},
+			networkMapping: map[string]string{
+				"network-1001": "shared-network",
+				"network-1002": "other-network",
+			},
+			expectedCount:    1,
+			expectedNetworks: []string{"shared-network"},
+			description:      "Should deduplicate network IDs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterNetworksByVMs(
+				tt.networks,
+				tt.vms,
+				tt.networkMapping,
+			)
+
+			assert.Equal(t, tt.expectedCount, len(result), tt.description)
+
+			if tt.expectedCount > 0 {
+				resultNames := make([]string, len(result))
+				for i, net := range result {
+					resultNames[i] = net.Name
+				}
+				assert.ElementsMatch(t, tt.expectedNetworks, resultNames,
+					"Expected network names to match (order-independent)")
+			}
+		})
+	}
+}
+
+func TestFilterNetworksByVMs_MultipleVMs(t *testing.T) {
+	networks := []api.Network{
+		{Name: "net1"},
+		{Name: "net2"},
+		{Name: "net3"},
+		{Name: "net4"},
+	}
+
+	vms := []vsphere.VM{
+		{
+			NICs: []vsphere.NIC{
+				{Network: vsphere.Ref{ID: "network-1"}},
+			},
+			Networks: []vsphere.Ref{
+				{ID: "network-2"},
+			},
+		},
+		{
+			NICs: []vsphere.NIC{
+				{Network: vsphere.Ref{ID: "network-2"}}, // Same as VM1
+				{Network: vsphere.Ref{ID: "network-3"}},
+			},
+		},
+		{
+			NICs: []vsphere.NIC{
+				{Network: vsphere.Ref{ID: "network-1"}}, // Same as VM1
+			},
+		},
+	}
+
+	networkMapping := map[string]string{
+		"network-1": "net1",
+		"network-2": "net2",
+		"network-3": "net3",
+		"network-4": "net4",
+	}
+
+	result := FilterNetworksByVMs(networks, vms, networkMapping)
+
+	assert.Equal(t, 3, len(result), "Should deduplicate and return 3 unique networks")
+
+	resultNames := make([]string, len(result))
+	for i, net := range result {
+		resultNames[i] = net.Name
+	}
+	assert.ElementsMatch(t, []string{"net1", "net2", "net3"}, resultNames)
+}
+
+func TestFilterInfraDataByClusterID_NilHostsGuard(t *testing.T) {
+	// Test that FilterInfraDataByClusterID handles nil Hosts pointer gracefully
+	infraData := InfrastructureData{
+		Datastores:      []api.Datastore{{DiskId: "ds1"}},
+		Networks:        []api.Network{{Name: "net1"}},
+		HostPowerStates: map[string]int{"green": 5},
+		Hosts:           nil, // Nil pointer
+	}
+
+	clusterMapping := map[string]string{
+		"host-1": "cluster-1",
+	}
+
+	vms := []vsphere.VM{
+		{
+			Disks: []vsphere.Disk{
+				{Datastore: vsphere.Ref{ID: "datastore-1"}},
+			},
+		},
+	}
+
+	datastoreMapping := map[string]string{
+		"ds1": "datastore-1",
+	}
+
+	datastoreIndexToName := map[int]string{
+		0: "ds1",
+	}
+
+	networkMapping := map[string]string{
+		"network-1": "net1",
+	}
+
+	hostIDToPowerState := map[string]string{}
+
+	// Should not panic
+	result := FilterInfraDataByClusterID(
+		infraData,
+		"cluster-1",
+		clusterMapping,
+		vms,
+		datastoreMapping,
+		datastoreIndexToName,
+		networkMapping,
+		hostIDToPowerState,
+	)
+
+	assert.NotNil(t, result.Hosts, "Should return non-nil Hosts pointer")
+	assert.Equal(t, 0, len(*result.Hosts), "Should return empty Hosts slice when input is nil")
+	assert.Equal(t, 0, result.TotalHosts, "TotalHosts should be 0")
+	assert.Equal(t, map[string]int{"green": 0}, result.HostPowerStates, "Should return zero green hosts")
+}
+
+func TestCalculateHostPowerStatesForCluster(t *testing.T) {
+	// Test the real power state calculation from vHost data
+	tests := []struct {
+		name               string
+		hosts              []api.Host
+		hostIDToPowerState map[string]string
+		expectedMap        map[string]int
+		description        string
+	}{
+		{
+			name: "actual power states from vHost data",
+			hosts: []api.Host{
+				{Id: stringPtr("host-1"), CpuCores: intPtr(32)},
+				{Id: stringPtr("host-2"), CpuCores: intPtr(32)},
+				{Id: stringPtr("host-3"), CpuCores: intPtr(32)},
+				{Id: stringPtr("host-4"), CpuCores: intPtr(32)},
+			},
+			hostIDToPowerState: map[string]string{
+				"host-1": "green",
+				"host-2": "green",
+				"host-3": "red",
+				"host-4": "yellow",
+			},
+			expectedMap: map[string]int{"green": 2, "red": 1, "yellow": 1},
+			description: "Should reflect actual power states from vHost sheet",
+		},
+		{
+			name: "host missing from power state map defaults to green",
+			hosts: []api.Host{
+				{Id: stringPtr("host-1"), CpuCores: intPtr(32)},
+				{Id: stringPtr("host-2"), CpuCores: intPtr(32)},
+			},
+			hostIDToPowerState: map[string]string{
+				"host-1": "red",
+				// host-2 is missing
+			},
+			expectedMap: map[string]int{"red": 1, "green": 1},
+			description: "Should default to green if host not in power state map",
+		},
+		{
+			name: "host with nil ID defaults to green",
+			hosts: []api.Host{
+				{Id: nil, CpuCores: intPtr(32)},
+				{Id: stringPtr("host-1"), CpuCores: intPtr(32)},
+			},
+			hostIDToPowerState: map[string]string{
+				"host-1": "yellow",
+			},
+			expectedMap: map[string]int{"green": 1, "yellow": 1},
+			description: "Should default to green if host ID is nil",
+		},
+		{
+			name:               "no hosts returns zero green",
+			hosts:              []api.Host{},
+			hostIDToPowerState: map[string]string{},
+			expectedMap:        map[string]int{"green": 0},
+			description:        "Empty hosts should return zero green count",
+		},
+		{
+			name:               "nil hosts slice returns zero green",
+			hosts:              nil,
+			hostIDToPowerState: map[string]string{},
+			expectedMap:        map[string]int{"green": 0},
+			description:        "Nil hosts should return zero green count",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateHostPowerStatesForCluster(tt.hosts, tt.hostIDToPowerState)
+			assert.Equal(t, tt.expectedMap, result, tt.description)
+		})
+	}
+}
+
+// Helper functions for tests
+func intPtr(i int) *int {
+	return &i
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/agent/service/inventory_helpers.go
+++ b/internal/agent/service/inventory_helpers.go
@@ -1,0 +1,63 @@
+package service
+
+import "sort"
+
+func CalculateHostsPerCluster(clusterToHosts map[string]map[string]struct{}) []int {
+	if len(clusterToHosts) == 0 {
+		return []int{}
+	}
+
+	// Sort cluster names for consistent ordering
+	clusterNames := make([]string, 0, len(clusterToHosts))
+	for cluster := range clusterToHosts {
+		clusterNames = append(clusterNames, cluster)
+	}
+	sort.Strings(clusterNames)
+
+	hostsPerCluster := make([]int, 0, len(clusterNames))
+	for _, cluster := range clusterNames {
+		hostsPerCluster = append(hostsPerCluster, len(clusterToHosts[cluster]))
+	}
+
+	return hostsPerCluster
+}
+
+func CalculateVMsPerCluster(clusterToVMs map[string]map[string]struct{}) []int {
+	if len(clusterToVMs) == 0 {
+		return []int{}
+	}
+
+	// Sort cluster names for consistent ordering
+	clusterNames := make([]string, 0, len(clusterToVMs))
+	for cluster := range clusterToVMs {
+		clusterNames = append(clusterNames, cluster)
+	}
+	sort.Strings(clusterNames)
+
+	vmsPerCluster := make([]int, 0, len(clusterNames))
+	for _, cluster := range clusterNames {
+		vmsPerCluster = append(vmsPerCluster, len(clusterToVMs[cluster]))
+	}
+
+	return vmsPerCluster
+}
+
+func CalculateClustersPerDatacenter(datacenterToClusters map[string]map[string]struct{}) []int {
+	if len(datacenterToClusters) == 0 {
+		return []int{}
+	}
+
+	// Sort datacenter names for consistent ordering
+	datacenterNames := make([]string, 0, len(datacenterToClusters))
+	for datacenter := range datacenterToClusters {
+		datacenterNames = append(datacenterNames, datacenter)
+	}
+	sort.Strings(datacenterNames)
+
+	clustersPerDatacenter := make([]int, 0, len(datacenterNames))
+	for _, datacenter := range datacenterNames {
+		clustersPerDatacenter = append(clustersPerDatacenter, len(datacenterToClusters[datacenter]))
+	}
+
+	return clustersPerDatacenter
+}

--- a/internal/rvtools/clusters.go
+++ b/internal/rvtools/clusters.go
@@ -1,0 +1,158 @@
+package rvtools
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+
+	"github.com/kubev2v/migration-planner/internal/agent/service"
+	"go.uber.org/zap"
+)
+
+// ExtractClusterIDMapping extracts cluster IDs and creates mappings from RVTools data
+func ExtractClusterIDMapping(vInfoRows, vHostRows, vClusterRows [][]string, vcenterUUID string) service.ClusterIDMapping {
+	clusterNameToID := buildClusterNameToIDMap(vClusterRows)
+
+	hostToClusterID := buildHostToClusterIDMap(vHostRows, clusterNameToID, vcenterUUID)
+
+	vmToClusterID := buildVMToClusterIDMap(vInfoRows, vHostRows, hostToClusterID)
+
+	clusterIDs := extractUniqueClusterIDs(vmToClusterID)
+
+	return service.ClusterIDMapping{
+		VMToClusterID:   vmToClusterID,
+		HostToClusterID: hostToClusterID,
+		ClusterIDs:      clusterIDs,
+	}
+}
+
+func buildClusterNameToIDMap(vClusterRows [][]string) map[string]string {
+	clusterNameToID := make(map[string]string)
+
+	if len(vClusterRows) <= 1 {
+		zap.S().Named("rvtools").Debugf("vCluster sheet not found or empty")
+		return clusterNameToID
+	}
+
+	colMap := buildColumnMap(vClusterRows[0])
+
+	for _, row := range vClusterRows[1:] {
+		if len(row) == 0 {
+			continue
+		}
+
+		clusterName := getColumnValue(row, colMap, "name")
+		objectID := getColumnValue(row, colMap, "object id")
+
+		if clusterName != "" && objectID != "" {
+			clusterNameToID[clusterName] = objectID
+			zap.S().Named("rvtools").Debugf("Mapped cluster '%s' -> '%s'", clusterName, objectID)
+		}
+	}
+
+	zap.S().Named("rvtools").Infof("Found %d clusters in vCluster sheet", len(clusterNameToID))
+	return clusterNameToID
+}
+
+func buildHostToClusterIDMap(vHostRows [][]string, clusterNameToID map[string]string, vcenterUUID string) map[string]string {
+	if len(vHostRows) <= 1 {
+		return make(map[string]string)
+	}
+
+	colMap := buildColumnMap(vHostRows[0])
+	hostToCluster := make(map[string]string)
+
+	for _, row := range vHostRows[1:] {
+		if len(row) == 0 {
+			continue
+		}
+
+		hostID := getColumnValue(row, colMap, "object id")
+		clusterName := getColumnValue(row, colMap, "cluster")
+
+		if hostID == "" || clusterName == "" {
+			continue
+		}
+
+		// Look up cluster object ID from vCluster sheet mapping
+		if clusterID, exists := clusterNameToID[clusterName]; exists {
+			hostToCluster[hostID] = clusterID
+		} else {
+			// Fallback: generate from cluster name if not found in vCluster sheet
+			datacenter := getColumnValue(row, colMap, "datacenter")
+			clusterID := generateClusterID(clusterName, datacenter, vcenterUUID)
+			hostToCluster[hostID] = clusterID
+			zap.S().Named("rvtools").Warnf("Cluster '%s' not found in vCluster sheet, generated ID: %s", clusterName, clusterID)
+		}
+	}
+
+	return hostToCluster
+}
+
+func buildVMToClusterIDMap(vInfoRows, vHostRows [][]string, hostToClusterID map[string]string) map[string]string {
+	if len(vInfoRows) <= 1 {
+		return make(map[string]string)
+	}
+
+	// Build Host IP/Name -> Host Object ID mapping from vHost
+	hostIPToObjectID := createHostIPToObjectIDMap(vHostRows)
+
+	vInfoColMap := buildColumnMap(vInfoRows[0])
+	vmToCluster := make(map[string]string)
+
+	for _, row := range vInfoRows[1:] {
+		if len(row) == 0 {
+			continue
+		}
+
+		vmName := getColumnValue(row, vInfoColMap, "vm")
+		hostIP := getColumnValue(row, vInfoColMap, "host")
+
+		if vmName == "" || hostIP == "" {
+			continue
+		}
+
+		// Convert host IP to object ID, then to cluster ID
+		if hostObjectID, exists := hostIPToObjectID[hostIP]; exists {
+			if clusterID, exists := hostToClusterID[hostObjectID]; exists {
+				vmToCluster[vmName] = clusterID
+			}
+		}
+	}
+
+	return vmToCluster
+}
+
+func extractUniqueClusterIDs(vmToClusterID map[string]string) []string {
+	clusterSet := make(map[string]struct{})
+
+	for _, clusterID := range vmToClusterID {
+		if clusterID != "" {
+			clusterSet[clusterID] = struct{}{}
+		}
+	}
+
+	clusterIDs := make([]string, 0, len(clusterSet))
+	for clusterID := range clusterSet {
+		clusterIDs = append(clusterIDs, clusterID)
+	}
+	sort.Strings(clusterIDs)
+
+	if len(clusterIDs) > 0 {
+		zap.S().Named("rvtools").Debugf("Extracted cluster IDs: %v", clusterIDs)
+	}
+
+	return clusterIDs
+}
+
+// generateClusterID creates a consistent anonymized cluster ID
+// This ensures no cluster names are exposed in the output
+func generateClusterID(clusterName, datacenterName, vcenterUUID string) string {
+	// Combine all identifying info for uniqueness
+	// Include vcenterUUID to avoid collisions across vCenters
+	combined := fmt.Sprintf("%s:%s:%s", vcenterUUID, datacenterName, clusterName)
+	hash := sha256.Sum256([]byte(combined))
+
+	// Return as cluster-{first16hexchars}
+	return fmt.Sprintf("cluster-%x", hash[:8])
+}

--- a/internal/rvtools/datastores.go
+++ b/internal/rvtools/datastores.go
@@ -9,9 +9,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func processDatastoreInfo(rows [][]string, vHostRows [][]string, inventory *api.Inventory) error {
+func processDatastoreInfo(rows [][]string, vHostRows [][]string, inventory *api.Inventory) (map[int]string, error) {
+	datastoreIndexToName := make(map[int]string)
+
 	if len(rows) <= 1 {
-		return nil
+		return datastoreIndexToName, nil
 	}
 
 	headers := rows[0]
@@ -82,11 +84,15 @@ func processDatastoreInfo(rows [][]string, vHostRows [][]string, inventory *api.
 			}
 		}
 
+		// Store the original name before it gets replaced by NAA/path
+		datastoreIndex := len(inventory.Infra.Datastores)
+		datastoreIndexToName[datastoreIndex] = name
+
 		inventory.Infra.Datastores = append(inventory.Infra.Datastores, datastore)
 	}
 
 	zap.S().Named("rvtools").Infof("Processed %d datastores", len(inventory.Infra.Datastores))
-	return nil
+	return datastoreIndexToName, nil
 }
 
 func correlateDatastoreInfo(multipathRows, hbaRows [][]string, inventory *api.Inventory) {

--- a/internal/rvtools/networks.go
+++ b/internal/rvtools/networks.go
@@ -44,7 +44,7 @@ func processNetworkInfo(dvswitchRows [][]string, dvportRows [][]string, inventor
 	}
 
 	vmsPerNetwork := collector.CountVmsByNetwork(vms)
-	networkNameToID := createNetworkNameToIDMap(dvportRows)
+	networkNameToID := createNetworkMappings(dvportRows).NameToID
 
 	for _, network := range networksMap {
 		netEntry := api.Network{

--- a/internal/rvtools/parser_test.go
+++ b/internal/rvtools/parser_test.go
@@ -272,9 +272,9 @@ var _ = Describe("Parser", func() {
 		Context("with invalid Excel data", func() {
 			It("should return error for invalid Excel content", func() {
 				invalidContent := []byte("not an excel file")
-				inventory, err := rvtools.ParseRVTools(context.Background(), invalidContent, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), invalidContent, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(inventory).To(BeNil())
+				Expect(clusteredInv).To(BeNil())
 				Expect(err.Error()).To(ContainSubstring("error opening Excel file"))
 			})
 		})
@@ -282,9 +282,9 @@ var _ = Describe("Parser", func() {
 		Context("with empty Excel data", func() {
 			It("should return error for empty content", func() {
 				emptyContent := []byte{}
-				inventory, err := rvtools.ParseRVTools(context.Background(), emptyContent, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), emptyContent, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(inventory).To(BeNil())
+				Expect(clusteredInv).To(BeNil())
 			})
 		})
 
@@ -292,10 +292,14 @@ var _ = Describe("Parser", func() {
 			It("should handle Excel with empty RVTools sheets", func() {
 				minimalExcel := createMinimalTestExcel()
 
-				inventory, err := rvtools.ParseRVTools(context.Background(), minimalExcel, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), minimalExcel, nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
+				Expect(clusteredInv.VCenter).ToNot(BeNil())
+
+				// Extract VCenter inventory for easier testing
+				inventory := clusteredInv.VCenter
 				Expect(inventory.Infra).ToNot(BeNil())
 
 				By("verifying empty data is handled gracefully")
@@ -319,10 +323,14 @@ var _ = Describe("Parser", func() {
 			})
 
 			It("should successfully parse Excel data with sample content", func() {
-				inventory, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
+				Expect(clusteredInv.VCenter).ToNot(BeNil())
+
+				// Extract VCenter inventory for easier testing
+				inventory := clusteredInv.VCenter
 				Expect(inventory.Infra).ToNot(BeNil())
 
 				By("checking that inventory has basic structure")
@@ -341,10 +349,13 @@ var _ = Describe("Parser", func() {
 			})
 
 			It("should handle Excel data with various sheet types", func() {
-				inventory, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
+
+				// Extract VCenter inventory for easier testing
+				inventory := clusteredInv.VCenter
 
 				By("verifying VMs were processed")
 				if inventory.Vms.Total > 0 {
@@ -390,10 +401,10 @@ concerns contains flag if {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(validator).ToNot(BeNil())
 
-				inventory, err := rvtools.ParseRVTools(context.Background(), testExcelFile, validator)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), testExcelFile, validator)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
 
 				// The validator should have been called but won't find any VMs matching our test policy
 				// The important thing is that it doesn't crash and completes successfully
@@ -401,10 +412,10 @@ concerns contains flag if {
 
 			It("should handle OPA validation errors gracefully", func() {
 				// Test with nil validator first to ensure it doesn't break
-				inventory, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
 
 				// Additional test: Create a validator with invalid policy to test error handling
 				invalidPolicy := `package io.konveyor.forklift.vmware
@@ -420,10 +431,13 @@ invalid syntax here`
 			})
 
 			It("should correlate data between different sheets", func() {
-				inventory, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
+				clusteredInv, err := rvtools.ParseRVTools(context.Background(), testExcelFile, nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(inventory).ToNot(BeNil())
+				Expect(clusteredInv).ToNot(BeNil())
+
+				// Extract VCenter inventory for easier testing
+				inventory := clusteredInv.VCenter
 
 				By("checking for data correlation signs")
 				// Check that VM totals and infrastructure data make sense together
@@ -1012,9 +1026,12 @@ invalid syntax here`
 			validator, err := opa.NewValidator(policies)
 			Expect(err).ToNot(HaveOccurred())
 
-			inventory, err := rvtools.ParseRVTools(context.Background(), excelContent, validator)
+			clusteredInv, err := rvtools.ParseRVTools(context.Background(), excelContent, validator)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(inventory).ToNot(BeNil())
+			Expect(clusteredInv).ToNot(BeNil())
+
+			// Extract VCenter inventory for easier testing
+			inventory := clusteredInv.VCenter
 
 			Expect(inventory.Vms.Total).To(Equal(1))
 			Expect(inventory.Vms.PowerStates).To(HaveKeyWithValue("poweredOn", 1))

--- a/internal/rvtools/vms.go
+++ b/internal/rvtools/vms.go
@@ -28,7 +28,7 @@ func processVMInfo(
 	vNetworkColMap := buildColumnMap(vNetworkHeader)
 
 	hostIPToObjectID := createHostIPToObjectIDMap(vHostRows)
-	networkNameToID := createNetworkNameToIDMap(dvPortRows)
+	networkNameToID := createNetworkMappings(dvPortRows).NameToID
 
 	vmCpuData := groupRowsByVM(vCpuData, vCpuColMap)
 	vmMemoryData := groupRowsByVM(vMemoryData, vMemoryColMap)

--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -129,11 +129,12 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 			return nil, err
 		}
 		tracer.Step("read_rvtools_file").WithInt("file_size", len(content)).Log()
-		rvtoolInventory, err := rvtools.ParseRVTools(ctx, content, as.opaValidator)
+		clusteredInventory, err := rvtools.ParseRVTools(ctx, content, as.opaValidator)
 		if err != nil {
 			return nil, NewErrRVToolsFileCorrupted(fmt.Sprintf("error parsing RVTools file: %v", err))
 		}
-		inventory = *rvtoolInventory
+
+		inventory = *clusteredInventory.VCenter
 		tracer.Step("parsed_rvtools_inventory").Log()
 	}
 


### PR DESCRIPTION
Implements hierarchical inventory structure with per-cluster and vcenter-level
data for RVTools parsing. Extracts reusable filtering logic to common service
package for future vSphere agent reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-cluster inventories with deterministic anonymized cluster IDs and a global vCenter view.
  * Host power-state extraction and per-cluster host power summaries.

* **Refactor**
  * Parser now returns clustered responses and reads additional sheets for cluster-aware processing.
  * Network mappings are bidirectional; datastore indexing/name tracking added for accurate per-cluster datastores.
  * Stable cluster-statistics helpers introduced.

* **Tests**
  * Comprehensive unit tests for cluster filtering, datastores, networks, host power-state aggregation, and updated parser tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->