### PR TITLE
ECOPROJECT-4429 | fix: differences between estimation and estimation by complexity

### DIFF
--- a/internal/handlers/v1alpha1/estimation.go
+++ b/internal/handlers/v1alpha1/estimation.go
@@ -155,7 +155,7 @@ func (h *ServiceHandler) CalculateMigrationEstimationByComplexity(ctx context.Co
 		if bucket.VMCount == 0 {
 			continue
 		}
-		diskGB := bucket.TotalSizeTB * 1000
+		diskGB := bucket.TotalSizeTB * 1024
 		bucketParams := h.estimationSrv.BuildBucketParams(baseParams, bucket.VMCount, diskGB)
 		schemaResults, err := h.estimationSrv.RunEstimation(schemas, bucketParams)
 		if err != nil {

--- a/internal/service/estimation.go
+++ b/internal/service/estimation.go
@@ -414,7 +414,7 @@ func (es *EstimationService) BuildBaseParams(userParams []estimation.Param) []es
 }
 
 // BuildBucketParams returns params for a single complexity bucket.
-// diskGB = bucket.TotalSizeTB * 1000 (decimal TB as reported by VMware).
+// diskGB = bucket.TotalSizeTB * 1024 (TiB → GiB; matches DiskGB.Total unit in the regular path).
 func (es *EstimationService) BuildBucketParams(baseParams []estimation.Param, vmCount int, diskGB float64) []estimation.Param {
 	return mergeParams(baseParams, []estimation.Param{
 		{Key: calculators.ParamVMCount, Value: vmCount},

--- a/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
@@ -87,11 +87,11 @@ SELECT
     COALESCE(SUM(CASE WHEN has_critical = 0 AND has_warning = 0 THEN disk_count ELSE 0 END), 0)::integer as disk_count_migratable,
     COALESCE(SUM(CASE WHEN has_critical = 0 AND has_warning = 1 THEN disk_count ELSE 0 END), 0)::integer as disk_count_migratable_warnings,
     COALESCE(SUM(CASE WHEN has_critical = 1 THEN disk_count ELSE 0 END), 0)::integer as disk_count_not_migratable,
-    -- Disk GB (round per-VM before summing to match old implementation)
-    COALESCE(SUM(ROUND(disk_mib / 1024.0)), 0)::integer as disk_gb_total,
-    COALESCE(SUM(CASE WHEN has_critical = 0 AND has_warning = 0 THEN ROUND(disk_mib / 1024.0) ELSE 0 END), 0)::integer as disk_gb_migratable,
-    COALESCE(SUM(CASE WHEN has_critical = 0 AND has_warning = 1 THEN ROUND(disk_mib / 1024.0) ELSE 0 END), 0)::integer as disk_gb_migratable_warnings,
-    COALESCE(SUM(CASE WHEN has_critical = 1 THEN ROUND(disk_mib / 1024.0) ELSE 0 END), 0)::integer as disk_gb_not_migratable,
+    -- Disk GB (sum MiB first, then round once to minimise rounding error)
+    COALESCE(ROUND(SUM(disk_mib) / 1024.0), 0)::integer as disk_gb_total,
+    COALESCE(ROUND(SUM(CASE WHEN has_critical = 0 AND has_warning = 0 THEN disk_mib ELSE 0 END) / 1024.0), 0)::integer as disk_gb_migratable,
+    COALESCE(ROUND(SUM(CASE WHEN has_critical = 0 AND has_warning = 1 THEN disk_mib ELSE 0 END) / 1024.0), 0)::integer as disk_gb_migratable_warnings,
+    COALESCE(ROUND(SUM(CASE WHEN has_critical = 1 THEN disk_mib ELSE 0 END) / 1024.0), 0)::integer as disk_gb_not_migratable,
     -- NIC Count
     COALESCE(SUM(nic_count), 0)::integer as nic_total,
     COALESCE(SUM(CASE WHEN has_critical = 0 AND has_warning = 0 THEN nic_count ELSE 0 END), 0)::integer as nic_migratable,


### PR DESCRIPTION


The estimations and estimations by complexity were misaligned - due to wrong unit conversion and accumulated rounding errors in the resource breakdown query.

 - replaced TB to GB conversion with TiB to GiB conversion
 - changed the resource breakdown query: sum first and round later (was other way around - which caused accumulated rounding error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected disk capacity calculations to use binary (1024-based) unit conversion instead of decimal (1000-based) conversion, resulting in more accurate storage capacity reporting in migration estimations.
* Updated disk aggregation logic to improve precision of disk size calculations in estimation reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->