### PR TITLE
ECOPROJECT-3632 | fix: increased job timeout to supprt big files processing

### DIFF
--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -29,6 +30,10 @@ func NewRVToolsWorker(opaValidator *opa.Validator, store store.Store) *RVToolsWo
 		opaValidator: opaValidator,
 		store:        store,
 	}
+}
+
+func (w *RVToolsWorker) Timeout(_ *river.Job[RVToolsJobArgs]) time.Duration {
+	return 10 * time.Minute
 }
 
 // Work processes an RVTools assessment job.


### PR DESCRIPTION
- Introduced a Timeout method to the RVToolsWorker, setting a default job timeout of 10 minutes.

This enhancement improves job management by ensuring that long-running jobs are appropriately timed out, contributing to better resource management and user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented a job execution timeout policy with a 10-minute default limit to prevent jobs from running indefinitely.
  * Expected impact: improves system reliability, reduces resource contention, and provides clearer behavior for long-running tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->