### PR TITLE
ECOPROJECT-4358 | feat: Upload RVTools files to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ PKG_MANAGER ?= apt
 SIZER_IMAGE ?= quay.io/redhat-user-workloads/odf-sizer-lib-tenant/sizer
 SIZER_IMAGE_TAG ?= latest
 SIZER_PORT ?= 9200
+MINIO_IMAGE ?= quay.io/minio/minio
+MINIO_IMAGE_TAG ?= latest
+MINIO_API_PORT ?= 9000
+MINIO_CONSOLE_PORT ?= 9001
+MINIO_ROOT_USER ?= admin
+MINIO_ROOT_PASSWORD ?= password
 
 # OPA Configuration for eval mode
 MIGRATION_PLANNER_OPA_POLICIES_FOLDER ?= $(CURDIR)/policies
@@ -54,14 +60,15 @@ help:
 	@echo "    run:                    run the service for development"
 	@echo "    setup-opa-policies:     download OPA policies from Forklift project"
 	@echo "    clean-opa-policies:     clean OPA policies directory"
-	@echo "    generate:        regenerate all generated files"
-	@echo "    tidy:            tidy go mod"
-	@echo "    lint:            run golangci-lint"
-	@echo "    build:           run all builds"
-	@echo "    clean:           clean up all containers and volumes"
-	@echo "    migrate:         run database migrations"
-	@echo "    run:             run the OpenShift Migration Advisor API service"
-	@echo "    integration-test: run e2e integration tests"
+	@echo "    generate:        	   regenerate all generated files"
+	@echo "    tidy:                   tidy go mod"
+	@echo "    lint:                   run golangci-lint"
+	@echo "    build:                  run all builds"
+	@echo "    clean:                  clean up all containers and volumes"
+	@echo "    migrate:                run database migrations"
+	@echo "    run:                    run the OpenShift Migration Advisor API service"
+	@echo "    integration-test:       run e2e integration tests"
+	@echo "    minio:                  run local MinIO (S3-compatible; default creds match MIGRATION_PLANNER_S3_*)"
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 OC_VERSION ?= 4.17.9
@@ -91,7 +98,7 @@ AIR := $(GOBIN)/air
 $(AIR):
 	@go install github.com/air-verse/air@v1.63.4
 
-run: $(AIR) image
+run: $(AIR) image minio
 	MIGRATION_PLANNER_MIGRATIONS_FOLDER=$(CURDIR)/pkg/migrations/sql \
 	MIGRATION_PLANNER_OPA_POLICIES_FOLDER=$(MIGRATION_PLANNER_OPA_POLICIES_FOLDER) \
 	$(AIR) --build.cmd "make build" --build.bin "./bin/planner-api" --build.args_bin "run" --build.include_dir "cmd,internal,pkg,api"
@@ -127,6 +134,18 @@ run-sizer:
 	@echo "   Health: http://localhost:$(SIZER_PORT)/health"
 	@echo "   API:    http://localhost:$(SIZER_PORT)/api/v1/size/custom"
 
+minio:
+	@echo "🚀 Starting MinIO (S3 API :$(MINIO_API_PORT), console :$(MINIO_CONSOLE_PORT))..."
+	@$(PODMAN) rm -f migration-planner-minio-local 2>/dev/null || true
+	@$(PODMAN) run -d --name migration-planner-minio-local \
+		-p $(MINIO_API_PORT):9000 \
+		-p $(MINIO_CONSOLE_PORT):9001 \
+		-e MINIO_ROOT_USER=$(MINIO_ROOT_USER) \
+		-e MINIO_ROOT_PASSWORD=$(MINIO_ROOT_PASSWORD) \
+		$(MINIO_IMAGE):$(MINIO_IMAGE_TAG) \
+		server /data --console-address ":9001"
+	@echo "✅ MinIO running at http://localhost:$(MINIO_API_PORT) (console: http://localhost:$(MINIO_CONSOLE_PORT))"
+	@echo "   Root user: $(MINIO_ROOT_USER)  Root password: $(MINIO_ROOT_PASSWORD)"
 
 image:
 ifeq ($(DOWNLOAD_RHCOS), true)
