### PR TITLE
ECOPROJECT-4339 | fix: handled invalid schema error

### DIFF
--- a/internal/handlers/v1alpha1/estimation.go
+++ b/internal/handlers/v1alpha1/estimation.go
@@ -150,7 +150,12 @@ func (h *ServiceHandler) CalculateMigrationEstimationByComplexity(ctx context.Co
 		schemaResults, err := h.estimationSrv.RunEstimation(schemas, bucketParams)
 		if err != nil {
 			logger.Error(err).Log()
-			return server.CalculateMigrationEstimationByComplexity500JSONResponse{Message: "failed to run estimation"}, nil
+			switch err.(type) {
+			case *service.ErrInvalidSchema:
+				return server.CalculateMigrationEstimationByComplexity400JSONResponse{Message: err.Error()}, nil
+			default:
+				return server.CalculateMigrationEstimationByComplexity500JSONResponse{Message: "failed to run estimation"}, nil
+			}
 		}
 		bucketEstimations[bucket.Score] = make(map[string]*service.MigrationAssessmentResult, len(schemaResults))
 		for schema, r := range schemaResults {


### PR DESCRIPTION
return a http 400 invalid schema error, if request contains an invalid estimation schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for migration estimations: requests with invalid schema now return a 400 response with the validation error message; other estimation failures continue to return a 500 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->