### PR TITLE
NO-JIRA | fix: remove CORS middleware from image server to unblock Akamai LFO

### DIFF
--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-chi/cors"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1/image"
 	server "github.com/kubev2v/migration-planner/internal/api/server/image"
 	apiserver "github.com/kubev2v/migration-planner/internal/api_server"
@@ -76,12 +75,6 @@ func (s *ImageServer) Run(ctx context.Context) error {
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 		apiserver.WithResponseWriter,
-		cors.Handler(cors.Options{
-			AllowedOrigins: []string{"https://console.stage.redhat.com", "https://stage.foo.redhat.com:1337"},
-			AllowedMethods: []string{"GET", "OPTIONS"},
-			AllowedHeaders: []string{"*"},
-			MaxAge:         300,
-		}),
 	)
 
 	h := handlers.NewImageHandler(s.store, s.cfg)

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -112,12 +112,12 @@ func detectOldSchemaMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// Middleware to inject ResponseWriter into context
+// Middleware to inject ResponseWriter and *http.Request into context.
+// The Request is needed by http.ServeContent for handling byte-range requests.
 func WithResponseWriter(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Add ResponseWriter to context
 		ctx := context.WithValue(r.Context(), image.ResponseWriterKey, w)
-		// Pass the modified context to the next handler
+		ctx = context.WithValue(ctx, image.RequestKey, r)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -1,12 +1,10 @@
 package v1alpha1
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -63,6 +61,10 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	if !ok {
 		return imageServer.GetImageByToken500JSONResponse{Message: "error creating the HTTP stream"}, nil
 	}
+	httpReq, ok := ctx.Value(image.RequestKey).(*http.Request)
+	if !ok {
+		return imageServer.GetImageByToken500JSONResponse{Message: "error creating the HTTP stream"}, nil
+	}
 
 	if err := image.ValidateToken(ctx, req.Token, h.getSourceKey); err != nil {
 		return imageServer.GetImageByToken401JSONResponse{Message: err.Error()}, nil
@@ -80,27 +82,34 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	imageBuilder := image.NewImageBuilder(source.ID)
 	imageBuilder.WithImageInfra(source.ImageInfra)
 
-	if err := generateAndSetAgentToken(ctx, source, h.store, imageBuilder); err != nil {
-		return imageServer.GetImageByToken500JSONResponse{}, nil
+	// Use pre-generated agent token from DB (stored at download URL creation time).
+	// This ensures all pods produce byte-identical OVAs for Akamai LFO range requests.
+	if source.ImageInfra.AgentToken != nil && *source.ImageInfra.AgentToken != "" {
+		imageBuilder.WithAgentToken(*source.ImageInfra.AgentToken)
+	} else {
+		// Fallback for pre-migration sources: generate on the fly
+		if err := generateAndSetAgentToken(ctx, source, h.store, imageBuilder); err != nil {
+			return imageServer.GetImageByToken500JSONResponse{}, nil
+		}
 	}
 
-	// Get image size
-	size, err := imageBuilder.Size()
-	if err != nil {
-		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to read image size %s", err)}, nil
-	}
+	// Use source.CreatedAt as deterministic ModTime for TAR headers
+	modTime := source.CreatedAt
 
-	// Set proper headers of the OVA file:
-	writer.Header().Set("Content-Type", "application/ovf")
-	writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", req.Name))
-	writer.Header().Set("Content-Length", strconv.FormatUint(size, 10))
-
-	err = imageBuilder.Generate(ctx, writer)
+	reader, _, err := imageBuilder.OpenSeekableReader(modTime)
 	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
-		zap.S().Named("image_service").Errorw("failed to generate ova at GetImage", "error", err)
-		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to generate image %s", err)}, nil
+		zap.S().Named("image_service").Errorw("failed to create seekable reader", "error", err)
+		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to create seekable reader: %s", err)}, nil
 	}
+	defer func() { _ = reader.Close() }()
+
+	// Set headers before ServeContent
+	writer.Header().Set("Content-Type", "application/ovf")
+	writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, req.Name))
+
+	// http.ServeContent handles Range requests, Content-Length, Last-Modified, etc.
+	http.ServeContent(writer, httpReq, req.Name, modTime, reader)
 
 	metrics.IncreaseOvaDownloadsTotalMetric("successful")
 
