### PR TITLE
NO-JIRA | chore: Add dependabot to validation skip list and chore commit type

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -32,6 +32,7 @@ jobs:
           # * red-hat-konflux[bot] - automatic bot responsible for any library or konflux integration update
           declare -a skip_pr_authors=(
             "red-hat-konflux[bot]"
+            "dependabot[bot]"
           )
           echo "The PR Author is \"${PR_AUTHOR}\""
           for skip_pr_author in "${skip_pr_authors[@]}"
@@ -42,7 +43,7 @@ jobs:
             fi
           done
 
-          VALID_TYPES="fix|feat|build|ci|docs|perf|refactor|style|test"
+          VALID_TYPES="fix|feat|build|chore|ci|docs|perf|refactor|style|test"
           PATTERN="^(NO-JIRA|[A-Z]+-[0-9]+) \| ($VALID_TYPES): .+"
           
           for message in "${commit_messages[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ The commit contains the following structural types, to communicate your intent:
 * **fix:** A commit of the type `fix` patches a bug in your codebase (this correlates with `PATCH` in Semantic Versioning).
 * **feat:** A commit of the type `feat` introduces a new feature to the codebase (this correlates with `MINOR` in Semantic Versioning).
 * **build:** Changes that affect the build system or external dependencies
+* **chore:** Routine tasks, maintenance, or minor changes that don't modify source or test files
 * **ci:** Changes to our CI configuration files and scripts
 * **docs:** Documentation-only changes
 * **perf:** A code change that improves performance


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal commit validation workflow to support additional commit types and bot accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->