### PR TITLE
NO-JIRA | fix: Update the size of the ISO in OVF template

### DIFF
--- a/data/MigrationAssessment.ovf
+++ b/data/MigrationAssessment.ovf
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
   <References>
-    <File ovf:href="MigrationAssessment.iso" ovf:id="file1" ovf:size="1244659712"/>
+    <File ovf:href="MigrationAssessment.iso" ovf:id="file1" ovf:size="2816475136"/>
     <File ovf:href="persistence-disk.vmdk" ovf:id="file2" ovf:size="146432"/>
   </References>
   <DiskSection>


### PR DESCRIPTION
When user deploy the OVA using VMware gui, get misleading info about image size.

<img width="1162" height="686" alt="Snímek obrazovky 2026-05-07 v 13 14 36" src="https://github.com/user-attachments/assets/f6e69e36-e8df-47f9-b1dd-4756db263e66" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated migration assessment data file configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->