### PR TITLE
NO-JIRA | ci: use team-based code review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @machacekondra @tupyy @nirarg @ronenav @Jos-Jerus
+*       @kubev2v/migration-planner-reviewers


### PR DESCRIPTION
Replace individual reviewers with team reference
to enable random assignment of 2 reviewers per PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration.

---

**Note:** This change is purely administrative and does not impact end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->