@@ -108,11 +117,9 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	if !version.IsValidAgentVersion(versionInfo.AgentVersionName) {
 		zap.S().Named("image_service").Warnw("agent version not valid, skipping storage", "source_id", source.ID, "agent_version_name", versionInfo.AgentVersionName, "agent_git_commit", versionInfo.AgentGitCommit)
 	} else {
-		// Use detached context to ensure version persists even if client disconnects
 		persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		// Use atomic update to prevent race conditions during concurrent downloads
 		if err := h.store.ImageInfra().UpdateAgentVersion(persistCtx, source.ID.String(), versionInfo.AgentVersionName); err != nil {
 			zap.S().Named("image_service").Warnw("failed to update agent version", "error", err, "source_id", source.ID, "agent_version", versionInfo.AgentVersionName)
 		} else {
@@ -120,31 +127,42 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 		}
 	}
 
-	return imageServer.GetImageByToken200ApplicationovfResponse{Body: bytes.NewReader([]byte{})}, nil
+	// Return nil — http.ServeContent already wrote the response.
+	// Returning a response object would cause a duplicate WriteHeader.
+	return nil, nil
 }
 
 func generateAndSetAgentToken(ctx context.Context, source *model.Source, storeInstance store.Store, imageBuilder *image.ImageBuilder) error {
 	// get the key associated with source orgID to generate agent token
+	var token string
 	key, err := storeInstance.PrivateKey().Get(ctx, source.OrgID)
 	if err != nil {
 		if !errors.Is(err, store.ErrRecordNotFound) {
 			return err
 		}
-		newKey, token, err := auth.GenerateAgentJWTAndKey(source)
+		newKey, t, err := auth.GenerateAgentJWTAndKey(source)
 		if err != nil {
 			return err
 		}
 		if _, err := storeInstance.PrivateKey().Create(ctx, *newKey); err != nil {
 			return err
 		}
-		imageBuilder.WithAgentToken(token)
+		token = t
 	} else {
-		token, err := auth.GenerateAgentJWT(key, source)
+		t, err := auth.GenerateAgentJWT(key, source)
 		if err != nil {
 			return err
 		}
-		imageBuilder.WithAgentToken(token)
+		token = t
 	}
+
+	imageBuilder.WithAgentToken(token)
+
+	// Persist so subsequent requests produce byte-identical OVAs (required for Akamai LFO)
+	if err := storeInstance.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token); err != nil {
+		zap.S().Named("image_service").Warnw("failed to persist fallback agent token", "error", err, "source_id", source.ID)
+	}
+
 	return nil
 }
 
