### PR TITLE
ECOPROJECT-4616 | feat: Add optional VM list filter to BuildInventory

### DIFF
--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -134,7 +134,7 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 
 	// Build inventory from parsed data
 	logger.Step("building_inventory").Log()
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	if err != nil {
 		return w.failJob(ctx, logger, job.ID, "build_inventory", err, fmt.Sprintf("error building inventory: %v", err))
 	}

--- a/pkg/duckdb_parser/builder.go
+++ b/pkg/duckdb_parser/builder.go
@@ -66,6 +66,7 @@ type queryParams struct {
 	OSFilter                string
 	PowerStateFilter        string
 	VmIDFilter              string
+	VMListFilter            string
 	Category                string
 	OSCaseClauses           string
 	ComplexityMatrixClauses string
@@ -88,6 +89,7 @@ func (b *QueryBuilder) VMQuery(filters Filters, options Options) (string, error)
 		OSFilter:         filters.OS,
 		PowerStateFilter: filters.PowerState,
 		VmIDFilter:       filters.VmId,
+		VMListFilter:     buildVMListFilter(filters.VMList, "i"),
 		Limit:            options.Limit,
 		Offset:           options.Offset,
 	}
@@ -128,6 +130,7 @@ func (b *QueryBuilder) HostQuery(filters Filters, options Options) (string, erro
 func (b *QueryBuilder) OsQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "v"),
 	}
 	return b.buildQuery("os_query", mustGetTemplate("os_query"), params)
 }
@@ -152,6 +155,7 @@ func (b *QueryBuilder) VMCountQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter:    filters.Cluster,
 		PowerStateFilter: filters.PowerState,
+		VMListFilter:     buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("vm_count_query", mustGetTemplate("vm_count_query"), params)
 }
@@ -160,6 +164,7 @@ func (b *QueryBuilder) VMCountQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) PowerStateCountsQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("power_state_counts_query", mustGetTemplate("power_state_counts_query"), params)
 }
@@ -176,6 +181,7 @@ func (b *QueryBuilder) HostPowerStateCountsQuery(filters Filters) (string, error
 func (b *QueryBuilder) CPUTierQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("cpu_tier_query", mustGetTemplate("cpu_tier_query"), params)
 }
@@ -184,6 +190,7 @@ func (b *QueryBuilder) CPUTierQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) MemoryTierQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("memory_tier_query", mustGetTemplate("memory_tier_query"), params)
 }
@@ -192,6 +199,7 @@ func (b *QueryBuilder) MemoryTierQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) NicTierQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("nic_tier_query", mustGetTemplate("nic_tier_query"), params)
 }
@@ -200,6 +208,7 @@ func (b *QueryBuilder) NicTierQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) ComplexityDistributionQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("complexity_distribution_query", mustGetTemplate("complexity_distribution_query"), params)
 }
@@ -208,6 +217,7 @@ func (b *QueryBuilder) ComplexityDistributionQuery(filters Filters) (string, err
 func (b *QueryBuilder) DiskSizeTierQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("disk_size_tier_query", mustGetTemplate("disk_size_tier_query"), params)
 }
@@ -216,6 +226,7 @@ func (b *QueryBuilder) DiskSizeTierQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) DiskComplexityTierQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("disk_complexity_tier_query", mustGetTemplate("disk_complexity_tier_query"), params)
 }
@@ -224,6 +235,7 @@ func (b *QueryBuilder) DiskComplexityTierQuery(filters Filters) (string, error) 
 func (b *QueryBuilder) DiskTypeSummaryQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("disk_type_summary_query", mustGetTemplate("disk_type_summary_query"), params)
 }
@@ -232,6 +244,7 @@ func (b *QueryBuilder) DiskTypeSummaryQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) ResourceTotalsQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("resource_totals_query", mustGetTemplate("resource_totals_query"), params)
 }
@@ -240,6 +253,7 @@ func (b *QueryBuilder) ResourceTotalsQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) AllocatedVCPUsQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("allocated_vcpus_query", mustGetTemplate("allocated_vcpus_query"), params)
 }
