### PR TITLE
ECOPROJECT-4366 | feat: carry BackingDevicesNames through to vdatastore

### DIFF
--- a/pkg/duckdb_parser/templates/create_schema.go.tmpl
+++ b/pkg/duckdb_parser/templates/create_schema.go.tmpl
@@ -122,7 +122,8 @@ CREATE TABLE IF NOT EXISTS vdatastore (
     "Free MiB" DOUBLE DEFAULT 0.0,
     "MHA" BOOLEAN DEFAULT false,
     "Capacity MiB" DOUBLE DEFAULT 0.0,
-    "Type" VARCHAR
+    "Type" VARCHAR,
+    "Backing Devices" VARCHAR DEFAULT '[]'
 );
 
 CREATE TABLE IF NOT EXISTS vhba (

--- a/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
+++ b/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
@@ -145,7 +145,7 @@ SELECT
 FROM src.Host h
 LEFT JOIN src.Cluster c ON h.Cluster = c.ID;
 
-INSERT INTO vdatastore ("Hosts", "Address", "Name", "Object ID", "Free MiB", "MHA", "Capacity MiB", "Type")
+INSERT INTO vdatastore ("Hosts", "Address", "Name", "Object ID", "Free MiB", "MHA", "Capacity MiB", "Type", "Backing Devices")
 SELECT
     string_agg(DISTINCT h.ID, ','),
     ds.Name,
@@ -154,14 +154,15 @@ SELECT
     ds.Free / 1048576,
     ds.MaintenanceMode = 'True',
     ds.Capacity / 1048576,
-    ds.Type
+    ds.Type,
+    COALESCE(ds.BackingDevicesNames, '[]')
 FROM src.Datastore ds
 LEFT JOIN (
     SELECT h.ID, h.Cluster, dsref->>'id' AS datastore_id
     FROM src.Host h,
     LATERAL unnest(from_json(h.Datastores, '[{"kind":"VARCHAR","id":"VARCHAR"}]')) AS t(dsref)
 ) h ON h.datastore_id = ds.ID
-GROUP BY ds.ID, ds.Name, ds.Free, ds.Capacity, ds.MaintenanceMode, ds.Type;
+GROUP BY ds.ID, ds.Name, ds.Free, ds.Capacity, ds.MaintenanceMode, ds.Type, ds.BackingDevicesNames;
 
 INSERT INTO dvport ("Port", "VLAN")
 SELECT


### PR DESCRIPTION
## Summary
- Adds `"Backing Devices"` column to the `vdatastore` schema in `create_schema.go.tmpl`
- Populates it with `COALESCE(ds.BackingDevicesNames, '[]')` during SQLite ingestion in `ingest_sqlite.go.tmpl`
- The forklift collector already stores NAA device IDs (`BackingDevicesNames`) on its Datastore model but `IngestSqlite` was dropping them. This enables the agent to derive storage vendor and array identity from inventory without querying vSphere hosts.

## Test plan
- [x] `go test ./pkg/duckdb_parser/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backing devices tracking capability for datastores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->