### PR TITLE
ECOPROJECT-4376 | feat: Add labels field to VM model

### DIFF
--- a/pkg/duckdb_parser/models/scanners.go
+++ b/pkg/duckdb_parser/models/scanners.go
@@ -121,6 +121,32 @@ func (n Networks) Value() (driver.Value, error) {
 	return n, nil
 }
 
+// Labels is a slice of strings that implements sql.Scanner for DuckDB LIST type.
+type Labels []string
+
+func (l *Labels) Scan(value interface{}) error {
+	if value == nil {
+		*l = nil
+		return nil
+	}
+	slice, ok := value.([]interface{})
+	if !ok {
+		return fmt.Errorf("Labels.Scan: expected []interface{}, got %T", value)
+	}
+	result := make([]string, 0, len(slice))
+	for _, item := range slice {
+		if s := toString(item); s != "" {
+			result = append(result, s)
+		}
+	}
+	*l = result
+	return nil
+}
+
+func (l Labels) Value() (driver.Value, error) {
+	return l, nil
+}
+
 // Concerns is a slice of Concern that implements sql.Scanner for DuckDB LIST type.
 type Concerns []Concern
 

--- a/pkg/duckdb_parser/models/vm.go
+++ b/pkg/duckdb_parser/models/vm.go
@@ -45,6 +45,7 @@ type VM struct {
 	Concerns                 Concerns `json:"concerns"`
 	NumaNodeAffinity         []string `json:"numaNodeAffinity"` // Always empty for RVTools, included for OPA compatibility
 	MigrationExcluded        bool     `json:"migrationExcluded" db:"migration_excluded"`
+	Labels                   Labels   `json:"labels" db:"labels"`
 }
 
 // EffectiveGuestName returns the best available guest OS name.

--- a/pkg/duckdb_parser/queries.go
+++ b/pkg/duckdb_parser/queries.go
@@ -583,6 +583,7 @@ func (p *Parser) readVMs(ctx context.Context, query string) ([]models.VM, error)
 			&vm.Networks,
 			&vm.Concerns,
 			&vm.MigrationExcluded,
+			&vm.Labels,
 		); err != nil {
 			return nil, fmt.Errorf("scanning VM row: %w", err)
 		}

