### PR TITLE
ECOPROJECT-4385 | feat: Add migration_excluded field to support VM exclusion from inventory

### DIFF
--- a/pkg/duckdb_parser/inventory_builder_test.go
+++ b/pkg/duckdb_parser/inventory_builder_test.go
@@ -88,7 +88,7 @@ var (
 		"FT State", "EnableUUID", "Folder", "DNS Name", "Primary IP Address",
 		"In Use MiB", "HW version", "Provisioned MiB", "Resource pool",
 		"OS according to the configuration file", "OS according to the VMware Tools",
-		"VM UUID", "Total disk capacity MiB",
+		"VM UUID", "Total disk capacity MiB", "migration_excluded",
 	}
 	vHostHeaders      = []string{"Datacenter", "Cluster", "# Cores", "# CPU", "Object ID", "# Memory", "Model", "Vendor", "Host", "Config status"}
 	vDatastoreHeaders = []string{"Hosts", "Address", "Name", "Object ID", "Free MiB", "MHA", "Capacity MiB", "Type"}
@@ -1265,4 +1265,53 @@ func TestPopulateComplexityQuery_IsDeterministic(t *testing.T) {
 	require.NoError(t, err1)
 	require.NoError(t, err2)
 	assert.Equal(t, sql1, sql2, "PopulateComplexityQuery output must be deterministic")
+}
+
+// TestVMs_MigrationExcluded verifies that the migration_excluded field:
+// 1. Defaults to false for RVTools-ingested VMs
+// 2. Can be updated via SQL and is properly returned in the VM model
+func TestVMs_MigrationExcluded(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	vms := []map[string]string{
+		{"VM": "vm-1", "VM ID": "vm-001", "VI SDK UUID": "uuid-1", "Host": "esxi-host-1", "CPUs": "4", "Memory": "8192", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		{"VM": "vm-2", "VM ID": "vm-002", "VI SDK UUID": "uuid-2", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		{"VM": "vm-3", "VM ID": "vm-003", "VI SDK UUID": "uuid-3", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "dc1", "Cluster": "cluster1", "# Cores": "8", "# CPU": "2", "Object ID": "host-001", "# Memory": "32768", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+	}
+
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err)
+
+	// Verify all VMs default to migration_excluded=false (RVTools behavior)
+	vmsOut, err := parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+	require.Len(t, vmsOut, 3)
+
+	for _, vm := range vmsOut {
+		assert.False(t, vm.MigrationExcluded, "RVTools-ingested VMs should default to migration_excluded=false")
+	}
+
+	// Simulate agent updating exclusion status via SQL (how the agent will use this)
+	_, err = parser.db.ExecContext(ctx, `UPDATE vinfo SET "migration_excluded" = true WHERE "VM ID" = 'vm-001'`)
+	require.NoError(t, err)
+
+	// Verify the update is reflected in VM query
+	vmsOut, err = parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+
+	vmMap := make(map[string]models.VM)
+	for _, vm := range vmsOut {
+		vmMap[vm.ID] = vm
+	}
+
+	assert.True(t, vmMap["vm-001"].MigrationExcluded, "Updated VM should have migration_excluded=true")
+	assert.False(t, vmMap["vm-002"].MigrationExcluded, "Non-updated VM should remain migration_excluded=false")
+	assert.False(t, vmMap["vm-003"].MigrationExcluded, "Non-updated VM should remain migration_excluded=false")
 }

--- a/pkg/duckdb_parser/inventory_builder_test.go
+++ b/pkg/duckdb_parser/inventory_builder_test.go
@@ -1315,3 +1315,69 @@ func TestVMs_MigrationExcluded(t *testing.T) {
 	assert.False(t, vmMap["vm-002"].MigrationExcluded, "Non-updated VM should remain migration_excluded=false")
 	assert.False(t, vmMap["vm-003"].MigrationExcluded, "Non-updated VM should remain migration_excluded=false")
 }
+
+// TestInventory_ExcludesMigrationExcludedVMs verifies that VMs marked with migration_excluded=true
+// are completely filtered out from all inventory aggregations.
+func TestInventory_ExcludesMigrationExcludedVMs(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	// Create 6 VMs with different characteristics
+	vms := []map[string]string{
+		// VMs to be included in inventory (migration_excluded=false)
+		{"VM": "included-1", "VM ID": "inc-001", "VI SDK UUID": "uuid-inc-1", "Host": "esxi-host-1", "CPUs": "4", "Memory": "8192", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "Red Hat Enterprise Linux 8 (64-bit)"},
+		{"VM": "included-2", "VM ID": "inc-002", "VI SDK UUID": "uuid-inc-2", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "Red Hat Enterprise Linux 8 (64-bit)"},
+		{"VM": "included-3", "VM ID": "inc-003", "VI SDK UUID": "uuid-inc-3", "Host": "esxi-host-1", "CPUs": "8", "Memory": "16384", "Powerstate": "poweredOff", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "CentOS 7 (64-bit)"},
+
+		// VMs to be excluded from inventory (migration_excluded=true)
+		{"VM": "excluded-1", "VM ID": "exc-001", "VI SDK UUID": "uuid-exc-1", "Host": "esxi-host-1", "CPUs": "16", "Memory": "65536", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "Red Hat Enterprise Linux 8 (64-bit)"},
+		{"VM": "excluded-2", "VM ID": "exc-002", "VI SDK UUID": "uuid-exc-2", "Host": "esxi-host-1", "CPUs": "4", "Memory": "8192", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "Windows Server 2019 (64-bit)"},
+		{"VM": "excluded-3", "VM ID": "exc-003", "VI SDK UUID": "uuid-exc-3", "Host": "esxi-host-1", "CPUs": "2", "Memory": "2048", "Powerstate": "poweredOff", "Cluster": "cluster1", "Datacenter": "dc1", "OS according to the VMware Tools": "CentOS 7 (64-bit)"},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "dc1", "Cluster": "cluster1", "# Cores": "64", "# CPU": "4", "Object ID": "host-001", "# Memory": "262144", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+	}
+
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err)
+
+	// Mark 3 VMs as migration_excluded
+	_, err = parser.db.ExecContext(ctx, `UPDATE vinfo SET "migration_excluded" = true WHERE "VM ID" IN ('exc-001', 'exc-002', 'exc-003')`)
+	require.NoError(t, err)
+
+	// Build inventory
+	inv, err := parser.BuildInventory(ctx)
+	require.NoError(t, err)
+
+	// Verify VM counts exclude the 3 excluded VMs
+	assert.Equal(t, 3, inv.VCenter.VMs.Total, "TotalVMs should only count non-excluded VMs")
+
+	// Verify power state counts exclude excluded VMs
+	assert.Equal(t, 2, inv.VCenter.VMs.PowerStates["poweredOn"], "poweredOn count should exclude excluded VMs")
+	assert.Equal(t, 1, inv.VCenter.VMs.PowerStates["poweredOff"], "poweredOff count should exclude excluded VMs")
+
+	// Verify OS distribution excludes excluded VMs
+	assert.Equal(t, 2, inv.VCenter.VMs.OSInfo["Red Hat Enterprise Linux 8 (64-bit)"].Count, "RHEL 8 count should exclude excluded VMs")
+	assert.Equal(t, 1, inv.VCenter.VMs.OSInfo["CentOS 7 (64-bit)"].Count, "CentOS 7 count should exclude excluded VMs")
+	assert.NotContains(t, inv.VCenter.VMs.OSInfo, "Windows Server 2019 (64-bit)", "Windows should not appear as all Windows VMs are excluded")
+
+	// Verify CPU tier distribution excludes excluded VMs
+	// Included VMs: included-1 (4 CPUs), included-2 (2 CPUs), included-3 (8 CPUs)
+	assert.Equal(t, 2, inv.VCenter.VMs.DistributionByCPUTier["0-4"], "CPU tier 0-4 should count 2 included VMs (2 and 4 CPUs)")
+	assert.Equal(t, 1, inv.VCenter.VMs.DistributionByCPUTier["5-8"], "CPU tier 5-8 should count 1 included VM (8 CPUs)")
+	assert.Equal(t, 0, inv.VCenter.VMs.DistributionByCPUTier["9-16"], "CPU tier 9-16 should be 0 as the only VM in this tier (16 CPUs) is excluded")
+
+	// Verify memory tier distribution excludes excluded VMs
+	// Included VMs: included-1 (8 GB), included-2 (4 GB), included-3 (16 GB)
+	assert.Equal(t, 1, inv.VCenter.VMs.DistributionByMemoryTier["0-4"], "Memory tier 0-4 should count 1 included VM (4 GB)")
+	assert.Equal(t, 2, inv.VCenter.VMs.DistributionByMemoryTier["5-16"], "Memory tier 5-16 should count 2 included VMs (8 GB and 16 GB)")
+	assert.Equal(t, 0, inv.VCenter.VMs.DistributionByMemoryTier["65-128"], "Memory tier 65-128 should be 0 as the only VM in this tier (64 GB) is excluded")
+
+	// Verify resource totals exclude excluded VMs
+	// Included VMs: 4 + 2 + 8 = 14 CPUs, 8 + 4 + 16 = 28 GB RAM
+	assert.Equal(t, 14, inv.VCenter.VMs.CPUCores.Total, "TotalCPUCores should exclude excluded VMs")
+	assert.Equal(t, 28, inv.VCenter.VMs.RamGB.Total, "TotalRAMGb should exclude excluded VMs")
+}

--- a/pkg/duckdb_parser/models/vm.go
+++ b/pkg/duckdb_parser/models/vm.go
@@ -44,6 +44,7 @@ type VM struct {
 	OsDiskComplexity         int32    `json:"osDiskComplexity" db:"OsDiskComplexity"`
 	Concerns                 Concerns `json:"concerns"`
 	NumaNodeAffinity         []string `json:"numaNodeAffinity"` // Always empty for RVTools, included for OPA compatibility
+	MigrationExcluded        bool     `json:"migrationExcluded" db:"migration_excluded"`
 }
 
 // EffectiveGuestName returns the best available guest OS name.

--- a/pkg/duckdb_parser/queries.go
+++ b/pkg/duckdb_parser/queries.go
@@ -582,6 +582,7 @@ func (p *Parser) readVMs(ctx context.Context, query string) ([]models.VM, error)
 			&vm.NICs,
 			&vm.Networks,
 			&vm.Concerns,
+			&vm.MigrationExcluded,
 		); err != nil {
 			return nil, fmt.Errorf("scanning VM row: %w", err)
 		}