@@ -256,6 +275,8 @@ deploy-on-kind: oc
 		| oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	oc process --local -f  deploy/templates/postgres-template.yml | oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	oc process --local -f deploy/templates/s3-secret-template.yml | oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
+	oc process --local -f deploy/templates/minio-template.yml | oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
+	oc wait --for=condition=available deployment/migration-planner-minio --timeout=120s -n "${MIGRATION_PLANNER_NAMESPACE}"; \
 	oc process --local -f deploy/templates/service-template.yml \
 	   -p SERVICE_API_PATH=$(SERVICE_API_PATH) \
 	   -p MIGRATION_PLANNER_URL=http://$${inet_ip}:7443$(SERVICE_API_PATH) \
@@ -269,6 +290,7 @@ deploy-on-kind: oc
 	   -p INSECURE_REGISTRY=$(INSECURE_REGISTRY) \
 	   -p MIGRATION_PLANNER_AUTH=$(MIGRATION_PLANNER_AUTH) \
 	   -p RHCOS_PASSWORD=${RHCOS_PASSWORD} \
+	   -p MIGRATION_PLANNER_S3_ENDPOINT=migration-planner-minio:9000 \
 	   | oc apply -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	echo "*** OpenShift Migration Advisor has been deployed successfully on Kind ***"
 
@@ -291,6 +313,7 @@ delete-from-kind: oc
 		-p E2E_PRIVATE_KEY_BASE64=$(shell base64 -w 0 $(E2E_PRIVATE_KEY_FOLDER_PATH)/private-key) \
 		| oc delete -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 	oc process --local -f deploy/templates/s3-secret-template.yml | oc delete -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
+	oc process --local -f deploy/templates/minio-template.yml | oc delete -n "${MIGRATION_PLANNER_NAMESPACE}" -f -; \
 
 deploy-local-obs:
 	@podman play kube --network host deploy/observability.yml
@@ -415,7 +438,7 @@ test-agent-v2: submodules
 	@echo "✅ All agent-v2 Unit tests passed successfully."
 
 # Full unit test cycle: build, prepare DB, run tests, and clean up
-unit-test: build kill-db deploy-db migrate test test-agent-v2 kill-db
+unit-test: build kill-db deploy-db migrate minio test test-agent-v2 kill-db
 
 # Run integration tests using ginkgo
 integration-test: $(GINKGO)
@@ -454,7 +477,7 @@ clean-opa-policies:
 	@echo "Cleaning OPA policies..."
 	@rm -rf $(MIGRATION_PLANNER_OPA_POLICIES_FOLDER)
 
-.PHONY: run-sizer
+.PHONY: run-sizer minio
 
 # include the deployment targets
 include deploy/deploy.mk

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+
 	"github.com/kubev2v/migration-planner/pkg/opa"
 
 	"github.com/kubev2v/migration-planner/internal/api_server/agentserver"
@@ -109,6 +112,10 @@ var runCmd = &cobra.Command{
 			}
 		}()
 
+		if err := ensureRvtoolsBucket(ctx, cfg.S3); err != nil {
+			zap.S().Fatalw("Error with Rvtools S3 bucket", "error", err)
+		}
+
 		// register metrics
 		metrics.RegisterMetrics(store)
 
@@ -153,6 +160,30 @@ func ensureIsoExist(path string) error {
 		}
 		return err
 	}
