### PR TITLE
ECOPROJECT-3483 | fix: Clicking on share aggregated data agreement in Agent UI don't have to remove the credentials fields

### DIFF
--- a/agent-ui/js/components/login-form.js
+++ b/agent-ui/js/components/login-form.js
@@ -111,7 +111,7 @@ export default class LoginForm {
                         <div class="pf-v6-c-form__group-control">
                             <div class="pf-v6-c-check ${disabled.elem}">
                                 <input id="checkbox-form-control" class="pf-v6-c-check__input"
-                                    name="isDataSharingAllowed" type="checkbox" aria-invalid="false" data"
+                                    name="isDataSharingAllowed" type="checkbox" aria-invalid="false"
                                     ${disabled.elem}
                                     ${self.props.dataSharingEnabled ? "checked" : ""}>
                                 <label class="pf-v6-c-check__label" for="checkbox-form-control">
@@ -133,8 +133,8 @@ export default class LoginForm {
 
 
         let dataSharingElement = formElement.querySelector("#checkbox-form-control");
-        dataSharingElement.addEventListener("click", () => {
-            self.props.enableDataSharingCallback(dataSharingElement);
+        dataSharingElement.addEventListener("change", (event) => {
+            self.props.enableDataSharingCallback(event.target);
         });
 
         return formElement;

--- a/agent-ui/js/views/form.js
+++ b/agent-ui/js/views/form.js
@@ -52,9 +52,14 @@ export default class FormView extends Observable {
             dataSharingEnabled: self.store.state.dataSharingAccepted,
             disabled: self.store.state.requestPending || self.store.state.formState == FormStates.CredentialsAccepted || self.store.state.formState == FormStates.GatheringInventory,
             enableDataSharingCallback: (elem) => {
-                self.store.dispatch("enableDataSharing", {
-                    enabled: elem.checked
-                });
+                // preserve current form values before state-triggered re-render
+                const credentials = {
+                    url: form.elements['url'].value,
+                    username: form.elements['username'].value,
+                    password: form.elements['password'].value,
+                };
+                self.store.dispatch('formCredentials', credentials);
+                self.store.dispatch("enableDataSharing", { enabled: elem.checked });
             },
             credentials: self.store.state.creds,
             state: self.store.state.formState,


### PR DESCRIPTION
On the OVA flow, after creating the environment, when user clicks on the Waiting for credentials link, and fill the fields in the Migration Discovery VM form, and then click on the share aggregated data agreement checkbox the form has to maintain the values added by the user and don't remove it.

https://github.com/user-attachments/assets/a3f41dae-4a47-48b1-8293-4a1d251b7c27



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data sharing checkbox responsiveness through refined event handling
  * Enhanced credential preservation—user-entered credentials are now properly maintained when enabling data sharing
  * Fixed form markup inconsistencies affecting form validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->