### PR TITLE
NO-JIRA | refactor: decouple image handler from image service

### DIFF
--- a/api/v1alpha1/openapi.yaml
+++ b/api/v1alpha1/openapi.yaml
@@ -346,6 +346,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /api/v1/sources/{id}/image:
     head:
       tags:

--- a/api/v1alpha1/spec.gen.go
+++ b/api/v1alpha1/spec.gen.go
@@ -175,9 +175,9 @@ var swaggerSpec = []string{
 	"ruMM1YO/zNlpNrY5M18XtZaPk/YxbhWEnD1E2jusJIP9tXy3q8l6YzzcJL1ZS82oJjWhXBKyglHPkNhw",
 	"6YZLN1y6NkWwxv+zgif119fGlutSRV/m4a9aGuj1JAJzIxk2kmGN53eF7r2DAzhRevcUQa8sQH5B0FNc",
 	"f/n5GOi2RSkim5ybL/UixHu5k73mIG7DHq3IuZn8GsllUfRqjDRgtxsxv9Y9M4dfMMMQfLr+UK3BvaX3",
-	"xKfQ041qUa47AOz95bS4kCGOJwR5Cno2mXb9AQiq0r1LYGQYZONSvza5ugjpkxkigjKd1b9GOUob2vWj",
-	"88z371ZFKm71lWpJGWRt9KWNvrRmfWmKoC+mlUen/gzcKXLvbFqRr9i+nTaSWYKZ9YtaP1cL1dJGHePO",
-	"jvP45fH/BwAA//9KRYHliycBAA==",
+	"xKfQ041qUa47AOz95bS4kCGOJwR5Cno2mXb9AQiq0r1LYGQYZONS//3L1UbGIzNEBGW6pkCNapY2tGtn",
+	"55nv362CVtzqK9XRMsjaaGsbbW3N2toUQV9MKw9u/Rm4U+Te2XQyX7F9O10oswQz6xe1fq4WqqWNUiKc",
+	"Hefxy+P/DwAA//8QipIhCSgBAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -61,8 +61,6 @@ parameters:
     value: "https://localhost:3443"
   - name: MIGRATION_PLANNER_BASE_AGENT_ENDPOINT_URL
     value: "https://localhost:7443"
-  - name: MIGRATION_PLANNER_BASE_IMAGE_ENDPOINT_URL
-    value: "https://localhost:11443"
   - name: MIGRATION_PLANNER_LOG_LEVEL
     value: "info"
   # Auth Config values
@@ -616,8 +614,6 @@ objects:
                   value: ${MIGRATION_PLANNER_BASE_URL}
                 - name: MIGRATION_PLANNER_BASE_AGENT_ENDPOINT_URL
                   value: ${MIGRATION_PLANNER_BASE_AGENT_ENDPOINT_URL}
-                - name: MIGRATION_PLANNER_BASE_IMAGE_ENDPOINT_URL
-                  value: ${MIGRATION_PLANNER_BASE_IMAGE_ENDPOINT_URL}
                 - name: MIGRATION_PLANNER_LOG_LEVEL
                   value: ${MIGRATION_PLANNER_LOG_LEVEL}
                 - name: RHCOS_PASSWORD

--- a/internal/api/client/client.gen.go
+++ b/internal/api/client/client.gen.go
@@ -4009,6 +4009,7 @@ type GetSourceDownloadURLResponse struct {
 	JSON400      *Error
 	JSON401      *Error
 	JSON404      *Error
+	JSON500      *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -6815,6 +6816,13 @@ func ParseGetSourceDownloadURLResponse(rsp *http.Response) (*GetSourceDownloadUR
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 

--- a/internal/api/server/server.gen.go
+++ b/internal/api/server/server.gen.go
@@ -3980,6 +3980,15 @@ func (response GetSourceDownloadURL404JSONResponse) VisitGetSourceDownloadURLRes
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetSourceDownloadURL500JSONResponse Error
+
+func (response GetSourceDownloadURL500JSONResponse) VisitGetSourceDownloadURLResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type UpdateInventoryRequestObject struct {
 	Id   openapi_types.UUID `json:"id"`
 	Body *UpdateInventoryJSONRequestBody

--- a/internal/api_server/imageserver/server.go
+++ b/internal/api_server/imageserver/server.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kubev2v/migration-planner/internal/service/image_server"
+
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
 
@@ -15,10 +17,10 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1/image"
 	server "github.com/kubev2v/migration-planner/internal/api/server/image"
-	apiserver "github.com/kubev2v/migration-planner/internal/api_server"
 	"github.com/kubev2v/migration-planner/internal/config"
 	handlers "github.com/kubev2v/migration-planner/internal/handlers/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/store"
+	pmiddleware "github.com/kubev2v/migration-planner/pkg/middleware"
 	oapimiddleware "github.com/oapi-codegen/nethttp-middleware"
 	"go.uber.org/zap"
 )
@@ -74,10 +76,10 @@ func (s *ImageServer) Run(ctx context.Context) error {
 		log.ConditionalLogger(s.cfg.Service.LogLevel, zap.L(), "image_server"),
 		middleware.Recoverer,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
-		apiserver.WithResponseWriter,
+		pmiddleware.RequestContext,
 	)
 
-	h := handlers.NewImageHandler(s.store, s.cfg)
+	h := handlers.NewImageHandler(image_server.NewImageService(s.store))
 	server.HandlerFromMux(server.NewStrictHandler(h, nil), router)
 	srv := http.Server{Addr: s.cfg.Service.Address, Handler: router}
 

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/client"
 	"github.com/kubev2v/migration-planner/internal/config"
 	handlers "github.com/kubev2v/migration-planner/internal/handlers/v1alpha1"
-	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/kubev2v/migration-planner/internal/rvtools/jobs"
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/store"
@@ -112,16 +111,6 @@ func detectOldSchemaMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// Middleware to inject ResponseWriter and *http.Request into context.
-// The Request is needed by http.ServeContent for handling byte-range requests.
-func WithResponseWriter(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := context.WithValue(r.Context(), image.ResponseWriterKey, w)
-		ctx = context.WithValue(ctx, image.RequestKey, r)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
 func (s *Server) Run(ctx context.Context) error {
 	zap.S().Named("api_server").Info("Initializing API server")
 	swagger, err := api.GetSwagger()
@@ -161,7 +150,6 @@ func (s *Server) Run(ctx context.Context) error {
 		chiMiddleware.Recoverer,
 		detectOldSchemaMiddleware,
 		oapimiddleware.OapiRequestValidatorWithOptions(swagger, &oapiOpts),
-		WithResponseWriter,
 	)
 
 	// Initialize sizer client
@@ -187,7 +175,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	h := handlers.NewServiceHandler(
-		service.NewSourceService(s.store, s.opaValidator),
+		service.NewSourceService(s.store, s.opaValidator, s.cfg.Service.BaseImageEndpointUrl),
 		assessmentSvc,
 		service.NewJobService(s.store, s.jobsClient.RiverClient, s.jobsClient.Pool),
 		service.NewSizerService(sizerClient, s.store),

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/kubev2v/migration-planner/internal/image"
+	image "github.com/kubev2v/migration-planner/internal/service/image_server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type svcConfig struct {
 	ImageEndpointAddress string `envconfig:"MIGRATION_PLANNER_IMAGE_ENDPOINT_ADDRESS" default:":11443"`
 	BaseUrl              string `envconfig:"MIGRATION_PLANNER_BASE_URL" default:"https://localhost:3443"`
 	BaseAgentEndpointUrl string `envconfig:"MIGRATION_PLANNER_BASE_AGENT_ENDPOINT_URL" default:"https://localhost:7443"`
-	BaseImageEndpointUrl string `envconfig:"MIGRATION_PLANNER_BASE_IMAGE_ENDPOINT_URL" default:"https://localhost:11443"`
+	BaseImageEndpointUrl string `envconfig:"MIGRATION_PLANNER_IMAGE_URL" default:"https://localhost:11443"`
 	LogLevel             string `envconfig:"MIGRATION_PLANNER_LOG_LEVEL" default:"info"`
 	Auth                 Auth
 	MigrationFolder      string `envconfig:"MIGRATION_PLANNER_MIGRATIONS_FOLDER" default:""`

--- a/internal/handlers/v1alpha1/assessment_test.go
+++ b/internal/handlers/v1alpha1/assessment_test.go
@@ -95,7 +95,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListAssessments(ctx, server.ListAssessmentsRequestObject{})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.ListAssessments200JSONResponse{}).String()))
@@ -119,7 +119,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListAssessments(ctx, server.ListAssessmentsRequestObject{})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.ListAssessments200JSONResponse{}).String()))
@@ -170,7 +170,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 				SourceId: &sourceIDOpenAPI,
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListAssessments(ctx, server.ListAssessmentsRequestObject{
 				Params: params,
 			})
