### PR TITLE
ECOPROJECT-3640 | fix: crash when source has v1 inventory

### DIFF
--- a/internal/handlers/v1alpha1/agent.go
+++ b/internal/handlers/v1alpha1/agent.go
@@ -3,9 +3,11 @@ package v1alpha1
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	v1alpha1 "github.com/kubev2v/migration-planner/api/v1alpha1/agent"
 	agentServer "github.com/kubev2v/migration-planner/internal/api/server/agent"
+	server "github.com/kubev2v/migration-planner/internal/api/server/agent"
 	apiMappers "github.com/kubev2v/migration-planner/internal/handlers/v1alpha1/mappers"
 	"github.com/kubev2v/migration-planner/internal/handlers/validator"
 	"github.com/kubev2v/migration-planner/internal/service"
@@ -54,7 +56,12 @@ func (h *AgentHandler) UpdateSourceInventory(ctx context.Context, request agentS
 		}
 	}
 
-	return agentServer.UpdateSourceInventory200JSONResponse(apiMappers.SourceToApi(*updatedSource)), nil
+	response, err := apiMappers.SourceToApi(*updatedSource)
+	if err != nil {
+		return server.UpdateSourceInventory500JSONResponse{Message: fmt.Sprintf("failed to map source to api: %v", err)}, nil
+	}
+
+	return agentServer.UpdateSourceInventory200JSONResponse(response), nil
 }
 
 // UpdateAgentStatus updates or creates a new agent resource

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -71,7 +71,12 @@ func (s *ServiceHandler) CreateSource(ctx context.Context, request server.Create
 		return server.CreateSource500JSONResponse{Message: fmt.Sprintf("failed to create source: %v", err)}, nil
 	}
 
-	return server.CreateSource201JSONResponse(mappers.SourceToApi(source)), nil
+	response, err := mappers.SourceToApi(source)
+	if err != nil {
+		return server.CreateSource500JSONResponse{Message: fmt.Sprintf("failed to map source to api: %v", err)}, nil
+	}
+
+	return server.CreateSource201JSONResponse(response), nil
 }
 
 // (DELETE /api/v1/sources)
@@ -126,7 +131,12 @@ func (s *ServiceHandler) GetSource(ctx context.Context, request server.GetSource
 		return server.GetSource403JSONResponse{Message: message}, nil
 	}
 
-	return server.GetSource200JSONResponse(mappers.SourceToApi(*source)), nil
+	response, err := mappers.SourceToApi(*source)
+	if err != nil {
+		return server.GetSource500JSONResponse{Message: fmt.Sprintf("failed to map source to api: %v", err)}, nil
+	}
+
+	return server.GetSource200JSONResponse(response), nil
 }
 
 // (PUT /api/v1/sources/{id})
@@ -168,7 +178,12 @@ func (s *ServiceHandler) UpdateSource(ctx context.Context, request server.Update
 		}
 	}
 
-	return server.UpdateSource200JSONResponse(mappers.SourceToApi(*updatedSource)), nil
+	response, err := mappers.SourceToApi(*updatedSource)
+	if err != nil {
+		return server.UpdateSource500JSONResponse{Message: fmt.Sprintf("failed to map source to api: %v", err)}, nil
+	}
+
+	return server.UpdateSource200JSONResponse(response), nil
 }
 
 // (PUT /api/v1/sources/{id}/inventory)
@@ -213,7 +228,12 @@ func (s *ServiceHandler) UpdateInventory(ctx context.Context, request server.Upd
 		}
 	}
 
-	return server.UpdateInventory200JSONResponse(mappers.SourceToApi(updatedSource)), nil
+	response, err := mappers.SourceToApi(updatedSource)
+	if err != nil {
+		return server.UpdateInventory500JSONResponse{Message: fmt.Sprintf("failed to map source to api: %v", err)}, nil
+	}
+
+	return server.UpdateInventory200JSONResponse(response), nil
 }
 
 // (HEAD /api/v1/sources/{id}/image)

--- a/internal/store/assessment.go
+++ b/internal/store/assessment.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/kubev2v/migration-planner/internal/store/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+
+	"github.com/kubev2v/migration-planner/internal/store/model"
+	"github.com/kubev2v/migration-planner/internal/util"
 )
 
 type Assessment interface {
@@ -78,7 +80,7 @@ func (a *AssessmentStore) Create(ctx context.Context, assessment model.Assessmen
 	snapshot := model.Snapshot{
 		AssessmentID: assessment.ID,
 		Inventory:    inventory,
-		Version:      model.SnapshotVersionV2,
+		Version:      uint(util.GetInventoryVersion(inventory)),
 	}
 
 	if err := a.getDB(ctx).Create(&snapshot).Error; err != nil {
@@ -105,11 +107,10 @@ func (a *AssessmentStore) Update(ctx context.Context, assessmentID uuid.UUID, na
 	}
 
 	if inventory != nil {
-		// Create a new snapshot
 		snapshot := model.Snapshot{
 			AssessmentID: assessmentID,
 			Inventory:    inventory,
-			Version:      model.SnapshotVersionV2,
+			Version:      uint(util.GetInventoryVersion(inventory)),
 		}
 
 		if err := a.getDB(ctx).Create(&snapshot).Error; err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/kubev2v/migration-planner/internal/store/model"
 )
 
 type StringerWithError func() (string, error)
@@ -140,4 +143,16 @@ func GBToTB[T ~int | ~int64 | ~float64](gb T) float64 {
 // Accepts int, int32, or float64.
 func MBToGB[T ~int | ~int32 | ~float64](mb T) int {
 	return int(math.Round(float64(mb) / 1024.0))
+}
+
+// Unmarshal does not return error when v1 inventory is unmarshal into a v2 struct.
+// The only way to differentiate the version is to check the internal structure.
+func GetInventoryVersion(inventory []byte) int {
+	i := v1alpha1.Inventory{}
+	_ = json.Unmarshal(inventory, &i)
+
+	if i.VcenterId == "" {
+		return model.SnapshotVersionV1
+	}
+	return model.SnapshotVersionV2
 }


### PR DESCRIPTION
Fixes two issues with old sources:

- create an assessment from sources with v1 inventory
- return v2 inventory from sources with v1 inventory