--- a/pkg/duckdb_parser/queries_test.go
+++ b/pkg/duckdb_parser/queries_test.go
@@ -1,0 +1,95 @@
+package duckdb_parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubev2v/migration-planner/pkg/duckdb_parser/models"
+)
+
+// TestVMs_Labels_RVToolsCompatibility verifies that RVTools ingestion still works
+// and that VMs get empty labels by default (RVTools Excel files don't have a labels column).
+func TestVMs_Labels_RVToolsCompatibility(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	vms := []map[string]string{
+		{"VM": "vm-1", "VM ID": "vm-001", "VI SDK UUID": "uuid-1", "Host": "esxi-host-1", "CPUs": "4", "Memory": "8192", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		{"VM": "vm-2", "VM ID": "vm-002", "VI SDK UUID": "uuid-2", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "dc1", "Cluster": "cluster1", "# Cores": "8", "# CPU": "2", "Object ID": "host-001", "# Memory": "32768", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+	}
+
+	// Create RVTools Excel file (no labels column in RVTools)
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err, "RVTools ingestion should work even though Excel has no labels column")
+
+	// Verify all VMs have empty labels (default from schema)
+	vmsOut, err := parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+	require.Len(t, vmsOut, 2)
+
+	for _, vm := range vmsOut {
+		assert.Empty(t, vm.Labels, "RVTools-ingested VMs should have empty labels array from DEFAULT '[]'")
+	}
+}
+
+// TestVMs_Labels verifies that the labels field:
+// 1. Defaults to empty array for RVTools-ingested VMs
+// 2. Can be updated via SQL and is properly returned in the VM model
+// 3. Supports multiple labels per VM
+func TestVMs_Labels(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	vms := []map[string]string{
+		{"VM": "vm-1", "VM ID": "vm-001", "VI SDK UUID": "uuid-1", "Host": "esxi-host-1", "CPUs": "4", "Memory": "8192", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		{"VM": "vm-2", "VM ID": "vm-002", "VI SDK UUID": "uuid-2", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		{"VM": "vm-3", "VM ID": "vm-003", "VI SDK UUID": "uuid-3", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "dc1", "Cluster": "cluster1", "# Cores": "8", "# CPU": "2", "Object ID": "host-001", "# Memory": "32768", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+	}
+
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err)
+
+	// Verify all VMs default to empty labels array (RVTools behavior)
+	vmsOut, err := parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+	require.Len(t, vmsOut, 3)
+
+	for _, vm := range vmsOut {
+		assert.Empty(t, vm.Labels, "RVTools-ingested VMs should default to empty labels array")
+	}
+
+	// Simulate agent updating labels via SQL (how the agent will use this)
+	_, err = parser.db.ExecContext(ctx, `UPDATE vinfo SET "labels" = '["production", "critical"]' WHERE "VM ID" = 'vm-001'`)
+	require.NoError(t, err)
+
+	_, err = parser.db.ExecContext(ctx, `UPDATE vinfo SET "labels" = '["test"]' WHERE "VM ID" = 'vm-002'`)
+	require.NoError(t, err)
+
+	// Verify the updates are reflected in VM query
+	vmsOut, err = parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+
+	vmMap := make(map[string]models.VM)
+	for _, vm := range vmsOut {
+		vmMap[vm.ID] = vm
+	}
+
+	assert.Equal(t, []string{"production", "critical"}, []string(vmMap["vm-001"].Labels), "vm-001 should have two labels")
+	assert.Equal(t, []string{"test"}, []string(vmMap["vm-002"].Labels), "vm-002 should have one label")
+	assert.Empty(t, vmMap["vm-003"].Labels, "vm-003 should still have empty labels")
+}

--- a/pkg/duckdb_parser/templates/create_schema.go.tmpl
+++ b/pkg/duckdb_parser/templates/create_schema.go.tmpl
@@ -48,7 +48,8 @@ CREATE TABLE IF NOT EXISTS vinfo (
     "Network #7" VARCHAR,
     "Network #8" VARCHAR,
     "OsDiskComplexity" INTEGER DEFAULT 0,
-    "migration_excluded" BOOLEAN DEFAULT false
+    "migration_excluded" BOOLEAN DEFAULT false,
+    "labels" VARCHAR DEFAULT '[]'
 );
 
 CREATE TABLE IF NOT EXISTS vcpu (

--- a/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
+++ b/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
@@ -26,7 +26,7 @@ INSERT INTO vinfo (
     "Template", "CBT", "EnableUUID",
     "Datacenter", "Cluster", "HW version",
     "Total disk capacity MiB", "Provisioned MiB", "Resource pool", "VI SDK UUID",
-    "migration_excluded"
+    "migration_excluded", "labels"
 )
 SELECT
     v.ID,
@@ -57,7 +57,8 @@ SELECT
     0,
     '',
     about.InstanceUuid,
-    false
+    false,
+    '[]'
 FROM src.VM v
 LEFT JOIN src.Host h ON v.Host = h.ID
 LEFT JOIN src.Cluster c ON h.Cluster = c.ID

--- a/pkg/duckdb_parser/templates/vm_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_query.go.tmpl
@@ -106,7 +106,8 @@ SELECT
         x -> x IS NOT NULL AND x != '' AND x != 'VM'
     ) AS "Networks",
     COALESCE(con.concerns, []) AS "Concerns",
-    COALESCE(i."migration_excluded", false) AS "MigrationExcluded"
+    COALESCE(i."migration_excluded", false) AS "MigrationExcluded",
+    COALESCE(CAST(i."labels" AS VARCHAR[]), []) AS "Labels"
 FROM vinfo i
 LEFT JOIN vcpu c ON i."VM ID" = c."VM ID"
 LEFT JOIN vmemory m ON i."VM ID" = m."VM ID"


### PR DESCRIPTION
Implement data foundation for VM labeling feature to support user-defined labels for VM categorization and filtering
The labels column defaults to '[]' (empty array) for backward compatibility RVTools ingestion is unaffected - VMs automatically get empty labels via DEFAULT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * VMs now support labels with automatic persistence and retrieval through queries
  * Backward compatible with existing imports that do not include labels

* **Tests**
  * Added test coverage for VM labels functionality and import compatibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1164)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->