--- a/pkg/duckdb_parser/templates/allocated_memory_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/allocated_memory_query.go.tmpl
@@ -8,4 +8,5 @@ Template Parameters:
 SELECT COALESCE(SUM("Memory"), 0)
 FROM vinfo
 WHERE "Powerstate" = 'poweredOn'
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/allocated_vcpus_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/allocated_vcpus_query.go.tmpl
@@ -8,4 +8,5 @@ Template Parameters:
 SELECT COALESCE(SUM("CPUs"), 0)
 FROM vinfo
 WHERE "Powerstate" = 'poweredOn'
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/complexity_distribution_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/complexity_distribution_query.go.tmpl
@@ -23,6 +23,7 @@ WITH vm_disk_totals AS (
     FROM vinfo i
     LEFT JOIN vdisk d ON i."VM ID" = d."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY i."VM ID", i."OsDiskComplexity"
 )

--- a/pkg/duckdb_parser/templates/cpu_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/cpu_tier_query.go.tmpl
@@ -15,5 +15,6 @@ SELECT
     COUNT(*) AS count
 FROM vinfo
 WHERE 1=1
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 GROUP BY tier;

--- a/pkg/duckdb_parser/templates/create_schema.go.tmpl
+++ b/pkg/duckdb_parser/templates/create_schema.go.tmpl
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS vinfo (
     "Network #6" VARCHAR,
     "Network #7" VARCHAR,
     "Network #8" VARCHAR,
-    "OsDiskComplexity" INTEGER DEFAULT 0
+    "OsDiskComplexity" INTEGER DEFAULT 0,
+    "migration_excluded" BOOLEAN DEFAULT false
 );
 
 CREATE TABLE IF NOT EXISTS vcpu (

--- a/pkg/duckdb_parser/templates/disk_complexity_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_complexity_tier_query.go.tmpl
@@ -13,6 +13,7 @@ WITH vm_disk_totals AS (
     FROM vinfo i
     LEFT JOIN vdisk d ON i."VM ID" = d."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY i."VM ID"
 )

--- a/pkg/duckdb_parser/templates/disk_size_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_size_tier_query.go.tmpl
@@ -15,6 +15,7 @@ WITH vm_disk_totals AS (
     FROM vinfo i
     LEFT JOIN vdisk d ON i."VM ID" = d."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY i."VM ID"
 )

--- a/pkg/duckdb_parser/templates/disk_type_summary_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_type_summary_query.go.tmpl
@@ -13,6 +13,7 @@ WITH vm_disk_types AS (
     JOIN vdatastore ds ON ds."Name" = REGEXP_EXTRACT(COALESCE(d."Path", d."Disk Path"), '\[([^\]]+)\]', 1)
     JOIN vinfo i ON d."VM ID" = i."VM ID"
     WHERE ds."Type" IS NOT NULL AND ds."Type" != ''
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
 )
 SELECT

--- a/pkg/duckdb_parser/templates/host_power_state_counts_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/host_power_state_counts_query.go.tmpl
@@ -20,6 +20,7 @@ vinfo_fallback AS (
     SELECT 'unknown' AS state, COUNT(DISTINCT "Host") AS count
     FROM vinfo
     WHERE "Host" IS NOT NULL AND "Host" != ''
+      AND COALESCE("migration_excluded", false) = false
     {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 )
 SELECT state, count FROM vhost_states

--- a/pkg/duckdb_parser/templates/host_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/host_query.go.tmpl
@@ -33,6 +33,7 @@ vinfo_fallback AS (
         'N/A' as "vendor"
     FROM vinfo
     WHERE "Host" IS NOT NULL AND "Host" != ''
+      AND COALESCE("migration_excluded", false) = false
     {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 )
 SELECT "cluster", "cpuCores", "cpuSockets", "id", "memoryMB", "model", "vendor"

--- a/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
+++ b/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
@@ -25,7 +25,8 @@ INSERT INTO vinfo (
     "DNS Name", "Primary IP Address", "In Use MiB",
     "Template", "CBT", "EnableUUID",
     "Datacenter", "Cluster", "HW version",
-    "Total disk capacity MiB", "Provisioned MiB", "Resource pool", "VI SDK UUID"
+    "Total disk capacity MiB", "Provisioned MiB", "Resource pool", "VI SDK UUID",
+    "migration_excluded"
 )
 SELECT
     v.ID,
@@ -55,7 +56,8 @@ SELECT
     0,
     0,
     '',
-    about.InstanceUuid
+    about.InstanceUuid,
+    false
 FROM src.VM v
 LEFT JOIN src.Host h ON v.Host = h.ID
 LEFT JOIN src.Cluster c ON h.Cluster = c.ID

--- a/pkg/duckdb_parser/templates/memory_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/memory_tier_query.go.tmpl
@@ -17,5 +17,6 @@ SELECT
     COUNT(*) AS count
 FROM vinfo
 WHERE 1=1
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 GROUP BY tier;

--- a/pkg/duckdb_parser/templates/migratable_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migratable_count_query.go.tmpl
@@ -8,4 +8,5 @@ SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 LEFT JOIN concerns c ON i."VM ID" = c."VM_ID" AND c."Category" = 'Critical'
 WHERE c."VM_ID" IS NULL
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/migratable_with_warnings_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migratable_with_warnings_count_query.go.tmpl
@@ -11,4 +11,5 @@ SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 JOIN concerns warn ON i."VM ID" = warn."VM_ID" AND warn."Category" = 'Warning'
 WHERE 1=1
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/migration_issues_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migration_issues_query.go.tmpl
@@ -17,5 +17,6 @@ SELECT
 FROM concerns c
 JOIN vinfo i ON c."VM_ID" = i."VM ID"
 WHERE c."Category" = '{{.Category}}'
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
 GROUP BY c."Concern_ID";

--- a/pkg/duckdb_parser/templates/nic_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/nic_tier_query.go.tmpl
@@ -18,6 +18,7 @@ WITH nic_counts AS (
     FROM vinfo i
     LEFT JOIN vnetwork n ON i."VM ID" = n."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY i."VM ID"
 )

--- a/pkg/duckdb_parser/templates/not_migratable_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/not_migratable_count_query.go.tmpl
@@ -8,4 +8,5 @@ SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 JOIN concerns c ON i."VM ID" = c."VM_ID" AND c."Category" = 'Critical'
 WHERE 1=1
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/os_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/os_query.go.tmpl
@@ -25,7 +25,8 @@ WITH os_data AS (
             'Unknown OS'
         ) AS os_name
     FROM vinfo v
-    WHERE (
+    WHERE COALESCE(v."migration_excluded", false) = false
+      AND (
         (v."OS according to the VMware Tools" IS NOT NULL AND v."OS according to the VMware Tools" != '')
         OR
         (v."OS according to the configuration file" IS NOT NULL AND v."OS according to the configuration file" != '')
@@ -42,6 +43,7 @@ unsupported_os AS (
     FROM vinfo v
     JOIN concerns c ON v."VM ID" = c."VM_ID"
     WHERE c."Concern_ID" = 'vmware.os.unsupported'
+      AND COALESCE(v."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND v."Cluster" = '{{.ClusterFilter}}'{{end}}
 ),
 upgrade_recommendations AS (
@@ -57,6 +59,7 @@ upgrade_recommendations AS (
     FROM vinfo v
     JOIN concerns c ON v."VM ID" = c."VM_ID"
     WHERE c."Concern_ID" = 'vmware.os.upgrade.recommendation'
+      AND COALESCE(v."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND v."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY 1
 )

--- a/pkg/duckdb_parser/templates/populate_complexity.go.tmpl
+++ b/pkg/duckdb_parser/templates/populate_complexity.go.tmpl
@@ -18,6 +18,7 @@ WITH vm_os AS (
             ''
         ) AS effective_os
     FROM vinfo
+    WHERE COALESCE("migration_excluded", false) = false
 ),
 vm_os_level AS (
     SELECT
@@ -34,6 +35,7 @@ vm_disk_totals AS (
         COALESCE(SUM(d."Capacity MiB"), 0) / 1048576.0 AS total_disk_tb
     FROM vinfo i
     LEFT JOIN vdisk d ON i."VM ID" = d."VM ID"
+    WHERE COALESCE(i."migration_excluded", false) = false
     GROUP BY i."VM ID"
 ),
 vm_disk_level AS (

--- a/pkg/duckdb_parser/templates/power_state_counts_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/power_state_counts_query.go.tmpl
@@ -7,5 +7,6 @@ Template Parameters:
 SELECT "Powerstate" AS state, COUNT(*) AS count
 FROM vinfo
 WHERE 1=1
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 GROUP BY "Powerstate";

--- a/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
@@ -21,6 +21,7 @@ WITH vm_concerns AS (
     FROM vinfo i
     LEFT JOIN concerns c ON i."VM ID" = c."VM_ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY i."VM ID"
 ),
@@ -34,6 +35,7 @@ vm_resources AS (
     FROM vinfo i
     LEFT JOIN vm_concerns vc ON i."VM ID" = vc.vm_id
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
 ),
 disk_resources AS (
@@ -44,6 +46,7 @@ disk_resources AS (
     FROM vdisk d
     JOIN vinfo i ON d."VM ID" = i."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY d."VM ID"
 ),
@@ -54,6 +57,7 @@ nic_resources AS (
     FROM vnetwork n
     JOIN vinfo i ON n."VM ID" = i."VM ID"
     WHERE 1=1
+      AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
     GROUP BY n."VM ID"
 ),

--- a/pkg/duckdb_parser/templates/resource_totals_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/resource_totals_query.go.tmpl
@@ -22,4 +22,5 @@ LEFT JOIN (
     GROUP BY "VM ID"
 ) n ON i."VM ID" = n."VM ID"
 WHERE 1=1
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/vm_count_by_network_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_count_by_network_query.go.tmpl
@@ -9,8 +9,8 @@ Template Parameters:
 */ -}}
 SELECT "Network" AS network, COUNT(*) AS count
 FROM vnetwork n
-{{- if .ClusterFilter }}
 JOIN vinfo i ON n."VM ID" = i."VM ID"
-WHERE i."Cluster" = '{{.ClusterFilter}}'
-{{- end}}
+WHERE 1=1
+  AND COALESCE(i."migration_excluded", false) = false
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{- end}}
 GROUP BY "Network";

--- a/pkg/duckdb_parser/templates/vm_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_count_query.go.tmpl
@@ -7,5 +7,6 @@ Template Parameters:
 */ -}}
 SELECT COUNT(*) FROM vinfo
 WHERE 1=1
+  AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
 {{- if .PowerStateFilter }} AND "Powerstate" = '{{.PowerStateFilter}}'{{end}};

--- a/pkg/duckdb_parser/templates/vm_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_query.go.tmpl
@@ -105,7 +105,8 @@ SELECT
         LIST_VALUE({{ .NetworkColumns }}),
         x -> x IS NOT NULL AND x != '' AND x != 'VM'
     ) AS "Networks",
-    COALESCE(con.concerns, []) AS "Concerns"
+    COALESCE(con.concerns, []) AS "Concerns",
+    COALESCE(i."migration_excluded", false) AS "MigrationExcluded"
 FROM vinfo i
 LEFT JOIN vcpu c ON i."VM ID" = c."VM ID"
 LEFT JOIN vmemory m ON i."VM ID" = m."VM ID"

--- a/pkg/duckdb_parser/templates/vms_with_shared_disks_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vms_with_shared_disks_count_query.go.tmpl
@@ -8,5 +8,6 @@ SELECT COUNT(DISTINCT d."VM ID")
 FROM vdisk d
 JOIN vinfo i ON d."VM ID" = i."VM ID"
 WHERE d."Sharing mode" = true
+  AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
 


### PR DESCRIPTION
## Summary
  Add `migration_excluded` boolean field to the parser to allow the assisted-migration-agent to exclude specific VMs from inventory generation.
  VMs marked as excluded are filtered out from all inventory aggregations while remaining queryable via the VMs() method.

  ## Changes

  ### VM Model & Schema
  - Add `migration_excluded` field to VM model (pkg/duckdb_parser/models/vm.go)
  - Add `migration_excluded` column to vinfo table schema (DEFAULT false)
  - Include field in VM query SELECT and Scan operations
  - Support migration_excluded in SQLite ingestion path

  ### Inventory Filtering
  - Add COALESCE-based NULL-safe exclusion filter to the inventory query templates

  ### Testing
  - Add test verifying RVTools default behavior (migration_excluded=false)
  - Add test verifying SQL UPDATE capability for agent usage
  - Add comprehensive test verifying excluded VMs are filtered from all inventory statistics

  ## Behavior
  - **RVTools ingestion**: All VMs default to `migration_excluded=false` (no behavior change)
  - **Agent usage**: Can UPDATE vinfo table to set `migration_excluded=true` for specific VMs
  - **Inventory generation**: Excluded VMs are filtered from all aggregations
  - **VM queries**: Excluded VMs remain queryable via VMs() method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMs can be marked as "migration excluded"; excluded VMs are omitted from inventory aggregates and reports (VM totals, power-state counts, OS breakdowns, resource tiers, CPU/memory/vCPU totals, shared-disk and migratability reports).

* **Tests**
  * Added tests verifying the migration-excluded flag defaults to false, can be updated, and that excluded VMs are removed from inventory calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->