+	return nil
+}
+
+func ensureRvtoolsBucket(ctx context.Context, s3 *config.S3) error {
+	client, err := minio.New(s3.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(s3.AccessKey, s3.SecretKey, ""),
+		Secure: false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create s3 client: %w", err)
+	}
+
+	exists, err := client.BucketExists(ctx, s3.RvtoolsBucket)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		err = client.MakeBucket(ctx, s3.RvtoolsBucket, minio.MakeBucketOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/deploy/templates/minio-template.yml
+++ b/deploy/templates/minio-template.yml
@@ -1,0 +1,87 @@
+---
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: migration-planner-minio
+parameters:
+  - name: MINIO_IMAGE
+    description: MinIO container image
+    value: quay.io/minio/minio
+  - name: MINIO_IMAGE_TAG
+    description: MinIO image tag
+    value: latest
+  - name: MINIO_ROOT_USER
+    description: MinIO root user (S3 access key)
+    value: admin
+  - name: MINIO_ROOT_PASSWORD
+    description: MinIO root password (S3 secret key)
+    value: password
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: migration-planner-minio
+      labels:
+        app: migration-planner-minio
+    spec:
+      ports:
+        - name: api
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+      selector:
+        app: migration-planner-minio
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: migration-planner-minio
+      labels:
+        app: migration-planner-minio
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: migration-planner-minio
+      template:
+        metadata:
+          labels:
+            app: migration-planner-minio
+        spec:
+          containers:
+            - name: minio
+              image: ${MINIO_IMAGE}:${MINIO_IMAGE_TAG}
+              imagePullPolicy: IfNotPresent
+              args:
+                - server
+                - /data
+              env:
+                - name: MINIO_ROOT_USER
+                  value: ${MINIO_ROOT_USER}
+                - name: MINIO_ROOT_PASSWORD
+                  value: ${MINIO_ROOT_PASSWORD}
+              ports:
+                - containerPort: 9000
+                  name: api
+              readinessProbe:
+                tcpSocket:
+                  port: 9000
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              livenessProbe:
+                tcpSocket:
+                  port: 9000
+                initialDelaySeconds: 10
+                periodSeconds: 20
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -116,6 +116,14 @@ parameters:
   - name: SIZER_IMAGE_PULL_POLICY
     description: Image pull policy for the sizer service
     value: Always
+  - name: MIGRATION_PLANNER_S3_ENDPOINT
+    description: S3-compatible API endpoint host:port (in-cluster service for Kind)
+  - name: MIGRATION_PLANNER_S3_BUCKET
+    description: Bucket for RVTools objects
+  - name: MIGRATION_PLANNER_S3_ACCESS_KEY
+    description: S3 access key
+  - name: MIGRATION_PLANNER_S3_SECRET_KEY
+    description: S3 secret key
 
 objects:
   - kind: ServiceAccount
@@ -639,6 +647,15 @@ objects:
                     secretKeyRef:
                       name: ${DB_SECRET_NAME}
                       key: db.user
+                # S3 / MinIO
+                - name: MIGRATION_PLANNER_S3_ENDPOINT
+                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
+                - name: MIGRATION_PLANNER_S3_BUCKET
+                  value: ${MIGRATION_PLANNER_S3_BUCKET}
+                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
+                  value: ${MIGRATION_PLANNER_S3_ACCESS_KEY}
+                - name: MIGRATION_PLANNER_S3_SECRET_KEY
+                  value: ${MIGRATION_PLANNER_S3_SECRET_KEY}
               volumeMounts:
                 - name: migration-planner-dir
                   mountPath: "/.migration-planner"

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -194,7 +194,7 @@ func (s *Server) Run(ctx context.Context) error {
 		service.NewEstimationService(s.store),
 		accountsSvc,
 		partnerSvc,
-	)
+	).WithS3Cfg(s.cfg.S3)
 	server.HandlerFromMux(server.NewStrictHandler(h, nil), router)
 	srv := http.Server{Addr: s.cfg.Service.Address, Handler: router}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ var singleConfig *Config = nil
 type Config struct {
 	Database *dbConfig
 	Service  *svcConfig
+	S3       *S3
 }
 
 type dbConfig struct {
@@ -33,6 +34,13 @@ type svcConfig struct {
 	OpaPoliciesFolder    string `envconfig:"MIGRATION_PLANNER_OPA_POLICIES_FOLDER" default:"/app/policies"`
 	IsoPath              string `envconfig:"MIGRATION_PLANNER_ISO_PATH" default:"rhcos-live-iso.x86_64.iso"`
 	Sizer                Sizer
+}
+
+type S3 struct {
+	Endpoint      string `envconfig:"MIGRATION_PLANNER_S3_ENDPOINT" default:"localhost:9000"`
+	RvtoolsBucket string `envconfig:"MIGRATION_PLANNER_S3_BUCKET" default:"rvtools"`
+	AccessKey     string `envconfig:"MIGRATION_PLANNER_S3_ACCESS_KEY" default:"admin"`
+	SecretKey     string `envconfig:"MIGRATION_PLANNER_S3_SECRET_KEY" default:"password"`
 }
 
 type Auth struct {

--- a/internal/handlers/v1alpha1/job.go
+++ b/internal/handlers/v1alpha1/job.go
@@ -7,6 +7,10 @@ import (
 	"io"
 	"mime/multipart"
 
+	"github.com/google/uuid"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+
 	"github.com/kubev2v/migration-planner/internal/api/server"
 	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/handlers/validator"
@@ -32,7 +36,7 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 
 	// Parse multipart form data
 	var name string
-	var fileContent []byte
+	var objectName string
 
 	// Helper to process a single part with deferred cleanup
 	processPart := func(part *multipart.Part) error {
@@ -45,16 +49,49 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 				return fmt.Errorf("failed to read name: %w", err)
 			}
 			name = string(nameBytes)
+			if err := validator.ValidateName(name); err != nil {
+				return err
+			}
 		case "file":
-			buff := bytes.NewBuffer([]byte{})
-			n, err := io.Copy(buff, part)
+			header := make([]byte, 4)
+
+			// read first 4 bytes from the stream
+			n, err := io.ReadFull(part, header)
 			if err != nil {
 				return fmt.Errorf("failed to read file: %w", err)
 			}
+
 			if n == 0 {
 				return fmt.Errorf("rvtools file is empty")
 			}
-			fileContent = buff.Bytes()
+
+			if err := validator.ValidateXLSXMagicBytes(header); err != nil {
+				return fmt.Errorf("invalid file format")
+			}
+
+			client, err := minio.New(h.S3.Endpoint, &minio.Options{
+				Creds:  credentials.NewStaticV4(h.S3.AccessKey, h.S3.SecretKey, ""),
+				Secure: false,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create s3 client: %w", err)
+			}
+
+			objectName = fmt.Sprintf("rvtool-%s.xlsx", uuid.New().String())
+
+			_, err = client.PutObject(
+				ctx,
+				h.S3.RvtoolsBucket,
+				objectName,
+				io.MultiReader(bytes.NewReader(header), part),
+				-1,
+				minio.PutObjectOptions{
+					ContentType: "application/octet-stream",
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to upload to minio: %w", err)
+			}
 		}
 		return nil
 	}
@@ -75,29 +112,14 @@ func (h *ServiceHandler) CreateRVToolsAssessment(ctx context.Context, request se
 		}
 	}
 
-	if err := validator.ValidateName(name); err != nil {
-		logger.Error(err).WithString("step", "validation").Log()
-		return server.CreateRVToolsAssessment400JSONResponse{Message: err.Error()}, nil
-	}
-	if len(fileContent) == 0 {
-		logger.Error(fmt.Errorf("file is required")).Log()
-		return server.CreateRVToolsAssessment400JSONResponse{Message: "file is required"}, nil
-	}
-	if err := validator.ValidateXLSXMagicBytes(fileContent); err != nil {
-		logger.Error(err).WithString("step", "validation").Log()
-		return server.CreateRVToolsAssessment400JSONResponse{Message: err.Error()}, nil
-	}
-
-	logger.Step("file_read").WithInt("file_size", len(fileContent)).Log()
-
 	// Create job args
 	jobArgs := jobs.RVToolsJobArgs{
-		Name:        name,
-		FileContent: fileContent,
-		OrgID:       user.Organization,
-		Username:    user.Username,
-		FirstName:   user.FirstName,
-		LastName:    user.LastName,
+		Name:              name,
+		S3RvtoolsFileName: objectName,
+		OrgID:             user.Organization,
+		Username:          user.Username,
+		FirstName:         user.FirstName,
+		LastName:          user.LastName,
 	}
 
 	// Create the job

--- a/internal/handlers/v1alpha1/service_handler.go
+++ b/internal/handlers/v1alpha1/service_handler.go
@@ -1,0 +1,42 @@
+package v1alpha1
+
+import (
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/internal/service"
+)
+
+type ServiceHandler struct {
+	sourceSrv     *service.SourceService
+	assessmentSrv service.AssessmentServicer
+	jobSrv        *service.JobService
+	sizerSrv      *service.SizerService
+	estimationSrv *service.EstimationService
+	accountsSrv   *service.AccountsService
+	partnerSrv    service.PartnerServicer
+	S3            *config.S3
+}
+
+func NewServiceHandler(
+	sourceService *service.SourceService,
+	a service.AssessmentServicer,
+	j *service.JobService,
+	sizer *service.SizerService,
+	estimation *service.EstimationService,
+	accounts *service.AccountsService,
+	partner service.PartnerServicer,
+) *ServiceHandler {
+	return &ServiceHandler{
+		sourceSrv:     sourceService,
+		assessmentSrv: a,
+		jobSrv:        j,
+		sizerSrv:      sizer,
+		estimationSrv: estimation,
+		accountsSrv:   accounts,
+		partnerSrv:    partner,
+	}
+}
+
+func (s *ServiceHandler) WithS3Cfg(cfg *config.S3) *ServiceHandler {
+	s.S3 = cfg
+	return s
+}

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -15,36 +15,6 @@ import (
 	srvMappers "github.com/kubev2v/migration-planner/internal/service/mappers"
 )
 
-type ServiceHandler struct {
-	sourceSrv     *service.SourceService
-	assessmentSrv service.AssessmentServicer
-	jobSrv        *service.JobService
-	sizerSrv      *service.SizerService
-	estimationSrv *service.EstimationService
-	accountsSrv   *service.AccountsService
-	partnerSrv    service.PartnerServicer
-}
-
-func NewServiceHandler(
-	sourceService *service.SourceService,
-	a service.AssessmentServicer,
-	j *service.JobService,
-	sizer *service.SizerService,
-	estimation *service.EstimationService,
-	accounts *service.AccountsService,
-	partner service.PartnerServicer,
-) *ServiceHandler {
-	return &ServiceHandler{
-		sourceSrv:     sourceService,
-		assessmentSrv: a,
-		jobSrv:        j,
-		sizerSrv:      sizer,
-		estimationSrv: estimation,
-		accountsSrv:   accounts,
-		partnerSrv:    partner,
-	}
-}
-
 // validateSourceData validates the source data using the source validation rules
 func validateSourceData(data interface{}) error {
 	v := validator.NewValidator()

--- a/internal/rvtools/jobs/client.go
+++ b/internal/rvtools/jobs/client.go
@@ -31,7 +31,7 @@ func NewClient(ctx context.Context, cfg *config.Config, s store.Store, opaValida
 
 	// Create worker with store and OPA validator (each job creates its own DuckDB instance)
 	// opa.Validator now directly implements duckdb_parser.Validator
-	worker := NewRVToolsWorker(s, opaValidator)
+	worker := NewRVToolsWorker(s, opaValidator, cfg.S3)
 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, worker)

--- a/internal/rvtools/jobs/types.go
+++ b/internal/rvtools/jobs/types.go
@@ -7,12 +7,12 @@ import (
 // RVToolsJobArgs contains the arguments for an RVTools assessment job.
 // This is stored in river_job.args as JSON.
 type RVToolsJobArgs struct {
-	Name        string `json:"name"`
-	FileContent []byte `json:"file_content"`
-	OrgID       string `json:"org_id"`
-	Username    string `json:"username"`
-	FirstName   string `json:"first_name"`
-	LastName    string `json:"last_name"`
+	Name              string `json:"name"`
+	S3RvtoolsFileName string `json:"file_url"`
+	OrgID             string `json:"org_id"`
+	Username          string `json:"username"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
 }
 
 // Kind returns the job kind for River registration.

--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -6,8 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
+
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 
 	"github.com/google/uuid"
 	_ "github.com/marcboeker/go-duckdb/v2" // DuckDB driver
@@ -25,13 +30,15 @@ type RVToolsWorker struct {
 	river.WorkerDefaults[RVToolsJobArgs]
 	store     store.Store
 	validator duckdb_parser.Validator // Shared, stateless
+	s3        *config.S3
 }
 
 // NewRVToolsWorker creates a new RVTools worker.
-func NewRVToolsWorker(store store.Store, validator duckdb_parser.Validator) *RVToolsWorker {
+func NewRVToolsWorker(store store.Store, validator duckdb_parser.Validator, cfg *config.S3) *RVToolsWorker {
 	return &RVToolsWorker{
 		store:     store,
 		validator: validator,
+		s3:        cfg,
 	}
 }
 
@@ -79,26 +86,33 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 
 	logger.Step("job_started").Log()
 
+	client, err := minio.New(w.s3.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(w.s3.AccessKey, w.s3.SecretKey, ""),
+		Secure: false,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create s3 client: %w", err)
+	}
+
+	defer func() {
+		_ = client.RemoveObject(
+			ctx,
+			w.s3.RvtoolsBucket,
+			job.Args.S3RvtoolsFileName,
+			minio.RemoveObjectOptions{},
+		)
+	}()
+
+	// Write file content to temp file for DuckDB ingestion
+	tempFilePath, cleanup, err := w.downloadToTempFile(ctx, client, job.Args.S3RvtoolsFileName)
+	defer cleanup()
+
 	// Create per-job DuckDB instance for isolation
 	parser, duckDB, err := w.createParser()
 	if err != nil {
 		return w.failJob(ctx, logger, job.ID, "create_parser", err, fmt.Sprintf("failed to create DuckDB parser: %v", err))
 	}
 	defer func() { _ = duckDB.Close() }()
-
-	// Write file content to temp file for DuckDB ingestion
-	tempFile, err := os.CreateTemp("", "rvtools-*.xlsx")
-	if err != nil {
-		return w.failJob(ctx, logger, job.ID, "create_temp_file", err, fmt.Sprintf("failed to create temp file: %v", err))
-	}
-	tempFilePath := tempFile.Name()
-	defer func() { _ = os.Remove(tempFilePath) }()
-
-	if _, err := tempFile.Write(job.Args.FileContent); err != nil {
-		_ = tempFile.Close()
-		return w.failJob(ctx, logger, job.ID, "write_temp_file", err, fmt.Sprintf("failed to write temp file: %v", err))
-	}
-	_ = tempFile.Close()
 
 	// Update status to validating before ingestion (which includes OPA validation)
 	if err := w.updateJobStatus(ctx, job.ID, model.JobStatusValidating, "", nil); err != nil {
@@ -149,39 +163,10 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 
 	logger.Step("creating_assessment").Log()
 
-	// Build assessment model
-	assessment := model.Assessment{
-		ID:         uuid.New(),
-		Name:       job.Args.Name,
-		OrgID:      job.Args.OrgID,
-		Username:   job.Args.Username,
-		SourceType: "rvtools",
-	}
-	if job.Args.FirstName != "" {
-		assessment.OwnerFirstName = &job.Args.FirstName
-	}
-	if job.Args.LastName != "" {
-		assessment.OwnerLastName = &job.Args.LastName
-	}
-
-	createdAssessment, err := w.store.Assessment().Create(ctx, assessment, inventoryJSON)
+	createdAssessment, err := w.createAssessment(ctx, job.Args, inventoryJSON)
 	if err != nil {
-		var errMsg string
-		if errors.Is(err, store.ErrDuplicateKey) {
-			// Same format as service.NewErrAssessmentDuplicateName
-			errMsg = fmt.Sprintf("assessment with name '%s' already exists", assessment.Name)
-		} else {
-			errMsg = fmt.Sprintf("failed to create assessment: %v", err)
-		}
-		return w.failJob(ctx, logger, job.ID, "create_assessment", err, errMsg)
-	}
-
-	updates := store.NewRelationshipBuilder().
-		With(model.NewAssessmentResource(assessment.ID.String()), model.OwnerRelation, model.NewUserSubject(job.Args.Username)).
-		Build()
-
-	if err := w.store.Authz().WriteRelationships(ctx, updates); err != nil {
-		return fmt.Errorf("authz: failed to write owner relation: %w", err)
+		logger.Error(err).WithString("step", "save_assessment").Log()
+		return err
 	}
 
 	// Update job with assessment ID
@@ -195,6 +180,83 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 		Log()
 
 	return nil
+}
+
+func (w *RVToolsWorker) downloadToTempFile(
+	ctx context.Context,
+	client *minio.Client,
+	S3FileName string,
+) (string, func(), error) {
+
+	tempFile, err := os.CreateTemp("", "rvtools-*.xlsx")
+	if err != nil {
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		_ = os.Remove(tempFile.Name())
+	}
+
+	obj, err := client.GetObject(ctx, w.s3.RvtoolsBucket, S3FileName, minio.GetObjectOptions{})
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	defer func() {
+		_ = obj.Close()
+	}()
+
+	if _, err := io.Copy(tempFile, obj); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+
+	_ = tempFile.Close()
+
+	return tempFile.Name(), cleanup, nil
+}
+
+func (w *RVToolsWorker) createAssessment(
+	ctx context.Context,
+	args RVToolsJobArgs,
+	inventoryJSON []byte,
+) (*model.Assessment, error) {
+	// Build assessment model
+	assessment := model.Assessment{
+		ID:         uuid.New(),
+		Name:       args.Name,
+		OrgID:      args.OrgID,
+		Username:   args.Username,
+		SourceType: "rvtools",
+	}
+	if args.FirstName != "" {
+		assessment.OwnerFirstName = &args.FirstName
+	}
+	if args.LastName != "" {
+		assessment.OwnerLastName = &args.LastName
+	}
+
+	createdAssessment, err := w.store.Assessment().Create(ctx, assessment, inventoryJSON)
+	if err != nil {
+		var errMsg string
+		if errors.Is(err, store.ErrDuplicateKey) {
+			// Same format as service.NewErrAssessmentDuplicateName
+			errMsg = fmt.Sprintf("assessment with name '%s' already exists", assessment.Name)
+		} else {
+			errMsg = fmt.Sprintf("failed to create assessment: %v", err)
+		}
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	updates := store.NewRelationshipBuilder().
+		With(model.NewAssessmentResource(assessment.ID.String()), model.OwnerRelation, model.NewUserSubject(args.Username)).
+		Build()
+
+	if err := w.store.Authz().WriteRelationships(ctx, updates); err != nil {
+		return nil, fmt.Errorf("authz: failed to write owner relation: %w", err)
+	}
+
+	return createdAssessment, nil
 }
 
 // updateJobStatus updates the job's metadata with the current status using job store.


### PR DESCRIPTION
Avoid buffering entire RVTools uploads in the API by streaming them to MinIO
after a quick XLSX magic-byte check. Job arguments store the S3 object key.
the worker downloads the file to a temp path for DuckDB ingestion and removes
the object when done.

- Add MinIO template, S3 config, and planner-api / service handler wiring
- Refactor RVTools job types and worker for S3-backed files

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RVTools assessment file uploads now stored in S3-compatible object storage for improved scalability and persistence
  * MinIO storage service integrated into local development environment

* **Infrastructure**
  * Added configurable S3 endpoint, bucket name, and authentication credentials
  * Service validates S3 bucket availability and automatically creates bucket if needed on startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->