### PR TITLE
ECOPROJECT-4359 | feat: Add metrics cache to reduce database queries for inventory statistics

### DIFF
--- a/internal/handlers/v1alpha1/sizer_test.go
+++ b/internal/handlers/v1alpha1/sizer_test.go
@@ -117,6 +117,8 @@ func (m *MockStore) Statistics(ctx context.Context) (model.InventoryStats, error
 	return model.InventoryStats{}, nil
 }
 
+func (m *MockStore) RequestMetricsCacheRefresh() {}
+
 func (m *MockStore) Accounts() store.Accounts {
 	panic("Accounts() not implemented in MockStore for this test")
 }

--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -179,6 +179,7 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 		}
 		return w.failJob(ctx, logger, job.ID, "create_assessment", err, errMsg)
 	}
+	w.store.RequestMetricsCacheRefresh()
 
 	updates := store.NewRelationshipBuilder().
 		With(model.NewAssessmentResource(assessment.ID.String()), model.OwnerRelation, model.NewUserSubject(job.Args.Username)).

--- a/internal/service/assessment.go
+++ b/internal/service/assessment.go
@@ -196,6 +196,8 @@ func (as *AssessmentService) CreateAssessment(ctx context.Context, createForm ma
 		return nil, err
 	}
 
+	as.store.RequestMetricsCacheRefresh()
+
 	tracer.Success().
 		WithUUID("assessment_id", createdAssessment.ID).
 		WithString("assessment_name", createdAssessment.Name).
@@ -249,6 +251,8 @@ func (as *AssessmentService) UpdateAssessment(ctx context.Context, id uuid.UUID,
 			return nil, err
 		}
 
+		as.store.RequestMetricsCacheRefresh()
+
 		tracer.Success().WithString("update_type", "with_new_snapshot").Log()
 		return as.GetAssessment(ctx, id)
 	}
@@ -291,6 +295,7 @@ func (as *AssessmentService) DeleteAssessment(ctx context.Context, id uuid.UUID)
 	if err := as.store.Assessment().Delete(ctx, id); err != nil {
 		return fmt.Errorf("failed to delete assessment: %w", err)
 	}
+	as.store.RequestMetricsCacheRefresh()
 
 	tracer.Success().WithString("deleted_assessment_name", assessment.Name).Log()
 	return nil

--- a/internal/service/sizer_test.go
+++ b/internal/service/sizer_test.go
@@ -83,6 +83,8 @@ func (m *MockStore) Statistics(ctx context.Context) (model.InventoryStats, error
 	return model.InventoryStats{}, nil
 }
 
+func (m *MockStore) RequestMetricsCacheRefresh() {}
+
 func (m *MockStore) Accounts() store.Accounts {
 	return nil
 }