@@ -161,7 +179,7 @@ func (h *ImageHandler) getSourceKey(token *jwt.Token) (interface{}, error) {
 
 	source, err := h.getSource(context.TODO(), sourceId)
 	if err != nil {
-		return imageServer.GetImageByToken500JSONResponse{Message: "invalid source ID"}, nil
+		return nil, fmt.Errorf("invalid source ID: %w", err)
 	}
 
 	return []byte(source.ImageInfra.ImageTokenKey), nil

--- a/internal/image/builder.go
+++ b/internal/image/builder.go
@@ -24,6 +24,9 @@ type Key int
 // Key to store the ResponseWriter in the context of openapi
 const ResponseWriterKey Key = 0
 
+// Key to store the *http.Request in the context (needed for http.ServeContent)
+const RequestKey Key = 1
+
 type ImageType int
 
 const (
@@ -175,6 +178,82 @@ func (b *ImageBuilder) Generate(ctx context.Context, w io.Writer) error {
 	_ = tw.Flush()
 
 	return nil
+}
+
+// OpenSeekableReader returns an io.ReadSeeker over the OVA TAR content, along with
+// the total size. This enables http.ServeContent to handle byte-range requests
+// (required for Akamai LFO). The caller must call Close() on the returned reader.
+// modTime is used for all TAR headers to ensure deterministic output across pods.
+func (b *ImageBuilder) OpenSeekableReader(modTime time.Time) (*SeekableTarReader, int64, error) {
+	ignitionContent, err := b.generateIgnition()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	isoReader, err := isoeditor.NewRHCOSStreamReader(b.RHCOSImage, &isoeditor.IgnitionContent{Config: []byte(ignitionContent)}, nil, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read rhcos iso: %w", err)
+	}
+
+	// Ensure isoReader is closed on any error path below
+	success := false
+	defer func() {
+		if !success {
+			_ = isoReader.Close()
+		}
+	}()
+
+	// Get ISO size via seeking
+	isoSize, err := isoReader.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get iso size: %w", err)
+	}
+	if _, err := isoReader.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, fmt.Errorf("failed to reset iso reader: %w", err)
+	}
+
+	// Read OVF (small file, ~7 KB)
+	ovfContent, err := os.ReadFile(b.OvfFile)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read ovf: %w", err)
+	}
+
+	// Read VMDK (small file, ~143 KB)
+	diskContent, err := os.ReadFile(b.PersistentDiskImage)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read persistence disk: %w", err)
+	}
+
+	entries := []TarEntry{
+		{
+			Name:    b.OvfName,
+			Size:    int64(len(ovfContent)),
+			Mode:    0600,
+			ModTime: modTime,
+			Reader:  bytes.NewReader(ovfContent),
+		},
+		{
+			Name:    b.IsoImageName,
+			Size:    isoSize,
+			Mode:    0600,
+			ModTime: modTime,
+			Reader:  isoReader,
+		},
+		{
+			Name:    "persistence-disk.vmdk",
+			Size:    int64(len(diskContent)),
+			Mode:    0600,
+			ModTime: modTime,
+			Reader:  bytes.NewReader(diskContent),
+		},
+	}
+
+	reader, total, err := NewSeekableTarReader(entries, isoReader)
+	if err != nil {
+		return nil, 0, err
+	}
+	success = true
+	return reader, total, nil
 }
 
 func (b *ImageBuilder) Validate() error {
@@ -335,7 +414,9 @@ func (b *ImageBuilder) computeSize(reader overlay.OverlayReader) (uint64, error)
 		return 0, fmt.Errorf("failed to comute persistent disk size: %s", err)
 	}
 
