### PR TITLE
NO-JIRA | fix: remove CORS middleware from image server

### DIFF
--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-	"github.com/go-chi/cors"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1/image"
 	server "github.com/kubev2v/migration-planner/internal/api/server/image"
 	apiserver "github.com/kubev2v/migration-planner/internal/api_server"
@@ -76,12 +75,6 @@ func (s *ImageServer) Run(ctx context.Context) error {
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
 		apiserver.WithResponseWriter,
-		cors.Handler(cors.Options{
-			AllowedOrigins: []string{"https://console.stage.redhat.com", "https://stage.foo.redhat.com:1337"},
-			AllowedMethods: []string{"GET", "OPTIONS"},
-			AllowedHeaders: []string{"*"},
-			MaxAge:         300,
-		}),
 	)
 
 	h := handlers.NewImageHandler(s.store, s.cfg)


### PR DESCRIPTION
## Summary
- Remove `go-chi/cors` middleware from the image server
- This removes the `Vary: Origin` header from OVA download responses

## Why
Akamai LFO requires responses to be cacheable. The `Vary: Origin` header (added by the CORS middleware) prevents Akamai from caching the response, which disables LFO fragment caching.

CORS is unnecessary on the image server — OVA downloads are triggered by `<a>` click (browser navigation), not XHR/fetch requests. CORS headers are ignored for navigations.

## Test plan
- [ ] Deploy to dev
- [ ] Verify OVA response no longer includes `Vary: Origin`:
  ```
  curl -s -D - -o /dev/null -H "Range: bytes=0-0" \
    https://migration-planner-image-.../api/v1/image/bytoken/{token}/test.ova
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)