@@ -248,6 +262,7 @@ func (b *QueryBuilder) AllocatedVCPUsQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) AllocatedMemoryQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("allocated_memory_query", mustGetTemplate("allocated_memory_query"), params)
 }
@@ -272,6 +287,7 @@ func (b *QueryBuilder) TotalHostMemoryQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) VMCountByNetworkQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, ""),
 	}
 	return b.buildQuery("vm_count_by_network_query", mustGetTemplate("vm_count_by_network_query"), params)
 }
@@ -290,6 +306,7 @@ func (b *QueryBuilder) ClustersPerDatacenterQuery() (string, error) {
 func (b *QueryBuilder) MigratableCountQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("migratable_count_query", mustGetTemplate("migratable_count_query"), params)
 }
@@ -298,6 +315,7 @@ func (b *QueryBuilder) MigratableCountQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) MigratableWithWarningsCountQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("migratable_with_warnings_count_query", mustGetTemplate("migratable_with_warnings_count_query"), params)
 }
@@ -306,6 +324,7 @@ func (b *QueryBuilder) MigratableWithWarningsCountQuery(filters Filters) (string
 func (b *QueryBuilder) NotMigratableCountQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("not_migratable_count_query", mustGetTemplate("not_migratable_count_query"), params)
 }
@@ -315,6 +334,7 @@ func (b *QueryBuilder) MigrationIssuesQuery(filters Filters, category string) (s
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
 		Category:      category,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("migration_issues_query", mustGetTemplate("migration_issues_query"), params)
 }
@@ -323,6 +343,7 @@ func (b *QueryBuilder) MigrationIssuesQuery(filters Filters, category string) (s
 func (b *QueryBuilder) ResourceBreakdownsQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("resource_breakdowns_query", mustGetTemplate("resource_breakdowns_query"), params)
 }
@@ -336,6 +357,7 @@ func (b *QueryBuilder) VCenterQuery() (string, error) {
 func (b *QueryBuilder) VMsWithSharedDisksCountQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("vms_with_shared_disks_count_query", mustGetTemplate("vms_with_shared_disks_count_query"), params)
 }
@@ -412,6 +434,31 @@ func (b *QueryBuilder) PopulateComplexityQuery() (string, error) {
 		ComplexityMatrixClauses: generateComplexityMatrixCaseClauses(),
 	}
 	return b.buildQuery("populate_complexity", mustGetTemplate("populate_complexity"), params)
+}
+
+// buildVMListFilter creates a SQL IN clause for filtering by VM IDs.
+// Returns an empty string if the VMList is empty.
+// tableAlias is the optional table alias (e.g., "i") - use empty string for no alias.
+func buildVMListFilter(vmList []string, tableAlias string) string {
+	if len(vmList) == 0 {
+		return ""
+	}
+
+	// Escape and quote each VM ID
+	quoted := make([]string, len(vmList))
+	for i, vmID := range vmList {
+		// Escape single quotes by doubling them
+		escaped := strings.ReplaceAll(vmID, "'", "''")
+		quoted[i] = fmt.Sprintf("'%s'", escaped)
+	}
+
+	// Build column reference with or without alias
+	columnRef := "\"VM ID\""
+	if tableAlias != "" {
+		columnRef = fmt.Sprintf("%s.\"VM ID\"", tableAlias)
+	}
+
+	return fmt.Sprintf(" AND %s IN (%s)", columnRef, strings.Join(quoted, ", "))
 }
 
 func (b *QueryBuilder) buildQuery(name, tmplContent string, params any) (string, error) {

--- a/pkg/duckdb_parser/ingest_sqlite_test.go
+++ b/pkg/duckdb_parser/ingest_sqlite_test.go
@@ -215,7 +215,7 @@ func TestIngestSqlite_VClusterMatchesInventoryClusterKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.IsValid())
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Collect vcluster Object IDs.

