### PR TITLE
NO-JIRA | fix: return empty list for requests

### DIFF
--- a/internal/service/partner.go
+++ b/internal/service/partner.go
@@ -42,8 +42,17 @@ func (s *PartnerService) ListPartners(ctx context.Context) (model.GroupList, err
 	return s.store.Accounts().ListGroups(ctx, store.NewGroupQueryFilter().ByKind("partner"))
 }
 
-// ListRequests returns all partner requests for a user.
+// ListRequests returns partner requests.
+// For regular users, it returns their own requests.
+// For partners, it returns all requests for their group.
 func (s *PartnerService) ListRequests(ctx context.Context, user auth.User) (model.PartnerCustomerList, error) {
+	identity, err := s.accountsSvc.GetIdentity(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	if identity.Kind == KindPartner && identity.GroupID != nil {
+		return s.store.PartnerCustomer().List(ctx, store.NewPartnerQueryFilter().ByPartnerID(*identity.GroupID))
+	}
 	return s.store.PartnerCustomer().List(ctx, store.NewPartnerQueryFilter().ByUsername(user.Username))
 }
 

--- a/internal/service/partner_test.go
+++ b/internal/service/partner_test.go
@@ -72,8 +72,28 @@ var _ = Describe("partner service", Ordered, func() {
 			Expect(partners).To(HaveLen(0))
 		})
 
+		It("returns all requests for the partner's group when called by a partner", func() {
+			tx := gormdb.Exec(fmt.Sprintf(insertPartnerMemberStm, uuid.New(), "partneruser", "p@acme.com", partnerGroupID1))
+			Expect(tx.Error).To(BeNil())
+
+			tx = gormdb.Exec(fmt.Sprintf(insertPartnerCustomerStm, uuid.New(), "user1", partnerGroupID1, "pending", "Name1", "Contact1", "555-0001", "user1@example.com", "Location1"))
+			Expect(tx.Error).To(BeNil())
+			tx = gormdb.Exec(fmt.Sprintf(insertPartnerCustomerStm, uuid.New(), "user2", partnerGroupID1, "accepted", "Name2", "Contact2", "555-0002", "user2@example.com", "Location2"))
+			Expect(tx.Error).To(BeNil())
+			tx = gormdb.Exec(fmt.Sprintf(insertPartnerCustomerStm, uuid.New(), "user3", partnerGroupID2, "pending", "Name3", "Contact3", "555-0003", "user3@example.com", "Location3"))
+			Expect(tx.Error).To(BeNil())
+
+			partners, err := srv.ListRequests(context.TODO(), auth.User{Username: "partneruser"})
+			Expect(err).To(BeNil())
+			Expect(partners).To(HaveLen(2))
+			for _, p := range partners {
+				Expect(p.PartnerID).To(Equal(partnerGroupID1.String()))
+			}
+		})
+
 		AfterEach(func() {
 			gormdb.Exec("DELETE FROM partners_customers;")
+			gormdb.Exec("DELETE FROM members;")
 			gormdb.Exec("DELETE FROM groups;")
 		})
 	})


### PR DESCRIPTION
Fix a bug when an empty list is returned for a partner.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced request visibility with role-based filtering. Partner users now see requests filtered to their assigned partner group, while regular users maintain their existing request list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->