### PR TITLE
NO-JIRA | docs: fix typos in permissions doc

### DIFF
--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -1,6 +1,6 @@
 # Minimum permissions for the agent account
 
-The **agent** only gathers information from vCenter, therefore a **read only** permission whould be enough. 
+The **agent** only gathers information from vCenter, therefore a **read only** permission should be enough. 
 
 One such role is the [Read Only Role](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-93B962A7-93FA-4E96-B68F-AE66D3D6C663.html).
 


### PR DESCRIPTION
## What

Renamed `doc/permssions.md` to `doc/permissions.md` (typo in the filename) and fixed a small typo inside the document: "whould" was corrected to "should".

## Why

The misspelled filename makes the doc harder to find when searching for "permissions" in the codebase. Also took the chance to fix a minor wording issue while at it.

## Scope

Documentation only, no functional changes.