### PR TITLE
NO-JIRA | test: Log the error if it occurs

### DIFF
--- a/test/e2e/e2e_rvtools_test.go
+++ b/test/e2e/e2e_rvtools_test.go
@@ -248,15 +248,14 @@ var _ = Describe("e2e-rvtools", func() {
 					<-done
 				}
 
-				successCount := 0
-				for i, err := range errors {
-					if err == nil && assessments[i] != nil {
-						successCount++
-
-						_ = svc.RemoveAssessment(assessments[i].Id)
-					}
+				for _, err := range errors {
+					Expect(err).To(BeNil())
 				}
-				Expect(successCount).To(BeNumerically("==", 3))
+
+				for _, a := range assessments {
+					err = svc.RemoveAssessment(a.Id)
+					Expect(err).To(BeNil())
+				}
 
 				zap.S().Infof("============Successfully Passed: %s=====", CurrentSpecReport().LeafNodeText)
 			})


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>

Sometimes one of the rvtools e2e test is failing: https://github.com/kubev2v/migration-planner/actions/runs/24300590741/job/70953156071

I want to understand the reason. The assert should now log the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified concurrent uploads test validation logic for improved clarity and maintainability.
  * Enhanced error assertion and cleanup procedures in post-test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->