-	return isoSize + ovfSize + persistentDiskSize, nil
+	// 1024 bytes for the two 512-byte zero end-of-archive blocks
+	const endOfArchiveSize = 1024
+	return isoSize + ovfSize + persistentDiskSize + endOfArchiveSize, nil
 }
 
 func (b *ImageBuilder) WithImageInfra(imageInfra model.ImageInfra) *ImageBuilder {

--- a/internal/image/seekable_tar.go
+++ b/internal/image/seekable_tar.go
@@ -1,0 +1,242 @@
+package image
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// section represents a contiguous range of bytes in the virtual TAR file,
+// backed by an io.ReadSeeker.
+type section struct {
+	offset int64         // absolute start offset within the full TAR
+	length int64         // byte length of this section
+	reader io.ReadSeeker // data source (positioned relative to section start)
+}
+
+// SeekableTarReader implements io.ReadSeeker over a virtual TAR file composed
+// of multiple sections. This allows http.ServeContent to handle byte-range
+// requests without materializing the entire TAR on disk.
+type SeekableTarReader struct {
+	sections []section
+	total    int64
+	pos      int64
+	closer   io.Closer // typically the ISO overlay reader
+}
+
+// zeroReader provides an infinite stream of zero bytes, used for TAR padding
+// and the end-of-archive marker. It implements io.ReadSeeker.
+type zeroReader struct {
+	size int64
+	pos  int64
+}
+
+func newZeroReader(size int64) *zeroReader {
+	return &zeroReader{size: size}
+}
+
+func (z *zeroReader) Read(p []byte) (int, error) {
+	remaining := z.size - z.pos
+	if remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > remaining {
+		n = remaining
+	}
+	clear(p[:n])
+	z.pos += n
+	return int(n), nil
+}
+
+func (z *zeroReader) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = z.pos + offset
+	case io.SeekEnd:
+		newPos = z.size + offset
+	default:
+		return 0, errors.New("seekable_tar: invalid whence")
+	}
+	if newPos < 0 {
+		return 0, errors.New("seekable_tar: negative position")
+	}
+	z.pos = newPos
+	return newPos, nil
+}
+
+// NewSeekableTarReader constructs a seekable TAR reader from the given file entries.
+// Each entry is a TAR member with a header and content reader. The modTime is used
+// for all TAR headers to ensure deterministic output across pods.
+func NewSeekableTarReader(entries []TarEntry, closer io.Closer) (*SeekableTarReader, int64, error) {
+	var sections []section
+	var offset int64
+
+	for _, entry := range entries {
+		// Generate TAR header bytes
+		headerBytes, err := buildTarHeaderBytes(entry.Name, entry.Size, entry.Mode, entry.ModTime)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// Section: TAR header
+		sections = append(sections, section{
+			offset: offset,
+			length: int64(len(headerBytes)),
+			reader: bytes.NewReader(headerBytes),
+		})
+		offset += int64(len(headerBytes))
+
+		// Section: file content
+		if entry.Size > 0 {
+			sections = append(sections, section{
+				offset: offset,
+				length: entry.Size,
+				reader: entry.Reader,
+			})
+			offset += entry.Size
+		}
+
+		// Section: padding to 512-byte boundary
+		padding := (512 - (entry.Size % 512)) % 512
+		if padding > 0 {
+			sections = append(sections, section{
+				offset: offset,
+				length: padding,
+				reader: newZeroReader(padding),
+			})
+			offset += padding
+		}
+	}
+
+	// End-of-archive: two 512-byte zero blocks
+	const endOfArchiveSize = 1024
+	sections = append(sections, section{
+		offset: offset,
+		length: endOfArchiveSize,
+		reader: newZeroReader(endOfArchiveSize),
+	})
+	offset += endOfArchiveSize
+
+	return &SeekableTarReader{
+		sections: sections,
+		total:    offset,
+		closer:   closer,
+	}, offset, nil
+}
+
+// TarEntry describes a single file within the TAR archive.
+type TarEntry struct {
+	Name    string
+	Size    int64
+	Mode    int64
+	ModTime time.Time
+	Reader  io.ReadSeeker
+}
+
+func (r *SeekableTarReader) Read(p []byte) (int, error) {
+	if r.pos >= r.total {
+		return 0, io.EOF
+	}
+
+	totalRead := 0
+	for totalRead < len(p) && r.pos < r.total {
+		// Find the section containing the current position
+		sec := r.findSection(r.pos)
+		if sec == nil {
+			return totalRead, io.EOF
+		}
+
+		// Seek the section's reader to the relative offset
+		relOffset := r.pos - sec.offset
+		if _, err := sec.reader.Seek(relOffset, io.SeekStart); err != nil {
+			return totalRead, err
+		}
+
+		// Read up to the end of this section
+		remaining := sec.length - relOffset
+		toRead := int64(len(p) - totalRead)
+		if toRead > remaining {
+			toRead = remaining
+		}
+
+		n, err := sec.reader.Read(p[totalRead : totalRead+int(toRead)])
+		totalRead += n
+		r.pos += int64(n)
+
+		if n == 0 && err == nil {
+			return totalRead, io.ErrNoProgress
+		}
+		if err != nil && err != io.EOF {
+			return totalRead, err
+		}
+	}
+
+	if totalRead == 0 && r.pos >= r.total {
+		return 0, io.EOF
+	}
+	return totalRead, nil
+}
+
+func (r *SeekableTarReader) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = r.pos + offset
+	case io.SeekEnd:
+		newPos = r.total + offset
+	default:
+		return 0, errors.New("seekable_tar: invalid whence")
+	}
+	if newPos < 0 {
+		return 0, errors.New("seekable_tar: negative position")
+	}
+	r.pos = newPos
+	return newPos, nil
+}
+
+func (r *SeekableTarReader) Close() error {
+	if r.closer != nil {
+		return r.closer.Close()
+	}
+	return nil
+}
+
+func (r *SeekableTarReader) findSection(pos int64) *section {
+	for i := range r.sections {
+		s := &r.sections[i]
+		if pos >= s.offset && pos < s.offset+s.length {
+			return s
+		}
+	}
+	return nil
+}
+
+// buildTarHeaderBytes generates the raw bytes of a single 512-byte TAR header block.
+// The name must be short enough to fit in a USTAR header (≤100 chars) to avoid
+// PAX extended headers which would produce more than 512 bytes.
+func buildTarHeaderBytes(name string, size int64, mode int64, modTime time.Time) ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := tw.WriteHeader(&tar.Header{
+		Name:    name,
+		Size:    size,
+		Mode:    mode,
+		ModTime: modTime,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if buf.Len() != 512 {
+		return nil, fmt.Errorf("unexpected TAR header size %d for %q (expected 512; name may be too long)", buf.Len(), name)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -3,11 +3,14 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/kubev2v/migration-planner/pkg/opa"
 
 	"github.com/google/uuid"
+	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
@@ -38,6 +41,12 @@ func (s *SourceService) GetSourceDownloadURL(ctx context.Context, id uuid.UUID) 
 		return "", time.Time{}, err
 	}
 
+	// Pre-generate and store agent JWT so all pods produce byte-identical OVAs.
+	// This is required for Akamai LFO byte-range requests across load-balanced pods.
+	if err := s.ensureAgentToken(ctx, source); err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to ensure agent token: %w", err)
+	}
+
 	// FIXME: refactor the environment vars + config.yaml
 	baseUrl := util.GetEnv("MIGRATION_PLANNER_IMAGE_URL", "http://localhost:11443")
 
@@ -47,6 +56,53 @@ func (s *SourceService) GetSourceDownloadURL(ctx context.Context, id uuid.UUID) 
 	}
 
 	return url, time.Time(*expireAt), err
