### PR TITLE
ECOPROJECT-4399 | fix: add numeric precision to "reason" string

### DIFF
--- a/pkg/estimations/estimation/calculators/storageMigration.go
+++ b/pkg/estimations/estimation/calculators/storageMigration.go
@@ -97,5 +97,5 @@ func (c *StorageMigration) Calculate(params map[string]estimation.Param) (estima
 	minsPer500GB := (500.0 * 1024.0) / transferRateMBps / 60.0
 	duration := time.Duration(totalMinutes * float64(time.Minute))
 
-	return estimation.NewPointEstimation(duration, fmt.Sprintf("%.2f GB at %.0f Mbps (%.0f min/500GB)", totalGB, transferRateMbps, minsPer500GB)), nil
+	return estimation.NewPointEstimation(duration, fmt.Sprintf("%.2f GB at %g Mbps (%.0f min/500GB)", totalGB, transferRateMbps, minsPer500GB)), nil
 }


### PR DESCRIPTION
In the estimation breakdown, the "reason" string for the network storage migration used zero decimal places for the transfer rate - causing a misleading user message. This fixed the formatting.