--- a/pkg/duckdb_parser/inventory_builder.go
+++ b/pkg/duckdb_parser/inventory_builder.go
@@ -13,7 +13,10 @@ import (
 
 // BuildInventory constructs domain inventory from parsed data.
 // It builds both vcenter-level and per-cluster inventories.
-func (p *Parser) BuildInventory(ctx context.Context) (*inventory.Inventory, error) {
+// vmList is an optional list of VM IDs to include in the inventory.
+// If vmList is provided, only VMs in the list will be included in the inventory.
+// If vmList is nil or empty, all VMs will be included (existing behavior).
+func (p *Parser) BuildInventory(ctx context.Context, vmList []string) (*inventory.Inventory, error) {
 	// Get vCenter ID
 	vcenterID, err := p.VCenterID(ctx)
 	if err != nil {
@@ -21,8 +24,8 @@ func (p *Parser) BuildInventory(ctx context.Context) (*inventory.Inventory, erro
 		vcenterID = ""
 	}
 
-	// Build vcenter-level inventory (no cluster filter)
-	vcenterData, err := p.buildInventoryData(ctx, Filters{})
+	// Build vcenter-level inventory (no cluster filter, optional VM list filter)
+	vcenterData, err := p.buildInventoryData(ctx, Filters{VMList: vmList})
 	if err != nil {
 		return nil, fmt.Errorf("building vcenter inventory: %w", err)
 	}
@@ -51,7 +54,7 @@ func (p *Parser) BuildInventory(ctx context.Context) (*inventory.Inventory, erro
 	// Build per-cluster inventories with cluster IDs from vCluster or generated
 	clusterInventories := make(map[string]inventory.InventoryData)
 	for _, clusterName := range clusters {
-		clusterFilters := Filters{Cluster: clusterName}
+		clusterFilters := Filters{Cluster: clusterName, VMList: vmList}
 		clusterInv, err := p.buildInventoryData(ctx, clusterFilters)
 		if err != nil {
 			zap.S().Named("duckdb_parser").Warnf("Failed to build inventory for cluster %s: %v", clusterName, err)

--- a/pkg/duckdb_parser/inventory_builder_test.go
+++ b/pkg/duckdb_parser/inventory_builder_test.go
@@ -227,7 +227,7 @@ func TestBuildInventory_BasicStructure(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify basic structure
@@ -254,7 +254,7 @@ func TestBuildInventory_VMCounts(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// VCenter total should equal sum of VMs
@@ -287,7 +287,7 @@ func TestBuildInventory_PowerStates(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify power states
@@ -314,7 +314,7 @@ func TestBuildInventory_MigrationIssues(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify migration warnings are populated
@@ -341,7 +341,7 @@ func TestBuildInventory_ResourceBreakdowns(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify CPU cores total (4 + 2 = 6)
@@ -369,7 +369,7 @@ func TestBuildInventory_InfraData(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify hosts are populated
@@ -397,7 +397,7 @@ func TestBuildInventory_ClusterInventories(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Per-cluster inventories should have correct structure
@@ -431,7 +431,7 @@ func TestBuildInventory_EmptyData(t *testing.T) {
 	}
 
 	// If no errors, inventory should still be valid but empty
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, inv)
 	assert.Equal(t, 0, inv.VCenter.VMs.Total)
@@ -566,7 +566,7 @@ func TestBuildInventory_MultiCluster(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// VCenter should have all 4 VMs
@@ -701,7 +701,7 @@ func TestBuildInventory_Overcommitment(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// With hosts, overcommitment should be calculated
@@ -733,7 +733,7 @@ func TestBuildInventory_MigratableCounts(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// With critical concerns, VMs should not be migratable
@@ -763,7 +763,7 @@ func TestBuildInventory_MigratableWithWarnings(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// With warning concerns (no critical), VMs should be migratable but with warnings
@@ -793,7 +793,7 @@ func TestBuildInventory_MinimalSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.IsValid(), "Minimal required schema should pass validation: %v", result.Errors)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 3, inv.VCenter.VMs.Total, "Should have 3 VMs from minimal schema")
 	assert.Equal(t, vcUUID, inv.VCenterID, "VCenterID should be populated from VI SDK UUID column")
@@ -1008,7 +1008,7 @@ func TestBuildInventory_LegacyRVToolsColumnNames(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, result.IsValid(), "legacy headers should pass validation: %v", result.Errors)
 
-			inv, err := parser.BuildInventory(ctx)
+			inv, err := parser.BuildInventory(ctx, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectVCenterID, inv.VCenterID, "VCenterID mismatch")
 			assert.Equal(t, 1, inv.VCenter.VMs.Total, "VM count mismatch")
@@ -1147,7 +1147,7 @@ func TestBuildInventory_ComplexityDistributionWithDiskSize(t *testing.T) {
 	_, err = parser.db.ExecContext(ctx, `UPDATE vinfo SET "OsDiskComplexity" = 2 WHERE "VM ID" = 'vm-2'`)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, inv.VCenter)
 
@@ -1211,7 +1211,7 @@ func TestBuildInventory_DiskSizeTiers(t *testing.T) {
 	_, err := parser.IngestRvTools(ctx, tmpFile)
 	require.NoError(t, err)
 
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, inv.VCenter)
 
@@ -1349,7 +1349,7 @@ func TestInventory_ExcludesMigrationExcludedVMs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build inventory
-	inv, err := parser.BuildInventory(ctx)
+	inv, err := parser.BuildInventory(ctx, nil)
 	require.NoError(t, err)
 
 	// Verify VM counts exclude the 3 excluded VMs
@@ -1380,4 +1380,97 @@ func TestInventory_ExcludesMigrationExcludedVMs(t *testing.T) {
 	// Included VMs: 4 + 2 + 8 = 14 CPUs, 8 + 4 + 16 = 28 GB RAM
 	assert.Equal(t, 14, inv.VCenter.VMs.CPUCores.Total, "TotalCPUCores should exclude excluded VMs")
 	assert.Equal(t, 28, inv.VCenter.VMs.RamGB.Total, "TotalRAMGb should exclude excluded VMs")
+}
+
+func TestBuildInventory_VMListFilter(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	vms := []map[string]string{
+		{"VM": "vm-001", "VM ID": "vm-001", "Powerstate": "poweredOn", "CPUs": "4", "Memory": "8192", "Cluster": "Cluster-A", "Datacenter": "DC1", "OS according to the configuration file": "CentOS 7 (64-bit)", "Total disk capacity MiB": "100000", "In Use MiB": "50000"},
+		{"VM": "vm-002", "VM ID": "vm-002", "Powerstate": "poweredOn", "CPUs": "2", "Memory": "4096", "Cluster": "Cluster-A", "Datacenter": "DC1", "OS according to the configuration file": "Ubuntu 20.04 (64-bit)", "Total disk capacity MiB": "50000", "In Use MiB": "25000"},
+		{"VM": "vm-003", "VM ID": "vm-003", "Powerstate": "poweredOn", "CPUs": "8", "Memory": "16384", "Cluster": "Cluster-B", "Datacenter": "DC1", "OS according to the configuration file": "Windows Server 2019 (64-bit)", "Total disk capacity MiB": "200000", "In Use MiB": "100000"},
+		{"VM": "vm-004", "VM ID": "vm-004", "Powerstate": "poweredOff", "CPUs": "4", "Memory": "8192", "Cluster": "Cluster-B", "Datacenter": "DC1", "OS according to the configuration file": "CentOS 8 (64-bit)", "Total disk capacity MiB": "100000", "In Use MiB": "50000"},
+		{"VM": "vm-005", "VM ID": "vm-005", "Powerstate": "poweredOn", "CPUs": "2", "Memory": "4096", "Cluster": "Cluster-A", "Datacenter": "DC1", "OS according to the configuration file": "Ubuntu 22.04 (64-bit)", "Total disk capacity MiB": "50000", "In Use MiB": "25000"},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "DC1", "Cluster": "Cluster-A", "# Cores": "16", "# CPU": "2", "Object ID": "host-001", "# Memory": "65536", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+		{"Datacenter": "DC1", "Cluster": "Cluster-B", "# Cores": "16", "# CPU": "2", "Object ID": "host-002", "# Memory": "65536", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-2", "Config status": "green"},
+	}
+
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err)
+
+	// Test 1: Filter by specific VM list (vm-001, vm-003, vm-005)
+	vmList := []string{"vm-001", "vm-003", "vm-005"}
+	inv, err := parser.BuildInventory(ctx, vmList)
+	require.NoError(t, err)
+
+	// Verify total count includes only the 3 VMs in the list
+	assert.Equal(t, 3, inv.VCenter.VMs.Total, "Total VMs should be 3 (filtered)")
+
+	// Verify power state counts (vm-001: poweredOn, vm-003: poweredOn, vm-005: poweredOn)
+	assert.Equal(t, 3, inv.VCenter.VMs.PowerStates["poweredOn"], "PoweredOn count should be 3")
+	assert.Equal(t, 0, inv.VCenter.VMs.PowerStates["poweredOff"], "PoweredOff count should be 0 (vm-004 is filtered out)")
+
+	// Verify OS distribution includes only filtered VMs
+	assert.Equal(t, 1, inv.VCenter.VMs.OSInfo["CentOS 7 (64-bit)"].Count, "CentOS 7 count should be 1 (vm-001)")
+	assert.Equal(t, 1, inv.VCenter.VMs.OSInfo["Windows Server 2019 (64-bit)"].Count, "Windows count should be 1 (vm-003)")
+	assert.Equal(t, 1, inv.VCenter.VMs.OSInfo["Ubuntu 22.04 (64-bit)"].Count, "Ubuntu 22.04 count should be 1 (vm-005)")
+	assert.NotContains(t, inv.VCenter.VMs.OSInfo, "Ubuntu 20.04 (64-bit)", "Ubuntu 20.04 should not appear (vm-002 filtered out)")
+	assert.NotContains(t, inv.VCenter.VMs.OSInfo, "CentOS 8 (64-bit)", "CentOS 8 should not appear (vm-004 filtered out)")
+
+	// Verify CPU totals: vm-001 (4) + vm-003 (8) + vm-005 (2) = 14
+	assert.Equal(t, 14, inv.VCenter.VMs.CPUCores.Total, "Total CPUs should be 14")
+
+	// Verify CPU tier distribution
+	// vm-001: 4 CPUs -> "0-4", vm-003: 8 CPUs -> "5-8", vm-005: 2 CPUs -> "0-4"
+	assert.Equal(t, 2, inv.VCenter.VMs.DistributionByCPUTier["0-4"], "CPU tier 0-4 should have 2 VMs (vm-001: 4, vm-005: 2)")
+	assert.Equal(t, 1, inv.VCenter.VMs.DistributionByCPUTier["5-8"], "CPU tier 5-8 should have 1 VM (vm-003: 8)")
+
+	// Verify memory totals: vm-001 (8 GB) + vm-003 (16 GB) + vm-005 (4 GB) = 28 GB
+	assert.Equal(t, 28, inv.VCenter.VMs.RamGB.Total, "Total RAM should be 28 GB")
+
+	// Verify per-cluster inventories also respect the VM list filter
+	// Cluster-A should have vm-001 and vm-005 (2 VMs)
+	// Cluster-B should have vm-003 (1 VM)
+	var clusterACount, clusterBCount int
+	for _, clusterInv := range inv.Clusters {
+		total := clusterInv.VMs.Total
+		switch total {
+		case 2:
+			clusterACount = total
+		case 1:
+			clusterBCount = total
+		}
+	}
+	assert.Equal(t, 2, clusterACount, "Cluster-A should have 2 VMs")
+	assert.Equal(t, 1, clusterBCount, "Cluster-B should have 1 VM")
+
+	// Test 2: Empty VM list should include all VMs
+	invAll, err := parser.BuildInventory(ctx, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 5, invAll.VCenter.VMs.Total, "Empty VM list should include all 5 VMs")
+
+	// Test 3: Nil VM list should include all VMs (backward compatibility)
+	invNil, err := parser.BuildInventory(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 5, invNil.VCenter.VMs.Total, "Nil VM list should include all 5 VMs")
+
+	// Test 4: Filter by single VM
+	singleVM := []string{"vm-002"}
+	invSingle, err := parser.BuildInventory(ctx, singleVM)
+	require.NoError(t, err)
+	assert.Equal(t, 1, invSingle.VCenter.VMs.Total, "Single VM filter should have 1 VM")
+	assert.Equal(t, 1, invSingle.VCenter.VMs.OSInfo["Ubuntu 20.04 (64-bit)"].Count, "Should be vm-002")
+	assert.Equal(t, 2, invSingle.VCenter.VMs.CPUCores.Total, "Should have 2 CPUs from vm-002")
+
+	// Test 5: Filter by non-existent VMs should return 0 VMs
+	nonExistent := []string{"vm-999", "vm-888"}
+	invNone, err := parser.BuildInventory(ctx, nonExistent)
+	require.NoError(t, err)
+	assert.Equal(t, 0, invNone.VCenter.VMs.Total, "Non-existent VMs should result in 0 count")
 }

--- a/pkg/duckdb_parser/templates/allocated_memory_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/allocated_memory_query.go.tmpl
@@ -4,9 +4,11 @@ Used for memory overcommitment calculation.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COALESCE(SUM("Memory"), 0)
 FROM vinfo
 WHERE "Powerstate" = 'poweredOn'
   AND COALESCE("migration_excluded", false) = false
-{{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/allocated_vcpus_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/allocated_vcpus_query.go.tmpl
@@ -4,9 +4,11 @@ Used for CPU overcommitment calculation.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COALESCE(SUM("CPUs"), 0)
 FROM vinfo
 WHERE "Powerstate" = 'poweredOn'
   AND COALESCE("migration_excluded", false) = false
-{{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/complexity_distribution_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/complexity_distribution_query.go.tmpl
@@ -10,6 +10,7 @@ Complexity levels:
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 
 NOTE: 4 decimal places (vs 2 in disk_size_tier_query) because complexity buckets
 can contain VMs with small total disk sizes (e.g., 2 GiB ≈ 0.002 TiB) that would
@@ -25,6 +26,7 @@ WITH vm_disk_totals AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY i."VM ID", i."OsDiskComplexity"
 )
 SELECT

--- a/pkg/duckdb_parser/templates/cpu_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/cpu_tier_query.go.tmpl
@@ -3,6 +3,7 @@ CPU Tier Query Template - Returns VM distribution by CPU tier.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT
     CASE
@@ -17,4 +18,5 @@ FROM vinfo
 WHERE 1=1
   AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
 GROUP BY tier;

--- a/pkg/duckdb_parser/templates/disk_complexity_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_complexity_tier_query.go.tmpl
@@ -5,6 +5,7 @@ in pkg/estimations/complexity/complexity.go.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH vm_disk_totals AS (
     SELECT
@@ -15,6 +16,7 @@ WITH vm_disk_totals AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY i."VM ID"
 )
 SELECT

--- a/pkg/duckdb_parser/templates/disk_size_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_size_tier_query.go.tmpl
@@ -7,6 +7,7 @@ This is the expected behavior.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH vm_disk_totals AS (
     SELECT
@@ -17,6 +18,7 @@ WITH vm_disk_totals AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY i."VM ID"
 )
 SELECT

--- a/pkg/duckdb_parser/templates/disk_type_summary_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/disk_type_summary_query.go.tmpl
@@ -3,6 +3,7 @@ Disk Type Summary Query Template - Returns disk usage aggregated by datastore ty
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH vm_disk_types AS (
     SELECT
@@ -15,6 +16,7 @@ WITH vm_disk_types AS (
     WHERE ds."Type" IS NOT NULL AND ds."Type" != ''
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
 )
 SELECT
     disk_type AS type,

--- a/pkg/duckdb_parser/templates/memory_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/memory_tier_query.go.tmpl
@@ -3,6 +3,7 @@ Memory Tier Query Template - Returns VM distribution by memory tier (in GB).
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT
     CASE
@@ -19,4 +20,5 @@ FROM vinfo
 WHERE 1=1
   AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
 GROUP BY tier;

--- a/pkg/duckdb_parser/templates/migratable_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migratable_count_query.go.tmpl
@@ -3,10 +3,12 @@ Migratable Count Query Template - Returns count of VMs without Critical concerns
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 LEFT JOIN concerns c ON i."VM ID" = c."VM_ID" AND c."Category" = 'Critical'
 WHERE c."VM_ID" IS NULL
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/migratable_with_warnings_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migratable_with_warnings_count_query.go.tmpl
@@ -6,10 +6,12 @@ any VM that has a warning, regardless of whether it also has critical concerns.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 JOIN concerns warn ON i."VM ID" = warn."VM_ID" AND warn."Category" = 'Warning'
 WHERE 1=1
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/migration_issues_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/migration_issues_query.go.tmpl
@@ -7,6 +7,7 @@ This means multiple disk-level warnings (e.g., scsi0:0, scsi0:1) are counted tog
 Template Parameters:
   - ClusterFilter: filter by cluster name
   - Category: concern category (e.g., "Critical", "Warning")
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT
     c."Concern_ID" AS id,
@@ -19,4 +20,5 @@ JOIN vinfo i ON c."VM_ID" = i."VM ID"
 WHERE c."Category" = '{{.Category}}'
   AND COALESCE(i."migration_excluded", false) = false
 {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
 GROUP BY c."Concern_ID";

--- a/pkg/duckdb_parser/templates/nic_tier_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/nic_tier_query.go.tmpl
@@ -10,6 +10,7 @@ Matches the old implementation's nicCountKey function:
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH nic_counts AS (
     SELECT
@@ -20,6 +21,7 @@ WITH nic_counts AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
     GROUP BY i."VM ID"
 )
 SELECT

--- a/pkg/duckdb_parser/templates/not_migratable_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/not_migratable_count_query.go.tmpl
@@ -3,10 +3,12 @@ Not Migratable Count Query Template - Returns count of VMs with Critical concern
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COUNT(DISTINCT i."VM ID")
 FROM vinfo i
 JOIN concerns c ON i."VM ID" = c."VM_ID" AND c."Category" = 'Critical'
 WHERE 1=1
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/os_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/os_query.go.tmpl
@@ -14,6 +14,7 @@ upgrade recommendations are only shown for OSes that are also marked unsupported
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH os_data AS (
     -- "VM" placeholder is filtered during ingestion (NULLIF in ingest_rvtools.go.tmpl)
@@ -32,6 +33,7 @@ WITH os_data AS (
         (v."OS according to the configuration file" IS NOT NULL AND v."OS according to the configuration file" != '')
     )
     {{- if .ClusterFilter }} AND v."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
 ),
 unsupported_os AS (
     SELECT DISTINCT
@@ -45,6 +47,7 @@ unsupported_os AS (
     WHERE c."Concern_ID" = 'vmware.os.unsupported'
       AND COALESCE(v."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND v."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
 ),
 upgrade_recommendations AS (
     -- Only get upgrade recommendations for OSes that are also unsupported
@@ -61,6 +64,7 @@ upgrade_recommendations AS (
     WHERE c."Concern_ID" = 'vmware.os.upgrade.recommendation'
       AND COALESCE(v."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND v."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY 1
 )
 SELECT

--- a/pkg/duckdb_parser/templates/power_state_counts_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/power_state_counts_query.go.tmpl
@@ -3,10 +3,12 @@ Power State Counts Query Template - Returns VM power state distribution.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT "Powerstate" AS state, COUNT(*) AS count
 FROM vinfo
 WHERE 1=1
   AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
 GROUP BY "Powerstate";

--- a/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/resource_breakdowns_query.go.tmpl
@@ -12,6 +12,7 @@ resources for VMs that are fully migratable without any warnings.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 WITH vm_concerns AS (
     SELECT DISTINCT
@@ -23,6 +24,7 @@ WITH vm_concerns AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY i."VM ID"
 ),
 vm_resources AS (
@@ -37,6 +39,7 @@ vm_resources AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
 ),
 disk_resources AS (
     SELECT
@@ -48,6 +51,7 @@ disk_resources AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY d."VM ID"
 ),
 nic_resources AS (
@@ -59,6 +63,7 @@ nic_resources AS (
     WHERE 1=1
       AND COALESCE(i."migration_excluded", false) = false
     {{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+    {{- .VMListFilter}}
     GROUP BY n."VM ID"
 ),
 combined AS (

--- a/pkg/duckdb_parser/templates/resource_totals_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/resource_totals_query.go.tmpl
@@ -3,6 +3,7 @@ Resource Totals Query Template - Returns aggregated resource totals.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT
     COALESCE(SUM(i."CPUs"), 0)::integer AS total_cpu_cores,
@@ -23,4 +24,5 @@ LEFT JOIN (
 ) n ON i."VM ID" = n."VM ID"
 WHERE 1=1
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/vm_count_by_network_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_count_by_network_query.go.tmpl
@@ -6,11 +6,13 @@ A VM with 2 NICs on the same network is counted twice.
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT "Network" AS network, COUNT(*) AS count
 FROM vnetwork n
 JOIN vinfo i ON n."VM ID" = i."VM ID"
 WHERE 1=1
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{- end}}
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}}
 GROUP BY "Network";

--- a/pkg/duckdb_parser/templates/vm_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_count_query.go.tmpl
@@ -4,9 +4,11 @@ VM Count Query Template - Returns count of VMs with optional filters.
 Template Parameters:
   - ClusterFilter: filter by cluster name
   - PowerStateFilter: filter by power state
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COUNT(*) FROM vinfo
 WHERE 1=1
   AND COALESCE("migration_excluded", false) = false
 {{- if .ClusterFilter }} AND "Cluster" = '{{.ClusterFilter}}'{{end}}
-{{- if .PowerStateFilter }} AND "Powerstate" = '{{.PowerStateFilter}}'{{end}};
+{{- if .PowerStateFilter }} AND "Powerstate" = '{{.PowerStateFilter}}'{{end}}
+{{- .VMListFilter}};

--- a/pkg/duckdb_parser/templates/vm_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_query.go.tmpl
@@ -10,6 +10,7 @@ Template Parameters:
   - ClusterFilter: filter by cluster name
   - OSFilter: filter by OS name
   - PowerStateFilter: filter by power state
+  - VMListFilter: filter by list of VM IDs
   - Limit: max results (0 = unlimited)
   - Offset: skip first N results
 */ -}}
@@ -118,5 +119,6 @@ WHERE 1=1
 {{- if .OSFilter }} AND i."OS according to the configuration file" LIKE '%{{.OSFilter}}%'{{end}}
 {{- if .VmIDFilter }} AND i."VM ID" = '{{.VmIDFilter}}'{{end}}
 {{- if .PowerStateFilter }} AND i."Powerstate" = '{{.PowerStateFilter}}'{{end}}
+{{- .VMListFilter}}
 {{- if and .Limit (gt .Limit 0) }} LIMIT {{.Limit}}{{end}}
 {{- if and .Offset (gt .Offset 0) }} OFFSET {{.Offset}}{{end}};

--- a/pkg/duckdb_parser/templates/vms_with_shared_disks_count_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vms_with_shared_disks_count_query.go.tmpl
@@ -3,11 +3,13 @@ VMs With Shared Disks Count Query Template - Returns count of VMs that have at l
 
 Template Parameters:
   - ClusterFilter: filter by cluster name
+  - VMListFilter: filter by list of VM IDs
 */ -}}
 SELECT COUNT(DISTINCT d."VM ID")
 FROM vdisk d
 JOIN vinfo i ON d."VM ID" = i."VM ID"
 WHERE d."Sharing mode" = true
   AND COALESCE(i."migration_excluded", false) = false
-{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}};
+{{- if .ClusterFilter }} AND i."Cluster" = '{{.ClusterFilter}}'{{end}}
+{{- .VMListFilter}};
 

--- a/pkg/duckdb_parser/types.go
+++ b/pkg/duckdb_parser/types.go
@@ -4,10 +4,11 @@ import "github.com/kubev2v/migration-planner/pkg/inventory"
 
 // Filters for querying data.
 type Filters struct {
-	Cluster    string // filter by cluster name
-	VmId       string // filter by vm ID
-	OS         string // filter by OS name (for VMs)
-	PowerState string // filter by power state (for VMs)
+	Cluster    string   // filter by cluster name
+	VmId       string   // filter by vm ID
+	OS         string   // filter by OS name (for VMs)
+	PowerState string   // filter by power state (for VMs)
+	VMList     []string // filter by list of VM IDs (optional, only includes VMs in this list)
 }
 
 // Options for pagination.


### PR DESCRIPTION
Allow BuildInventory to filter by a specific list of VM IDs. 
When provided, only VMs in the list are included in inventory calculations. 
When empty, all VMs are included (backward compatible). 
Updated 21 query templates and added comprehensive test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering inventory and resource data by a specified list of VM IDs, enabling more precise query results across all inventory operations and resource analyses.

* **Tests**
  * Added comprehensive test coverage for VM list filtering, verifying behavior with empty lists, null values, and non-existent VM IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1169)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->