### PR TITLE
ECOPROJECT-4358 | fix: memory usage improvement. Better to save the RVTools file first and then read it from memory when needed.

### DIFF
--- a/internal/handlers/v1alpha1/job.go
+++ b/internal/handlers/v1alpha1/job.go
@@ -1,11 +1,11 @@
 package v1alpha1
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"mime/multipart"
+	"os"
 
 	"github.com/kubev2v/migration-planner/internal/api/server"
 	"github.com/kubev2v/migration-planner/internal/auth"
@@ -32,7 +32,18 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 
 	// Parse multipart form data
 	var name string
-	var fileContent []byte
+	// Write file content to temp file for DuckDB ingestion
+	tempFile, err := os.CreateTemp("", "rvtools-*.xlsx")
+	if err != nil {
+		return server.CreateRVToolsAssessment500JSONResponse{Message: fmt.Sprintf("error saving rvtool: %v", err)}, nil
+	}
+	cleanupTempFile := true
+	defer func() {
+		_ = tempFile.Close()
+		if cleanupTempFile {
+			_ = os.Remove(tempFile.Name())
+		}
+	}()
 
 	// Helper to process a single part with deferred cleanup
 	processPart := func(part *multipart.Part) error {
@@ -46,15 +57,13 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 			}
 			name = string(nameBytes)
 		case "file":
-			buff := bytes.NewBuffer([]byte{})
-			n, err := io.Copy(buff, part)
+			n, err := io.Copy(tempFile, part)
 			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
+				return fmt.Errorf("failed to write file: %w", err)
 			}
 			if n == 0 {
 				return fmt.Errorf("rvtools file is empty")
 			}
-			fileContent = buff.Bytes()
 		}
 		return nil
 	}
@@ -79,25 +88,25 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 		logger.Error(err).WithString("step", "validation").Log()
 		return server.CreateRVToolsAssessment400JSONResponse{Message: err.Error()}, nil
 	}
-	if len(fileContent) == 0 {
-		logger.Error(fmt.Errorf("file is required")).Log()
-		return server.CreateRVToolsAssessment400JSONResponse{Message: "file is required"}, nil
+
+	_, err = tempFile.Seek(0, io.SeekStart)
+	if err != nil {
+		return server.CreateRVToolsAssessment500JSONResponse{Message: fmt.Sprintf("failed to seek file: %v", err)}, nil
 	}
-	if err := validator.ValidateXLSXMagicBytes(fileContent); err != nil {
+
+	if err := validator.ValidateXLSXMagicBytes(tempFile); err != nil {
 		logger.Error(err).WithString("step", "validation").Log()
 		return server.CreateRVToolsAssessment400JSONResponse{Message: err.Error()}, nil
 	}
 
-	logger.Step("file_read").WithInt("file_size", len(fileContent)).Log()
-
 	// Create job args
 	jobArgs := jobs.RVToolsJobArgs{
-		Name:        name,
-		FileContent: fileContent,
-		OrgID:       user.Organization,
-		Username:    user.Username,
-		FirstName:   user.FirstName,
-		LastName:    user.LastName,
+		Name:            name,
+		RvtoolsFilePath: tempFile.Name(),
+		OrgID:           user.Organization,
+		Username:        user.Username,
+		FirstName:       user.FirstName,
+		LastName:        user.LastName,
 	}
 
 	// Create the job
@@ -106,6 +115,8 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 		logger.Error(err).Log()
 		return server.CreateRVToolsAssessment500JSONResponse{Message: fmt.Sprintf("failed to create job: %v", err)}, nil
 	}
+
+	cleanupTempFile = false
 
 	logger.Success().WithParam("job_id", job.Id).Log()
 

--- a/internal/handlers/validator/custom.go
+++ b/internal/handlers/validator/custom.go
@@ -5,6 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,10 +52,18 @@ func ValidateName(name string) error {
 
 // ValidateXLSXMagicBytes checks if the file starts with ZIP magic bytes.
 // XLSX files are ZIP archives, so this is a fast preliminary check.
-func ValidateXLSXMagicBytes(data []byte) error {
-	if len(data) < 4 || !bytes.Equal(data[:4], xlsxMagicBytes) {
+func ValidateXLSXMagicBytes(r io.ReadSeeker) error {
+	header := make([]byte, 4)
+
+	_, err := r.Read(header)
+	if err != nil {
+		return fmt.Errorf("failed to read file header: %w", err)
+	}
+
+	if !bytes.Equal(header, xlsxMagicBytes) {
 		return NewErrInvalidFile("file is not a valid Excel file")
 	}
+
 	return nil
 }
 

--- a/internal/rvtools/jobs/types.go
+++ b/internal/rvtools/jobs/types.go
@@ -7,12 +7,12 @@ import (
 // RVToolsJobArgs contains the arguments for an RVTools assessment job.
 // This is stored in river_job.args as JSON.
 type RVToolsJobArgs struct {
-	Name        string `json:"name"`
-	FileContent []byte `json:"file_content"`
-	OrgID       string `json:"org_id"`
-	Username    string `json:"username"`
-	FirstName   string `json:"first_name"`
-	LastName    string `json:"last_name"`
+	Name            string `json:"name"`
+	RvtoolsFilePath string `json:"file_path"`
+	OrgID           string `json:"org_id"`
+	Username        string `json:"username"`
+	FirstName       string `json:"first_name"`
+	LastName        string `json:"last_name"`
 }
 
 // Kind returns the job kind for River registration.

--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -79,6 +79,10 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 
 	logger.Step("job_started").Log()
 
+	defer func() {
+		_ = os.Remove(job.Args.RvtoolsFilePath)
+	}()
+
 	// Create per-job DuckDB instance for isolation
 	parser, duckDB, err := w.createParser()
 	if err != nil {
@@ -86,27 +90,13 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 	}
 	defer func() { _ = duckDB.Close() }()
 
-	// Write file content to temp file for DuckDB ingestion
-	tempFile, err := os.CreateTemp("", "rvtools-*.xlsx")
-	if err != nil {
-		return w.failJob(ctx, logger, job.ID, "create_temp_file", err, fmt.Sprintf("failed to create temp file: %v", err))
-	}
-	tempFilePath := tempFile.Name()
-	defer func() { _ = os.Remove(tempFilePath) }()
-
-	if _, err := tempFile.Write(job.Args.FileContent); err != nil {
-		_ = tempFile.Close()
-		return w.failJob(ctx, logger, job.ID, "write_temp_file", err, fmt.Sprintf("failed to write temp file: %v", err))
-	}
-	_ = tempFile.Close()
-
 	// Update status to validating before ingestion (which includes OPA validation)
 	if err := w.updateJobStatus(ctx, job.ID, model.JobStatusValidating, "", nil); err != nil {
 		logger.Error(err).WithString("step", "update_validating_status").Log()
 	}
 
 	// Ingest RVTools file using duckdb_parser
-	validationResult, err := parser.IngestRvTools(ctx, tempFilePath)
+	validationResult, err := parser.IngestRvTools(ctx, job.Args.RvtoolsFilePath)
 	if err != nil {
 		return w.failJob(ctx, logger, job.ID, "ingest_rvtools", err, fmt.Sprintf("error ingesting RVTools file: %v", err))
 	}


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Stream uploaded RVTools files to disk instead of buffering in memory to reduce memory use and improve processing reliability.
* **Bug Fixes**
  * More robust XLSX validation and clearer error responses when uploads or validation fail.
  * Temporary files are now managed and removed reliably after processing to avoid lingering artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->