@@ -216,7 +216,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 				SourceId: &sourceIDOpenAPI,
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListAssessments(ctx, server.ListAssessmentsRequestObject{
 				Params: params,
 			})
@@ -248,7 +248,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 			inventory := createMinimalInventory()
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
 				Body: &v1alpha1.AssessmentForm{
 					Name:       "test-assessment",
@@ -283,7 +283,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 
 			inventory := createMinimalInventory()
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			// Note: AssessmentForm schema deliberately excludes owner fields
 			// This prevents users from spoofing owner information via API requests
@@ -323,7 +323,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
 				Body: &v1alpha1.AssessmentForm{
 					Name:       "agent-assessment",
@@ -348,7 +348,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.CreateAssessment400JSONResponse{}).String()))
@@ -370,7 +370,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
 				Body: &v1alpha1.AssessmentForm{
 					Name:       "forbidden-assessment",
@@ -395,7 +395,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateAssessment(ctx, server.CreateAssessmentRequestObject{
 				Body: &v1alpha1.AssessmentForm{
 					Name:       "no-inventory-assessment",
@@ -426,7 +426,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 				EmailDomain:  "admin.example.com",
 			}
 			ctx = auth.NewTokenContext(context.TODO(), user)
-			srv = handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv = handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 		})
 
 		Context("name validation", func() {
@@ -750,7 +750,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetAssessment(ctx, server.GetAssessmentRequestObject{Id: assessmentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetAssessment200JSONResponse{}).String()))
@@ -771,7 +771,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetAssessment(ctx, server.GetAssessmentRequestObject{Id: nonExistentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetAssessment404JSONResponse{}).String()))
@@ -787,7 +787,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetAssessment(ctx, server.GetAssessmentRequestObject{Id: assessmentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetAssessment403JSONResponse{}).String()))
@@ -816,7 +816,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			updatedName := "updated-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: assessmentID,
@@ -841,7 +841,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id:   assessmentID,
 				Body: nil,
@@ -863,7 +863,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			newName := "new-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: nonExistentID,
@@ -885,7 +885,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
 			hackedName := "hacked-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: assessmentID,
@@ -913,7 +913,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			updatedName := "updated-inventory-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: assessmentID,
@@ -949,7 +949,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			updatedName := "updated-rvtools-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: assessmentID,
@@ -994,7 +994,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			updatedName := "updated-agent-name"
 			resp, err := srv.UpdateAssessment(ctx, server.UpdateAssessmentRequestObject{
 				Id: assessmentID,
@@ -1035,7 +1035,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.DeleteAssessment(ctx, server.DeleteAssessmentRequestObject{Id: assessmentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.DeleteAssessment200JSONResponse{}).String()))
@@ -1062,7 +1062,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.DeleteAssessment(ctx, server.DeleteAssessmentRequestObject{Id: nonExistentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.DeleteAssessment404JSONResponse{}).String()))
@@ -1078,7 +1078,7 @@ var _ = Describe("assessment handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), &ForbiddenAssessmentService{}, nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.DeleteAssessment(ctx, server.DeleteAssessmentRequestObject{Id: assessmentID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.DeleteAssessment403JSONResponse{}).String()))

--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -2,36 +2,27 @@ package v1alpha1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
-	"github.com/golang-jwt/jwt/v4"
-	"github.com/google/uuid"
+	"github.com/kubev2v/migration-planner/pkg/middleware"
+
 	imageServer "github.com/kubev2v/migration-planner/internal/api/server/image"
-	"github.com/kubev2v/migration-planner/internal/auth"
-	"github.com/kubev2v/migration-planner/internal/config"
-	"github.com/kubev2v/migration-planner/internal/image"
-	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/internal/store/model"
+	image "github.com/kubev2v/migration-planner/internal/service/image_server"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
-	"github.com/kubev2v/migration-planner/pkg/version"
 	"go.uber.org/zap"
 )
 
 type ImageHandler struct {
-	store store.Store
-	cfg   *config.Config
+	is *image.ImageService
 }
 
 // Make sure we conform to servers Service interface
 var _ imageServer.Service = (*ImageHandler)(nil)
 
