### PR TITLE
ECOPROJECT-4503 | fix: revoke partner access to assessments 

### DIFF
--- a/internal/service/partner.go
+++ b/internal/service/partner.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,6 +11,21 @@ import (
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
 )
+
+func revokeSharedAssessments(ctx context.Context, s store.Store, username, partnerID string) error {
+	assessments, err := s.Assessment().List(ctx, store.NewAssessmentQueryFilter().WithUsername(username))
+	if err != nil {
+		return fmt.Errorf("failed to list assessments for user %s: %w", username, err)
+	}
+	if len(assessments) == 0 {
+		return nil
+	}
+	builder := store.NewRelationshipBuilder()
+	for _, a := range assessments {
+		builder.Without(model.NewAssessmentResource(a.ID.String()), model.ViewerRelation, model.NewOrgSubject(partnerID))
+	}
+	return s.Authz().WriteRelationships(ctx, builder.Build())
+}
 
 type PartnerServicer interface {
 	// Regular user
@@ -159,12 +175,28 @@ func (s *PartnerService) LeavePartner(ctx context.Context, user auth.User, partn
 		}
 		return err
 	}
+	ctx, err = s.store.NewTransactionContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = store.Rollback(ctx)
+	}()
+
 	now := time.Now()
-	_, err = s.store.PartnerCustomer().Update(ctx, model.PartnerCustomer{
+	if _, err = s.store.PartnerCustomer().Update(ctx, model.PartnerCustomer{
 		ID:            pc.ID,
 		RequestStatus: model.RequestStatusCancelled,
 		TerminatedAt:  &now,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if err = revokeSharedAssessments(ctx, s.store, user.Username, partnerID); err != nil {
+		return err
+	}
+
+	_, err = store.Commit(ctx)
 	return err
 }
 
@@ -225,11 +257,27 @@ func (s *PartnerService) RemoveCustomer(ctx context.Context, user auth.User, use
 		}
 		return err
 	}
+	ctx, err = s.store.NewTransactionContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = store.Rollback(ctx)
+	}()
+
 	now := time.Now()
-	_, err = s.store.PartnerCustomer().Update(ctx, model.PartnerCustomer{
+	if _, err = s.store.PartnerCustomer().Update(ctx, model.PartnerCustomer{
 		ID:            pc.ID,
 		RequestStatus: model.RequestStatusCancelled,
 		TerminatedAt:  &now,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if err = revokeSharedAssessments(ctx, s.store, username, pc.PartnerID); err != nil {
+		return err
+	}
+
+	_, err = store.Commit(ctx)
 	return err
 }

--- a/test/e2e/e2e_share_test.go
+++ b/test/e2e/e2e_share_test.go
@@ -265,7 +265,32 @@ var _ = Describe("e2e-share", func() {
 			code, err := partnerSvc.CalculateMigrationEstimationByComplexity(assessment.Id, clusterID)
 			Expect(err).To(BeNil())
 			Expect(code).To(Equal(http.StatusOK))
+			zap.S().Infof("============Successfully Passed: %s=====", CurrentSpecReport().LeafNodeText)
+		})
+	})
 
+	Context("Share revocation on leave", func() {
+		It("customer leaves partner, shared assessment is revoked", func() {
+			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
+
+			// Customer shares the assessment
+			statusCode, err := customerSvc.ShareAssessment(assessment.Id)
+			Expect(err).To(BeNil())
+			Expect(statusCode).To(Equal(http.StatusOK))
+
+			// Partner can see the assessment
+			partnerAssessments, err := partnerSvc.GetAssessments()
+			Expect(err).To(BeNil())
+			Expect(findAssessment(partnerAssessments, assessment.Id)).To(BeTrue())
+
+			// Customer leaves the partner
+			err = customerSvc.LeavePartner(group.Id)
+			Expect(err).To(BeNil())
+
+			// Partner can no longer see the assessment
+			partnerAssessments, err = partnerSvc.GetAssessments()
+			Expect(err).To(BeNil())
+			Expect(findAssessment(partnerAssessments, assessment.Id)).To(BeFalse())
 			zap.S().Infof("============Successfully Passed: %s=====", CurrentSpecReport().LeafNodeText)
 		})
 	})


### PR DESCRIPTION
Description

When a customer in a partner’s group shares an assessment with the partner, then later leaves the group or is removed, the share affordance goes away, but the assessment remains visible to the partner. That is inconsistent with the intended model: sharing must be removed when the customer is no longer in the group or when the partner terminates the relationship.

Current behavior: Partner can still see assessments that were shared before the customer stopped being a member.

Expected behavior: Assessments that were shared must no longer appear for the partner once the customer is not a member of the group (and analogously when the relationship is terminated by the partner). Partner-side copies or references created by sharing should be revoked/deleted in line with that rule, not only the UI option to share.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shared assessments are now automatically revoked when a customer leaves a partner group, ensuring former partners immediately lose access to previously shared assessments.

* **Tests**
  * Added end-to-end tests verifying assessment sharing is revoked correctly when a customer departs a partner group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->