### PR TITLE
remove log entry when cannot unmarshal inventory in stat

### DIFF
--- a/internal/store/model/inventory_stats.go
+++ b/internal/store/model/inventory_stats.go
@@ -69,7 +69,6 @@ func NewInventoryStats(assessments []Assessment) InventoryStats {
 		inventory := &api.Inventory{}
 
 		if err := json.Unmarshal(latesSnapshot.Inventory, &inventory); err != nil {
-			zap.S().Warnw("failed to unmarshal inventory", "error", err)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary warning that appeared during inventory data processing when unmarshalling failed. Processing now quietly continues on such errors, preventing spurious alerts while preserving existing control flow and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->