### PR TITLE
NO-JIRA | fix: improve error handling in agent service

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -42,16 +42,18 @@ func (as *AgentService) UpdateSourceInventory(ctx context.Context, updateForm ma
 		if errors.Is(err, store.ErrRecordNotFound) {
 			return nil, NewErrSourceNotFound(updateForm.SourceID)
 		}
-		return nil, fmt.Errorf("failed to fetch source: %s", err)
+		return nil, fmt.Errorf("failed to fetch source: %w", err)
 	}
 
+	// we want to treat "not found" as a 404 but surface any other DB error as
+	// an actual internal error, otherwise real infra problems end up looking
+	// like the client asked for something that does not exist.
 	agent, err := as.store.Agent().Get(ctx, updateForm.AgentID)
-	if err != nil && !errors.Is(err, store.ErrRecordNotFound) {
-		return nil, NewErrAgentNotFound(updateForm.AgentID)
-	}
-
-	if agent == nil {
-		return nil, NewErrAgentNotFound(updateForm.AgentID)
+	if err != nil {
+		if errors.Is(err, store.ErrRecordNotFound) {
+			return nil, NewErrAgentNotFound(updateForm.AgentID)
+		}
+		return nil, fmt.Errorf("failed to fetch agent: %w", err)
 	}
 
 	// don't allow updates of sources not associated with this agent
@@ -67,7 +69,7 @@ func (as *AgentService) UpdateSourceInventory(ctx context.Context, updateForm ma
 	source = mappers.UpdateSourceFromApi(source, updateForm.VCenterID, updateForm.Inventory)
 	updatedSource, err := as.store.Source().Update(ctx, *source)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update source: %s", err)
+		return nil, fmt.Errorf("failed to update source: %w", err)
 	}
 
 	return updatedSource, nil
@@ -81,25 +83,25 @@ func (as *AgentService) UpdateAgentStatus(ctx context.Context, updateForm mapper
 		if errors.Is(err, store.ErrRecordNotFound) {
 			return nil, false, NewErrSourceNotFound(updateForm.SourceID)
 		}
-		return nil, false, fmt.Errorf("failed to fetch source: %s", err)
+		return nil, false, fmt.Errorf("failed to fetch source: %w", err)
 	}
 
 	agent, err := as.store.Agent().Get(ctx, updateForm.ID)
 	if err != nil && !errors.Is(err, store.ErrRecordNotFound) {
-		return nil, false, fmt.Errorf("failed to fetch the agent: %s", err)
+		return nil, false, fmt.Errorf("failed to fetch the agent: %w", err)
 	}
 
 	if agent == nil {
 		a, err := as.store.Agent().Create(ctx, updateForm.ToModel())
 		if err != nil {
-			return nil, false, fmt.Errorf("failed to create the agent: %s", err)
+			return nil, false, fmt.Errorf("failed to create the agent: %w", err)
 		}
 
 		return a, true, nil
 	}
 
 	if _, err := as.store.Agent().Update(ctx, updateForm.ToModel()); err != nil {
-		return nil, false, fmt.Errorf("failed to update agent: %s", err)
+		return nil, false, fmt.Errorf("failed to update agent: %w", err)
 	}
 
 	// must not block here.

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -303,6 +303,30 @@ var _ = Describe("agent service", Ordered, func() {
 			Expect(ok).To(BeTrue())
 		})
 
+		// Covers the agent lookup branch in UpdateSourceInventory: when the
+		// source exists but the agent id does not, we should get back an
+		// ErrResourceNotFound (agent flavor), not a generic wrapped error.
+		It("returns agent not found when the source exists but the agent id is unknown", func() {
+			sourceID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))
+			Expect(tx.Error).To(BeNil())
+
+			inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+				VcenterId: "vcenter",
+			})
+
+			srv := service.NewAgentService(s)
+			_, err := srv.UpdateSourceInventory(context.TODO(), mappers.InventoryUpdateForm{
+				SourceID:  sourceID,
+				AgentID:   uuid.New(), // no agent was inserted for this id
+				VCenterID: "vcenter",
+				Inventory: inventoryJSON,
+			})
+			Expect(err).ToNot(BeNil())
+			_, ok := err.(*service.ErrResourceNotFound)
+			Expect(ok).To(BeTrue())
+		})
+
 		AfterEach(func() {
 			gormdb.Exec("DELETE FROM agents;")
 			gormdb.Exec("DELETE FROM sources;")


### PR DESCRIPTION
## What

Two related cleanups in `internal/service/agent.go`:

### 1. Inverted error handling when fetching the agent

In `UpdateSourceInventory`, the previous code was:

```go
agent, err := as.store.Agent().Get(ctx, updateForm.AgentID)
if err != nil && !errors.Is(err, store.ErrRecordNotFound) {
    return nil, NewErrAgentNotFound(updateForm.AgentID)
}
if agent == nil {
    return nil, NewErrAgentNotFound(updateForm.AgentID)
}
```

This returns `NewErrAgentNotFound` (which maps to a 404) whenever `Agent.Get` returns any error, including real DB failures like a connection timeout. Real infra problems end up looking like the client asked for something that does not exist.

Changed to follow the same pattern already used for the source lookup right above it:

```go
agent, err := as.store.Agent().Get(ctx, updateForm.AgentID)
if err != nil {
    if errors.Is(err, store.ErrRecordNotFound) {
        return nil, NewErrAgentNotFound(updateForm.AgentID)
    }
    return nil, fmt.Errorf("failed to fetch agent: %w", err)
}
```

The `if agent == nil` check becomes unreachable after this change (per `Agent.Get` contract a nil agent is always paired with an error), so it was removed.

### 2. `%s` to `%w` for error wrapping

All `fmt.Errorf` calls in this file were using `%s` for the error, which renders the error text but breaks the error chain. Switched them to `%w` so callers can still use `errors.Is` and `errors.As` to inspect the original error.

## Why

The inverted logic in `UpdateSourceInventory` means operational issues (DB down, slow queries) show up in metrics and logs as 404s instead of 500s, which makes it harder to spot real infrastructure problems. The `%s` pattern is also something we want to keep out of new code for the same observability reason.

This pairs with issue #821 which raised the same kind of status code mismatch in the spec (already fixed in #1044).

## Scope

One file, behavior preserved for the happy path and for the "agent truly not found" case. Only real DB errors now propagate correctly instead of being masked as 404.

## Validation

Locally on this branch:

- `make build`: ok
- `make lint`: 0 issues
- `make check-format`: clean after commit
- `make check-generate`: clean after commit
- `make test`: 19 suites passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error wrapping to preserve original errors and provide clearer diagnostics during agent status and inventory updates.
  * Clarified handling of "agent not found" vs internal fetch errors so callers receive accurate error types.
  * Added a test to verify the correct "agent not found" behavior when an unknown agent ID is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->