--- a/internal/store/metric_cache.go
+++ b/internal/store/metric_cache.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/kubev2v/migration-planner/internal/store/model"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	minCooldownPeriod = 5 * time.Minute
+	maxCooldownPeriod = 3 * time.Hour
+)
+
+// MetricsCache manages cached inventory statistics
+type MetricsCache struct {
+	assessmentStore Assessment
+	needsUpdate     atomic.Bool // Set when the server modifies data requiring cache refresh
+
+	stats       atomic.Pointer[model.InventoryStats]
+	lastRefresh atomic.Int64
+
+	group singleflight.Group
+}
+
+// NewMetricsCache creates a new metrics cache
+func NewMetricsCache(s Assessment) *MetricsCache {
+	return &MetricsCache{
+		assessmentStore: s,
+	}
+}
+
+// GetStats returns cached stats, refreshing only if cooldown expired.
+func (mc *MetricsCache) GetStats(ctx context.Context) (model.InventoryStats, error) {
+	ptr := mc.stats.Load()
+
+	if ptr != nil && !mc.shouldRefresh() {
+		return *ptr, nil
+	}
+
+	v, err, _ := mc.group.Do("refresh_stats", func() (any, error) {
+
+		assessments, err := mc.assessmentStore.List(ctx, NewAssessmentQueryFilter())
+		if err != nil {
+			return nil, err
+		}
+
+		stats := model.NewInventoryStats(assessments)
+
+		mc.stats.Store(&stats)
+		mc.lastRefresh.Store(time.Now().UnixNano())
+		mc.needsUpdate.Store(false)
+
+		return stats, nil
+	})
+
+	if err != nil {
+		return model.InventoryStats{}, fmt.Errorf("refresh cache failed: %w", err)
+	}
+
+	return v.(model.InventoryStats), nil
+}
+
+func (mc *MetricsCache) RequestMetricsCacheRefresh() {
+	mc.needsUpdate.Store(true)
+}
+
+// shouldRefresh checks if cooldown period has passed
+func (mc *MetricsCache) shouldRefresh() bool {
+	last := mc.lastRefresh.Load()
+	if last == 0 {
+		return true
+	}
+
+	// Potential change by other pods
+	if time.Since(time.Unix(0, last)) > maxCooldownPeriod {
+		return true
+	}
+
+	if !mc.needsUpdate.Load() {
+		return false
+	}
+
+	return time.Since(time.Unix(0, last)) > minCooldownPeriod
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	PartnerCustomer() PartnerCustomer
 	Statistics(ctx context.Context) (model.InventoryStats, error)
 	Close() error
+	RequestMetricsCacheRefresh()
 }
 
 type DataStore struct {
@@ -37,21 +38,25 @@ type DataStore struct {
 	job             Job
 	accounts        Accounts
 	partnerCustomer PartnerCustomer
+	metricCache     *MetricsCache
 }
 
 func NewStore(db *gorm.DB) Store {
+	assessment := NewAssessmentStore(db)
+
 	return &DataStore{
 		agent:           NewAgentSource(db),
 		source:          NewSource(db),
 		imageInfra:      NewImageInfraStore(db),
 		privateKey:      NewCacheKeyStore(NewPrivateKey(db)),
 		label:           NewLabelStore(db),
-		assessment:      NewAssessmentStore(db),
+		assessment:      assessment,
 		cluster:         NewClusterSizingInputStore(db),
 		job:             NewJobStore(db),
 		authz:           NewAuthzStore(db),
 		accounts:        NewAccountsStore(db),
 		partnerCustomer: NewPartnerCustomerStore(db),
+		metricCache:     NewMetricsCache(assessment),
 		db:              db,
 	}
 }
@@ -105,11 +110,11 @@ func (s *DataStore) PartnerCustomer() PartnerCustomer {
 }
 
 func (s *DataStore) Statistics(ctx context.Context) (model.InventoryStats, error) {
-	assessments, err := s.Assessment().List(ctx, NewAssessmentQueryFilter())
-	if err != nil {
-		return model.InventoryStats{}, err
-	}
-	return model.NewInventoryStats(assessments), nil
+	return s.metricCache.GetStats(ctx)
+}
+
+func (s *DataStore) RequestMetricsCacheRefresh() {
+	s.metricCache.RequestMetricsCacheRefresh()
 }
 
 func (s *DataStore) Close() error {


### PR DESCRIPTION
Implements a thread-safe cache layer for inventory statistics to avoid
repeated database queries. The cache uses atomic operations and the
singleflight pattern to prevent duplicate concurrent refreshes.

Key features:
- Configurable cooldown periods (5min-3hr) to balance freshness vs performance
- Automatic invalidation on assessment create/update/delete operations
- Thread-safe concurrent access using atomic.Pointer and atomic.Bool
- Singleflight deduplication prevents thundering herd on cache misses

Changes:
- Add MetricsCache type with GetStats() and RequestMetricsCacheRefresh()
- Modify Statistics() to use cache instead of direct database queries
- Trigger cache refresh after assessment mutations
- Update MockStore in tests to implement new interface method

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory statistics are now cached with intelligent refresh logic to improve application performance and reduce server load.
  * Cache automatically refreshes whenever assessments are created, updated, or deleted, ensuring statistics remain fresh and accurate without manual intervention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->