### PR TITLE
NO-JIRA | docs: include necessary dependencies

### DIFF
--- a/doc/run-locally.md
+++ b/doc/run-locally.md
@@ -9,6 +9,8 @@ This guide provides instructions for setting up and running the OpenShift Migrat
 - Docker or Podman
 - Git
 
+Additional system packages (Fedora / RHEL): `gcc-c++`, `libstdc++-devel`, `podman-compose`
+
 ## Clone the repository
 
 ```bash


### PR DESCRIPTION
In the process of following the `run-locally` doc, the following dependencies are required and they should be stated in the prerequisites section.