-func NewImageHandler(store store.Store, cfg *config.Config) *ImageHandler {
+func NewImageHandler(is *image.ImageService) *ImageHandler {
 	return &ImageHandler{
-		store: store,
-		cfg:   cfg,
+		is: is,
 	}
 }
 
@@ -40,164 +31,62 @@ func (h *ImageHandler) Health(ctx context.Context, request imageServer.HealthReq
 }
 
 func (h *ImageHandler) HeadImageByToken(ctx context.Context, req imageServer.HeadImageByTokenRequestObject) (imageServer.HeadImageByTokenResponseObject, error) {
-	if err := image.ValidateToken(ctx, req.Token, h.getSourceKey); err != nil {
+	if err := h.is.ValidateToken(req.Token); err != nil {
 		return imageServer.HeadImageByToken401JSONResponse{Message: err.Error()}, nil
-	}
-
-	sourceId, err := image.IdFromJWT(req.Token)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the HTTP stream: %v", err)
-	}
-	_, err = h.getSource(ctx, sourceId)
-	if err != nil {
-		return imageServer.HeadImageByToken401JSONResponse{Message: "failed to create the HTTP stream"}, nil
 	}
 
 	return imageServer.HeadImageByToken200Response{}, nil
 }
 
 func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetImageByTokenRequestObject) (imageServer.GetImageByTokenResponseObject, error) {
-	writer, ok := ctx.Value(image.ResponseWriterKey).(http.ResponseWriter)
-	if !ok {
-		return imageServer.GetImageByToken500JSONResponse{Message: "error creating the HTTP stream"}, nil
-	}
-	httpReq, ok := ctx.Value(image.RequestKey).(*http.Request)
-	if !ok {
-		return imageServer.GetImageByToken500JSONResponse{Message: "error creating the HTTP stream"}, nil
-	}
-
-	if err := image.ValidateToken(ctx, req.Token, h.getSourceKey); err != nil {
+	if err := h.is.ValidateToken(req.Token); err != nil {
 		return imageServer.GetImageByToken401JSONResponse{Message: err.Error()}, nil
 	}
 
-	sourceId, err := image.IdFromJWT(req.Token)
+	sourceId, err := h.is.IdFromJWT(req.Token)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the HTTP stream: %v", err)
-	}
-	source, err := h.getSource(ctx, sourceId)
-	if err != nil {
-		return imageServer.GetImageByToken401JSONResponse{Message: "failed to create the HTTP stream"}, nil
+		return imageServer.GetImageByToken401JSONResponse{Message: err.Error()}, nil
 	}
 
-	imageBuilder := image.NewImageBuilder(source.ID)
-	imageBuilder.WithImageInfra(source.ImageInfra)
+	writer, ok := ctx.Value(middleware.ResponseWriterKey).(http.ResponseWriter)
+	httpReq, ok2 := ctx.Value(middleware.RequestKey).(*http.Request)
+	if !ok || !ok2 {
+		return imageServer.GetImageByToken500JSONResponse{Message: "error creating the HTTP stream"}, nil
+	}
 
-	// Use pre-generated agent token from DB (stored at download URL creation time).
-	// This ensures all pods produce byte-identical OVAs for Akamai LFO range requests.
-	if source.ImageInfra.AgentToken != nil && *source.ImageInfra.AgentToken != "" {
-		imageBuilder.WithAgentToken(*source.ImageInfra.AgentToken)
-	} else {
-		// Fallback for pre-migration sources: generate on the fly
-		if err := generateAndSetAgentToken(ctx, source, h.store, imageBuilder); err != nil {
-			return imageServer.GetImageByToken500JSONResponse{}, nil
+	success := false
+	defer func() {
+		if success {
+			metrics.IncreaseOvaDownloadsTotalMetric("successful")
+			return
 		}
-	}
-
-	// Use source.CreatedAt as deterministic ModTime for TAR headers
-	modTime := source.CreatedAt
-
-	reader, _, err := imageBuilder.OpenSeekableReader(modTime)
-	if err != nil {
 		metrics.IncreaseOvaDownloadsTotalMetric("failed")
+	}()
+
+	imageReader, modTime, err := h.is.ImageReader(ctx, sourceId)
+	if err != nil {
 		zap.S().Named("image_service").Errorw("failed to create seekable reader", "error", err)
-		return imageServer.GetImageByToken500JSONResponse{Message: fmt.Sprintf("failed to create seekable reader: %s", err)}, nil
+		return imageServer.GetImageByToken500JSONResponse{Message: err.Error()}, nil
 	}
-	defer func() { _ = reader.Close() }()
+
+	defer func() { _ = imageReader.Close() }()
 
 	// Set headers before ServeContent.
 	// ETag derived from source ID + creation time — deterministic across pods.
 	// Must be strong (no W/ prefix) for Akamai LFO.
-	etag := fmt.Sprintf(`"%s-%d"`, source.ID, modTime.Unix())
+	etag := fmt.Sprintf(`"%s-%d"`, sourceId, modTime.Unix())
 	writer.Header().Set("ETag", etag)
 	writer.Header().Set("Content-Type", "application/ovf")
 	writer.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, req.Name))
 
 	// http.ServeContent handles Range requests, Content-Length, Last-Modified, etc.
-	http.ServeContent(writer, httpReq, req.Name, modTime, reader)
+	http.ServeContent(writer, httpReq, req.Name, modTime, imageReader)
 
-	metrics.IncreaseOvaDownloadsTotalMetric("successful")
+	h.is.UpdateAgentVersion(sourceId)
 
-	versionInfo := version.Get()
-	if !version.IsValidAgentVersion(versionInfo.AgentVersionName) {
-		zap.S().Named("image_service").Warnw("agent version not valid, skipping storage", "source_id", source.ID, "agent_version_name", versionInfo.AgentVersionName, "agent_git_commit", versionInfo.AgentGitCommit)
-	} else {
-		persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		if err := h.store.ImageInfra().UpdateAgentVersion(persistCtx, source.ID.String(), versionInfo.AgentVersionName); err != nil {
-			zap.S().Named("image_service").Warnw("failed to update agent version", "error", err, "source_id", source.ID, "agent_version", versionInfo.AgentVersionName)
-		} else {
-			zap.S().Named("image_service").Infow("stored agent version", "source_id", source.ID, "agent_version", versionInfo.AgentVersionName)
-		}
-	}
+	success = true
 
 	// Return nil — http.ServeContent already wrote the response.
 	// Returning a response object would cause a duplicate WriteHeader.
 	return nil, nil
-}
-
-func generateAndSetAgentToken(ctx context.Context, source *model.Source, storeInstance store.Store, imageBuilder *image.ImageBuilder) error {
-	// get the key associated with source orgID to generate agent token
-	var token string
-	key, err := storeInstance.PrivateKey().Get(ctx, source.OrgID)
-	if err != nil {
-		if !errors.Is(err, store.ErrRecordNotFound) {
-			return err
-		}
-		newKey, t, err := auth.GenerateAgentJWTAndKey(source)
-		if err != nil {
-			return err
-		}
-		if _, err := storeInstance.PrivateKey().Create(ctx, *newKey); err != nil {
-			return err
-		}
-		token = t
-	} else {
-		t, err := auth.GenerateAgentJWT(key, source)
-		if err != nil {
-			return err
-		}
-		token = t
-	}
-
-	imageBuilder.WithAgentToken(token)
-
-	// Persist so subsequent requests produce byte-identical OVAs (required for Akamai LFO)
-	if err := storeInstance.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token); err != nil {
-		zap.S().Named("image_service").Warnw("failed to persist fallback agent token", "error", err, "source_id", source.ID)
-	}
-
-	return nil
-}
-
-func (h *ImageHandler) getSourceKey(token *jwt.Token) (interface{}, error) {
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, fmt.Errorf("malformed token claims")
-	}
-
-	sourceId, ok := claims["sub"].(string)
-	if !ok {
-		return nil, fmt.Errorf("token missing 'sub' claim")
-	}
-
-	source, err := h.getSource(context.TODO(), sourceId)
-	if err != nil {
-		return nil, fmt.Errorf("invalid source ID: %w", err)
-	}
-
-	return []byte(source.ImageInfra.ImageTokenKey), nil
-}
-
-func (h *ImageHandler) getSource(ctx context.Context, sourceId string) (*model.Source, error) {
-	sourceUUID, err := uuid.Parse(sourceId)
-	if err != nil {
-		return nil, fmt.Errorf("invalid source ID")
-	}
-	source, err := h.store.Source().Get(ctx, sourceUUID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid source ID")
-	}
-
-	return source, nil
 }