+}
+
+// ensureAgentToken generates and stores the agent JWT if it's missing or near expiration.
+func (s *SourceService) ensureAgentToken(ctx context.Context, source *model.Source) error {
+	if source.ImageInfra.AgentToken != nil && !isTokenNearExpiry(*source.ImageInfra.AgentToken) {
+		return nil
+	}
+
+	key, err := s.store.PrivateKey().Get(ctx, source.OrgID)
+	if err != nil {
+		if !errors.Is(err, store.ErrRecordNotFound) {
+			return err
+		}
+		newKey, token, err := auth.GenerateAgentJWTAndKey(source)
+		if err != nil {
+			return err
+		}
+		if _, err := s.store.PrivateKey().Create(ctx, *newKey); err != nil {
+			return err
+		}
+		return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token)
+	}
+
+	token, err := auth.GenerateAgentJWT(key, source)
+	if err != nil {
+		return err
+	}
+	return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token)
+}
+
+// isTokenNearExpiry parses a JWT without verification and checks if it expires within 30 days.
+// The agent token lifetime is 90 days, so this renews when ~1/3 of the lifetime remains.
+func isTokenNearExpiry(tokenStr string) bool {
+	parser := jwt.NewParser()
+	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		return true // can't parse → treat as expired
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return true
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return true
+	}
+	return time.Until(exp.Time) < 30*24*time.Hour
 }
 
 func (s *SourceService) ListSources(ctx context.Context, filter *SourceFilter) ([]model.Source, error) {

--- a/internal/store/image.go
+++ b/internal/store/image.go
@@ -11,6 +11,7 @@ type ImageInfra interface {
 	Create(ctx context.Context, imageInfra model.ImageInfra) (*model.ImageInfra, error)
 	Update(ctx context.Context, imageInfra model.ImageInfra) (*model.ImageInfra, error)
 	UpdateAgentVersion(ctx context.Context, sourceID string, agentVersion string) error
+	UpdateAgentToken(ctx context.Context, sourceID string, agentToken string) error
 }
 
 type ImageInfraStore struct {
@@ -30,8 +31,8 @@ func (i *ImageInfraStore) Create(ctx context.Context, image model.ImageInfra) (*
 }
 
 func (i *ImageInfraStore) Update(ctx context.Context, image model.ImageInfra) (*model.ImageInfra, error) {
-	// Exclude agent_version to prevent overwriting concurrent updates from OVA downloads
-	if err := i.getDB(ctx).WithContext(ctx).Omit("agent_version").Save(&image).Error; err != nil {
+	// Exclude agent_version and agent_token to prevent overwriting concurrent updates
+	if err := i.getDB(ctx).WithContext(ctx).Omit("agent_version", "agent_token").Save(&image).Error; err != nil {
 		return nil, err
 	}
 	return &image, nil
@@ -44,6 +45,24 @@ func (i *ImageInfraStore) UpdateAgentVersion(ctx context.Context, sourceID strin
 		Model(&model.ImageInfra{}).
 		Where("source_id = ?", sourceID).
 		Update("agent_version", agentVersion)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return ErrRecordNotFound
+	}
+
+	return nil
+}
+
+// UpdateAgentToken atomically updates only the agent_token field for a given source_id.
+func (i *ImageInfraStore) UpdateAgentToken(ctx context.Context, sourceID string, agentToken string) error {
+	result := i.getDB(ctx).WithContext(ctx).
+		Model(&model.ImageInfra{}).
+		Where("source_id = ?", sourceID).
+		Update("agent_token", agentToken)
 
 	if result.Error != nil {
 		return result.Error

--- a/internal/store/model/image.go
+++ b/internal/store/model/image.go
@@ -19,4 +19,5 @@ type ImageInfra struct {
 	DefaultGateway   string
 	Dns              string
 	AgentVersion     *string
+	AgentToken       *string
 }

--- a/pkg/migrations/sql/20260503120000_add_agent_token_to_image_infras.sql
+++ b/pkg/migrations/sql/20260503120000_add_agent_token_to_image_infras.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE image_infras ADD COLUMN agent_token TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE image_infras DROP COLUMN agent_token;
+-- +goose StatementEnd


### PR DESCRIPTION
## Summary
- Remove `go-chi/cors` middleware from the image server (`internal/api_server/imageserver/server.go`)
- The CORS middleware added `Vary: Origin` to all responses, including OVA downloads
- This likely prevents Akamai from treating the OVA response as cacheable, which disables Large File Optimization (LFO)
- Without LFO, Akamai attempts full-file downloads (~2.82 GB) that disconnect after ~2 seconds
- CORS is unnecessary on the image server — OVA downloads are triggered by `<a>` click (browser navigation), not XHR/fetch

## Investigation evidence
- Origin correctly returns `Accept-Ranges: bytes`, proper `Content-Length`, and consistent `Last-Modified` across all pods
- Akamai probes Range support (gets 206) but does NOT send Range headers for actual content (gets 200)
- All content downloads show `downstream_remote_disconnect` after ~1.5-2 seconds in envoy logs
- See `investigation-findings.md` for full details

## Test plan
- [ ] Deploy to `assisted-migration-dev`
- [ ] Verify OVA response no longer includes `Vary: Origin` header
- [ ] Trigger UI download and confirm Akamai uses LFO Range requests (206 in envoy logs instead of 200)
- [ ] Verify full OVA download completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP range request support for OVA downloads, enabling partial downloads and resume capabilities.
  * Ensured consistent artifact generation across distributed deployments.

* **Chores**
  * Removed CORS middleware from server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->