### PR TITLE
NO-JIRA | fix: add ETag header to OVA responses for Akamai LFO compatibility

### DIFF
--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -104,7 +104,11 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 	}
 	defer func() { _ = reader.Close() }()
 
-	// Set headers before ServeContent
+	// Set headers before ServeContent.
+	// ETag derived from source ID + creation time — deterministic across pods.
+	// Must be strong (no W/ prefix) for Akamai LFO.
+	etag := fmt.Sprintf(`"%s-%d"`, source.ID, modTime.Unix())
+	writer.Header().Set("ETag", etag)
 	writer.Header().Set("Content-Type", "application/ovf")
 	writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, req.Name))
 


### PR DESCRIPTION
## Summary
- Add a strong `ETag` header to OVA download responses, derived from source ID + creation timestamp
- The ETag is deterministic across all pods since both values come from the shared DB

## Why
Akamai LFO (Large File Optimization) requires a strong ETag from origin for fragment validation when splitting large file downloads into Range-request chunks ([docs](https://techdocs.akamai.com/property-mgr/docs/large-file-optimization-lfo)).

## Test plan
- [ ] Deploy to `assisted-migration-dev`
- [ ] Verify response includes `ETag` header:
  ```
  curl -s -D - -o /dev/null -H "Range: bytes=0-0" \
    https://migration-planner-image-.../api/v1/image/bytoken/{token}/test.ova
  ```
- [ ] Verify ETag is consistent across pods (same value for same source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)