### PR TITLE
NO-JIRA | fix: removing size header

### DIFF
--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -84,16 +83,9 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 		return imageServer.GetImageByToken500JSONResponse{}, nil
 	}
 
-	// Get image size
-	size, err := imageBuilder.Size()
-	if err != nil {
-		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to read image size %s", err)}, nil
-	}
-
 	// Set proper headers of the OVA file:
 	writer.Header().Set("Content-Type", "application/ovf")
 	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", req.Name))
-	writer.Header().Set("Content-Length", strconv.FormatUint(size, 10))
 
 	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified image download handler by removing runtime size computation and Content-Length header generation during image retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->