### PR TITLE
Revert "NO-JIRA | fix: removing size header"

### DIFF
--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -83,9 +84,16 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 		return imageServer.GetImageByToken500JSONResponse{}, nil
 	}
 
+	// Get image size
+	size, err := imageBuilder.Size()
+	if err != nil {
+		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to read image size %s", err)}, nil
+	}
+
 	// Set proper headers of the OVA file:
 	writer.Header().Set("Content-Type", "application/ovf")
 	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", req.Name))
+	writer.Header().Set("Content-Length", strconv.FormatUint(size, 10))
 
 	err = imageBuilder.Generate(ctx, writer)
 	if err != nil {


### PR DESCRIPTION
Reverts kubev2v/migration-planner#1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling when retrieving images; now properly reports failures in size computation.
  
* **Improvements**
  * Enhanced HTTP response headers for image downloads to better support client-side progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->