--- a/internal/handlers/v1alpha1/job_test.go
+++ b/internal/handlers/v1alpha1/job_test.go
@@ -63,7 +63,7 @@ var _ = Describe("job handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
 			resp, err := srv.GetJob(ctx, server.GetJobRequestObject{Id: 123})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetJob404JSONResponse{}).String()))
@@ -78,7 +78,7 @@ var _ = Describe("job handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
 			resp, err := srv.CancelJob(ctx, server.CancelJobRequestObject{Id: 123})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.CancelJob404JSONResponse{}).String()))
@@ -116,7 +116,7 @@ var _ = Describe("job handler", Ordered, func() {
 				LastName:     "User",
 			}
 			ctx = auth.NewTokenContext(context.TODO(), user)
-			srv = handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
+			srv = handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), service.NewJobService(s, nil, nil), service.NewSizerService(sizerClient, s), nil, nil, nil)
 		})
 
 		It("returns 400 when name is empty", func() {

--- a/internal/handlers/v1alpha1/source.go
+++ b/internal/handlers/v1alpha1/source.go
@@ -266,11 +266,12 @@ func (s *ServiceHandler) HeadImage(ctx context.Context, request server.HeadImage
 func (s *ServiceHandler) GetSourceDownloadURL(ctx context.Context, request server.GetSourceDownloadURLRequestObject) (server.GetSourceDownloadURLResponseObject, error) {
 	url, expireAt, err := s.sourceSrv.GetSourceDownloadURL(ctx, request.Id)
 	if err != nil {
-		switch err.(type) {
-		case *service.ErrResourceNotFound:
+		var errResourceNotFound *service.ErrResourceNotFound
+		switch {
+		case errors.As(err, &errResourceNotFound):
 			return server.GetSourceDownloadURL404JSONResponse{Message: err.Error()}, nil
 		default:
-			return server.GetSourceDownloadURL400JSONResponse{}, nil // FIX: should be 500
+			return server.GetSourceDownloadURL500JSONResponse{}, nil
 		}
 	}
 	return server.GetSourceDownloadURL200JSONResponse{Url: url, ExpiresAt: &expireAt}, nil

--- a/internal/handlers/v1alpha1/source_test.go
+++ b/internal/handlers/v1alpha1/source_test.go
@@ -90,7 +90,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListSources(ctx, server.ListSourcesRequestObject{})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.ListSources200JSONResponse{}).String()))
@@ -117,7 +117,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.ListSources(ctx, server.ListSourcesRequestObject{})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.ListSources200JSONResponse{}).String()))
@@ -144,7 +144,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name: "test",
@@ -178,7 +178,7 @@ var _ = Describe("source handler", Ordered, func() {
 				return &s
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name: "test",
@@ -217,7 +217,7 @@ var _ = Describe("source handler", Ordered, func() {
 				return &s
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name: "full-infra",
@@ -261,7 +261,7 @@ var _ = Describe("source handler", Ordered, func() {
 				return &s
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name: "test",
@@ -294,7 +294,7 @@ var _ = Describe("source handler", Ordered, func() {
 				return &s
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name:             "test",
@@ -324,7 +324,7 @@ var _ = Describe("source handler", Ordered, func() {
 				return &s
 			}
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
 				Body: &v1alpha1.CreateSourceJSONRequestBody{
 					Name:             "test",
@@ -349,7 +349,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			// First create succeeds
 			resp1, err := srv.CreateSource(ctx, server.CreateSourceRequestObject{
@@ -401,7 +401,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -434,7 +434,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -491,7 +491,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -535,7 +535,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -570,7 +570,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -614,7 +614,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -652,7 +652,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -688,7 +688,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: uuid.New()})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource404JSONResponse{}).String()))
@@ -715,7 +715,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource403JSONResponse{}).String()))
@@ -741,7 +741,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: sourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -781,7 +781,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.GetSource(ctx, server.GetSourceRequestObject{Id: sourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.GetSource200JSONResponse{}).String()))
@@ -822,7 +822,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", secondSourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			_, err := srv.DeleteSources(context.TODO(), server.DeleteSourcesRequestObject{})
 			Expect(err).To(BeNil())
 
@@ -847,7 +847,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			_, err := srv.DeleteSource(ctx, server.DeleteSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 
@@ -877,7 +877,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.DeleteSource(ctx, server.DeleteSourceRequestObject{Id: firstSourceID})
 			Expect(err).To(BeNil())
 			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.DeleteSource403JSONResponse{}).String()))
@@ -901,7 +901,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			invalidLabels := []v1alpha1.Label{
 				{Key: "-invalid-key", Value: "valid-value"},
 			}
@@ -926,7 +926,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			invalidLabels := []v1alpha1.Label{
 				{Key: "valid-key", Value: "invalid value with space"},
 			}
@@ -960,7 +960,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateInventory(ctx, server.UpdateInventoryRequestObject{
 				Id: firstSourceID,
 				Body: &v1alpha1.UpdateInventory{
@@ -1002,7 +1002,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateInventory(ctx, server.UpdateInventoryRequestObject{
 				Id: firstSourceID,
 				Body: &v1alpha1.UpdateInventory{
@@ -1050,7 +1050,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateInventory(ctx, server.UpdateInventoryRequestObject{
 				Id: firstSourceID,
 				Body: &v1alpha1.UpdateInventory{

--- a/internal/service/image_server/builder.go
+++ b/internal/service/image_server/builder.go
@@ -1,4 +1,4 @@
-package image
+package image_server
 
 import (
 	"archive/tar"
@@ -18,14 +18,6 @@ import (
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 	"github.com/openshift/assisted-image-service/pkg/overlay"
 )
-
-type Key int
-
-// Key to store the ResponseWriter in the context of openapi
-const ResponseWriterKey Key = 0
-
-// Key to store the *http.Request in the context (needed for http.ServeContent)
-const RequestKey Key = 1
 
 type ImageType int
 

--- a/internal/service/image_server/image.go
+++ b/internal/service/image_server/image.go
@@ -1,0 +1,144 @@
+package image_server
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"github.com/kubev2v/migration-planner/internal/store"
+	"github.com/kubev2v/migration-planner/internal/store/model"
+	"github.com/kubev2v/migration-planner/pkg/version"
+	"go.uber.org/zap"
+)
+
+var jwtPayloadRegexp = regexp.MustCompile(`^.+\.(.+)\..+`)
+
+type ImageService struct {
+	store store.Store
+}
+
+func NewImageService(store store.Store) *ImageService {
+	return &ImageService{
+		store: store,
+	}
+}
+
+func (i *ImageService) ValidateToken(token string) error {
+	parsedToken, err := jwt.Parse(token, i.getSourceKey)
+	if err != nil {
+		return fmt.Errorf("unauthorized: %v", err)
+	}
+
+	return parsedToken.Claims.Valid()
+}
+
+func (i *ImageService) getSource(ctx context.Context, sourceId string) (*model.Source, error) {
+	sourceUUID, err := uuid.Parse(sourceId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid source ID")
+	}
+	source, err := i.store.Source().Get(ctx, sourceUUID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid source ID")
+	}
+
+	return source, nil
+}
+
+func (i *ImageService) UpdateAgentVersion(sourceId string) {
+	versionInfo := version.Get()
+	if !version.IsValidAgentVersion(versionInfo.AgentVersionName) {
+		zap.S().Named("image_service").Warnw("agent version not valid, skipping storage", "source_id", sourceId, "agent_version_name", versionInfo.AgentVersionName, "agent_git_commit", versionInfo.AgentGitCommit)
+		return
+	}
+
+	// Use detached context to ensure version persists even if client disconnects
+	persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Use atomic update to prevent race conditions during concurrent downloads
+	if err := i.store.ImageInfra().UpdateAgentVersion(persistCtx, sourceId, versionInfo.AgentVersionName); err != nil {
+		zap.S().Named("image_service").Warnw("failed to update agent version", "error", err, "source_id", sourceId, "agent_version", versionInfo.AgentVersionName)
+		return
+	}
+
+	zap.S().Named("image_service").Infow("stored agent version", "source_id", sourceId, "agent_version", versionInfo.AgentVersionName)
+}
+
+func (i *ImageService) ImageReader(ctx context.Context, sourceId string) (io.ReadSeekCloser, time.Time, error) {
+	source, err := i.getSource(ctx, sourceId)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	// Expect the agent token to be existed in this stage.
+	// The Generate Url step should be responsible for saving the token
+	if source.ImageInfra.AgentToken == nil || *source.ImageInfra.AgentToken == "" {
+		return nil, time.Time{}, fmt.Errorf("expect agent token to be exist")
+	}
+
+	// Use pre-generated agent token from DB (stored at generate download URL creation time).
+	// This ensures all pods produce byte-identical OVAs for Akamai LFO range requests.
+	imageBuilder := NewImageBuilder(source.ID).WithImageInfra(source.ImageInfra).WithAgentToken(*source.ImageInfra.AgentToken)
+
+	imageReader, _, err := imageBuilder.OpenSeekableReader(source.UpdatedAt)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	return imageReader, source.UpdatedAt, nil
+}
+
+func (i *ImageService) IdFromJWT(jwt string) (string, error) {
+	match := jwtPayloadRegexp.FindStringSubmatch(jwt)
+
+	if len(match) != 2 {
+		return "", fmt.Errorf("failed to parse JWT from URL")
+	}
+
+	decoded, err := base64.RawStdEncoding.DecodeString(match[1])
+	if err != nil {
+		return "", err
+	}
+
+	var p struct {
+		Sub string `json:"sub"` // used by OCM tokens
+	}
+
+	err = json.Unmarshal(decoded, &p)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case p.Sub != "":
+		return p.Sub, nil
+	}
+
+	return "", fmt.Errorf("sub ID not found in token")
+}
+
+func (i *ImageService) getSourceKey(token *jwt.Token) (interface{}, error) {
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("malformed token claims")
+	}
+
+	sourceId, ok := claims["sub"].(string)
+	if !ok {
+		return nil, fmt.Errorf("token missing 'sub' claim")
+	}
+
+	source, err := i.getSource(context.TODO(), sourceId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid source ID: %w", err)
+	}
+
+	return []byte(source.ImageInfra.ImageTokenKey), nil
+}

--- a/internal/service/image_server/seekable_tar.go
+++ b/internal/service/image_server/seekable_tar.go
@@ -1,4 +1,4 @@
-package image
+package image_server
 
 import (
 	"archive/tar"

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -3,31 +3,33 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/kubev2v/migration-planner/pkg/opa"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/internal/auth"
-	"github.com/kubev2v/migration-planner/internal/image"
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
-	"github.com/kubev2v/migration-planner/internal/util"
+	"github.com/kubev2v/migration-planner/pkg/image"
 	"github.com/kubev2v/migration-planner/pkg/version"
 )
 
+// The agent token lifetime is 90 days, so this renews when ~1/3 of the lifetime remains.
+const renewTokenDaysThreshold = 30
+
 type SourceService struct {
-	store        store.Store
-	opaValidator *opa.Validator
+	store              store.Store
+	opaValidator       *opa.Validator
+	imageServerBaseURL string
 }
 
-func NewSourceService(store store.Store, opaValidator *opa.Validator) *SourceService {
+func NewSourceService(store store.Store, opaValidator *opa.Validator, imageServerBaseURL string) *SourceService {
 	return &SourceService{
-		store:        store,
-		opaValidator: opaValidator,
+		store:              store,
+		opaValidator:       opaValidator,
+		imageServerBaseURL: imageServerBaseURL,
 	}
 }
 
@@ -43,66 +45,19 @@ func (s *SourceService) GetSourceDownloadURL(ctx context.Context, id uuid.UUID) 
 
 	// Pre-generate and store agent JWT so all pods produce byte-identical OVAs.
 	// This is required for Akamai LFO byte-range requests across load-balanced pods.
-	if err := s.ensureAgentToken(ctx, source); err != nil {
-		return "", time.Time{}, fmt.Errorf("failed to ensure agent token: %w", err)
+	if source.ImageInfra.AgentToken == nil || image.IsTokenNearExpiry(*source.ImageInfra.AgentToken, renewTokenDaysThreshold) {
+		if err := s.generateAndSetAgentToken(ctx, source); err != nil {
+			return "", time.Time{}, err
+		}
 	}
 
-	// FIXME: refactor the environment vars + config.yaml
-	baseUrl := util.GetEnv("MIGRATION_PLANNER_IMAGE_URL", "http://localhost:11443")
-
-	url, expireAt, err := image.GenerateDownloadURLByToken(baseUrl, source)
+	url, expireAt, err := image.GenerateDownloadURLByToken(s.imageServerBaseURL, source.ID.String(),
+		source.ImageInfra.ImageTokenKey, source.Name)
 	if err != nil {
 		return "", time.Time{}, err
 	}
 
 	return url, time.Time(*expireAt), err
-}
-
-// ensureAgentToken generates and stores the agent JWT if it's missing or near expiration.
-func (s *SourceService) ensureAgentToken(ctx context.Context, source *model.Source) error {
-	if source.ImageInfra.AgentToken != nil && !isTokenNearExpiry(*source.ImageInfra.AgentToken) {
-		return nil
-	}
-
-	key, err := s.store.PrivateKey().Get(ctx, source.OrgID)
-	if err != nil {
-		if !errors.Is(err, store.ErrRecordNotFound) {
-			return err
-		}
-		newKey, token, err := auth.GenerateAgentJWTAndKey(source)
-		if err != nil {
-			return err
-		}
-		if _, err := s.store.PrivateKey().Create(ctx, *newKey); err != nil {
-			return err
-		}
-		return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token)
-	}
-
-	token, err := auth.GenerateAgentJWT(key, source)
-	if err != nil {
-		return err
-	}
-	return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), token)
-}
-
-// isTokenNearExpiry parses a JWT without verification and checks if it expires within 30 days.
-// The agent token lifetime is 90 days, so this renews when ~1/3 of the lifetime remains.
-func isTokenNearExpiry(tokenStr string) bool {
-	parser := jwt.NewParser()
-	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
-	if err != nil {
-		return true // can't parse → treat as expired
-	}
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return true
-	}
-	exp, err := claims.GetExpirationTime()
-	if err != nil || exp == nil {
-		return true
-	}
-	return time.Until(exp.Time) < 30*24*time.Hour
 }
 
 func (s *SourceService) ListSources(ctx context.Context, filter *SourceFilter) ([]model.Source, error) {
@@ -279,6 +234,31 @@ func (s *SourceService) UpdateInventory(ctx context.Context, form mappers.Invent
 	}
 
 	return *source, nil
+}
+
+func (s *SourceService) generateAndSetAgentToken(ctx context.Context, source *model.Source) error {
+	key, err := s.store.PrivateKey().Get(ctx, source.OrgID)
+	if err != nil {
+		if !errors.Is(err, store.ErrRecordNotFound) {
+			return err
+		}
+		newKey, t, err := auth.GenerateAgentJWTAndKey(source)
+		if err != nil {
+			return err
+		}
+		if _, err := s.store.PrivateKey().Create(ctx, *newKey); err != nil {
+			return err
+		}
+
+		return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), t)
+	}
+
+	t, err := auth.GenerateAgentJWT(key, source)
+	if err != nil {
+		return err
+	}
+
+	return s.store.ImageInfra().UpdateAgentToken(ctx, source.ID.String(), t)
 }
 
 type SourceFilterFunc func(s *SourceFilter)

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -65,7 +65,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", sourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithUsername("batman"), service.WithOrgID("batman")))
 			Expect(err).To(BeNil())
 			Expect(resp).To(HaveLen(1))
@@ -84,7 +84,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", sourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			resp, err := srv.ListSources(context.TODO(), service.NewSourceFilter(service.WithUsername("admin"), service.WithOrgID("admin")))
 			Expect(err).To(BeNil())
 			Expect(resp).To(HaveLen(2))
@@ -105,7 +105,7 @@ var _ = Describe("source handler", Ordered, func() {
 
 	Context("create", func() {
 		It("successfully creates a source", func() {
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			source, err := srv.CreateSource(context.TODO(), mappers.SourceCreateForm{Name: "test", OrgID: "admin", Username: "admin"})
 			Expect(err).To(BeNil())
 			Expect(source.Name).To(Equal("test"))
@@ -117,7 +117,7 @@ var _ = Describe("source handler", Ordered, func() {
 		})
 
 		It("successfully creates a source -- with proxy paramters defined", func() {
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			httpUrl := "http"
 			httpsUrl := "https"
 			noProxy := "noproxy"
@@ -139,7 +139,7 @@ var _ = Describe("source handler", Ordered, func() {
 		})
 
 		It("successfully creates a source -- with certificate chain defined", func() {
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			source, err := srv.CreateSource(context.TODO(), mappers.SourceCreateForm{
 				Username:         "admin",
 				OrgID:            "admin",
@@ -156,7 +156,7 @@ var _ = Describe("source handler", Ordered, func() {
 		})
 
 		It("successfully creates a source -- email domain defined", func() {
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			source, err := srv.CreateSource(context.TODO(), mappers.SourceCreateForm{Name: "test", OrgID: "admin", Username: "admin", EmailDomain: "domain.com"})
 			Expect(err).To(BeNil())
 			Expect(source.Name).To(Equal("test"))
@@ -193,7 +193,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			source, err := srv.GetSource(ctx, firstSourceID)
 			Expect(err).To(BeNil())
 			Expect(source.ID.String()).To(Equal(firstSourceID.String()))
@@ -211,7 +211,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			source, err := srv.GetSource(ctx, firstSourceID)
 			Expect(err).To(BeNil())
 			Expect(source.ID.String()).To(Equal(firstSourceID.String()))
@@ -233,7 +233,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", secondSourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			_, err := srv.GetSource(context.TODO(), uuid.New())
 			Expect(err).ToNot(BeNil())
 			_, ok := err.(*service.ErrResourceNotFound)
@@ -263,7 +263,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, uuid.New(), "not-connected", "status-info-1", "cred_url-1", secondSourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			err := srv.DeleteSources(context.TODO())
 			Expect(err).To(BeNil())
 
@@ -281,7 +281,7 @@ var _ = Describe("source handler", Ordered, func() {
 			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, firstAgentID, "not-connected", "status-info-1", "cred_url-1", firstSourceID))
 			Expect(tx.Error).To(BeNil())
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			err := srv.DeleteSource(context.TODO(), firstSourceID)
 			Expect(err).To(BeNil())
 
@@ -314,7 +314,7 @@ var _ = Describe("source handler", Ordered, func() {
 				VcenterId: "vcenter",
 			})
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
 				SourceID:  firstSourceID,
 				AgentID:   uuid.New(),
@@ -349,7 +349,7 @@ var _ = Describe("source handler", Ordered, func() {
 				VcenterId: "vcenter",
 			})
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
 				SourceID:  firstSourceID,
 				AgentID:   uuid.New(),
@@ -386,7 +386,7 @@ var _ = Describe("source handler", Ordered, func() {
 				VcenterId: "vcenter",
 			})
 
-			srv := service.NewSourceService(s, nil)
+			srv := service.NewSourceService(s, nil, "")
 			_, err := srv.UpdateInventory(context.TODO(), mappers.InventoryUpdateForm{
 				SourceID:  firstSourceID,
 				AgentID:   uuid.New(),
@@ -437,7 +437,7 @@ var _ = Describe("source handler", Ordered, func() {
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			newName := "updated-name"
 			newLabels := []v1alpha1.Label{
 				{Key: "env", Value: "prod"},
@@ -506,7 +506,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{
 				Id:   uuid.New(),
 				Body: &v1alpha1.SourceUpdate{},
@@ -526,7 +526,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{
 				Id:   uuid.MustParse(sourceID),
 				Body: &v1alpha1.SourceUpdate{},
@@ -553,7 +553,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			// First set initial labels
 			initialLabels := []v1alpha1.Label{
@@ -626,7 +626,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			newSshKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCk83ddeteALlqCbO43E3ardbavFPboYIoFnlQZ3zVi+ls96c1x3P9DDWkNhuOgpQurull2y55Wm7HWLLK5hlk49s6tUuBDftH3XXfGMAmncBH9apGHxl0O+k/X1MrfhoEXHmmEwXTv+X6vC3BsZiazSOkKbIozHgnD7y1z83wuYWbbW0NYvgwhaoOtkWteKSJWwPxNaTwGCpj+RQ6xWygt5EbMSf7U3Ih2P1hcsa615zD5P2GSLxtLwWnHgWCylT/krdyIYlR1pqW9e/Iv2MKlGX6W1DSUxUz5BNxzCA8O53C0NSCeDFAhn9T8VE9U/RkGDtXBFJ8JVcmtM6S9buq5HZ12+0E0VCGFdmnvNT8XxdYrN0ff8f3DQI7ERgHEKQiqjrSPDv2+OMdv3nr3n5+tOBvQEn6aYDbnybILyrUP76UvLvjfgDTnnRxlkpw2Y43EtgtdeIUUo/VBSE9qfzRa21Pz3gBh6ZJE9xF+u6DstgvFigNJ7nMJoSktH5mzuBM= test@test"
 			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{
@@ -667,7 +667,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			initialLabels := []v1alpha1.Label{
 				{Key: "env", Value: "dev"},
@@ -717,7 +717,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			enableProxy := false
 			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{
@@ -757,7 +757,7 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			}
 			ctx := auth.NewTokenContext(context.TODO(), user)
 
-			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil, ""), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
 
 			networkConfigType := v1alpha1.SourceUpdateNetworkConfigTypeDhcp
 			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{

--- a/pkg/duckdb_parser/builder.go
+++ b/pkg/duckdb_parser/builder.go
@@ -35,7 +35,7 @@ func mustGetTemplate(name string) string {
 // QueryBuilder builds SQL queries from templates.
 type QueryBuilder struct{}
 
-// NewBuilder creates a new Builder.
+// NewBuilder creates a new ImageReader.
 func NewBuilder() *QueryBuilder {
 	return &QueryBuilder{}
 }

--- a/pkg/image/url.go
+++ b/pkg/image/url.go
@@ -1,36 +1,40 @@
 package image
 
 import (
-	"context"
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"path"
-	"regexp"
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/golang-jwt/jwt/v4"
-	"github.com/kubev2v/migration-planner/internal/store/model"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 )
-
-var jwtPayloadRegexp = regexp.MustCompile(`^.+\.(.+)\..+`)
-
-type payload struct {
-	Sub string `json:"sub"` // used by OCM tokens
-}
 
 const (
 	// ImageExpirationTime define the expiration of the image download URL
 	ImageExpirationTime = 4 * time.Hour
 )
 
-func GenerateDownloadURLByToken(baseUrl string, source *model.Source) (string, *strfmt.DateTime, error) {
-	token, err := JWTForSymmetricKey([]byte(source.ImageInfra.ImageTokenKey), ImageExpirationTime, source.ID.String())
+// HMACKey generates a hex string representing n random bytes
+//
+// This string is intended to be used as a private key for signing and
+// verifying jwt tokens. Specifically ones used for downloading images
+// when using rhsso auth and the image service.
+func HMACKey(n int) (string, error) {
+	buf := make([]byte, n)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(buf), nil
+}
+
+func GenerateDownloadURLByToken(baseURL, id, privateKey, name string) (string, *strfmt.DateTime, error) {
+	token, err := JWTForSymmetricKey([]byte(privateKey), ImageExpirationTime, id)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to sign image URL")
 	}
@@ -40,8 +44,8 @@ func GenerateDownloadURLByToken(baseUrl string, source *model.Source) (string, *
 		return "", nil, err
 	}
 
-	path := fmt.Sprintf("%s/%s/%s.ova", "/api/v1/image/bytoken/", token, source.Name)
-	shortURL, err := buildURL(baseUrl, path, false, map[string]string{})
+	path := fmt.Sprintf("%s/%s/%s.ova", "/api/v1/image/bytoken/", token, name)
+	shortURL, err := buildURL(baseURL, path, false, map[string]string{})
 	if err != nil {
 		return "", nil, err
 	}
@@ -100,52 +104,20 @@ func buildURL(baseURL string, suffix string, insecure bool, params map[string]st
 	return downloadURL.String(), nil
 }
 
-// HMACKey generates a hex string representing n random bytes
-//
-// This string is intended to be used as a private key for signing and
-// verifying jwt tokens. Specifically ones used for downloading images
-// when using rhsso auth and the image service.
-func HMACKey(n int) (string, error) {
-	buf := make([]byte, n)
-	_, err := rand.Read(buf)
+// IsTokenNearExpiry parses a JWT without verification and checks if it expires within provided days.
+func IsTokenNearExpiry(tokenStr string, days int) bool {
+	parser := jwt.NewParser()
+	token, _, err := parser.ParseUnverified(tokenStr, jwt.MapClaims{})
 	if err != nil {
-		return "", err
+		return true // can't parse → treat as expired
 	}
-
-	return hex.EncodeToString(buf), nil
-}
-
-func ValidateToken(ctx context.Context, token string, keyFunc func(token *jwt.Token) (interface{}, error)) error {
-	parsedToken, err := jwt.Parse(token, keyFunc)
-	if err != nil {
-		return fmt.Errorf("unauthorized: %v", err)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return true
 	}
-
-	return parsedToken.Claims.Valid()
-}
-
-func IdFromJWT(jwt string) (string, error) {
-	match := jwtPayloadRegexp.FindStringSubmatch(jwt)
-
-	if len(match) != 2 {
-		return "", fmt.Errorf("failed to parse JWT from URL")
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return true
 	}
-
-	decoded, err := base64.RawStdEncoding.DecodeString(match[1])
-	if err != nil {
-		return "", err
-	}
-
-	var p payload
-	err = json.Unmarshal(decoded, &p)
-	if err != nil {
-		return "", err
-	}
-
-	switch {
-	case p.Sub != "":
-		return p.Sub, nil
-	}
-
-	return "", fmt.Errorf("sub ID not found in token")
+	return time.Until(exp.Time) < time.Duration(days)*24*time.Hour
 }

--- a/pkg/middleware/request_context.go
+++ b/pkg/middleware/request_context.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+type Key int
+
+const (
+	// ResponseWriterKey to store the ResponseWriter in the context of openapi
+	ResponseWriterKey Key = 0
+	// RequestKey to store the *http.Request in the context (needed for http.ServeContent)
+	RequestKey Key = 1
+)
+
+// RequestContext Middleware to inject ResponseWriter and *http.Request into context.
+// The Request is needed by http.ServeContent for handling byte-range requests.
+func RequestContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), ResponseWriterKey, w)
+		ctx = context.WithValue(ctx, RequestKey, r)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}


### PR DESCRIPTION
Separates image building/serving logic from HTTP handler layer by:
- Extracting image service to internal/service/image_server with builder
- Moving image/url utilities to pkg for broader reuse
- Updating NewSourceService to accept imageServerBaseURL parameter
- Simplifying image handler to delegate to dedicated service layer

This improves separation of concerns.

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image download endpoint now returns correct HTTP 500 for server errors and 404 for missing resources.

* **API Updates**
  * OpenAPI spec updated to document 500 responses for the image download endpoint.

* **Improvements**
  * More robust token validation and streaming for image downloads, reducing failed/duplicate responses.

* **Configuration**
  * Deployment parameters simplified and clarified for general vs. agent-specific base URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->