### PR TITLE
ECOPROJECT-4414 | fix: persist empty description on group update

### DIFF
--- a/internal/handlers/v1alpha1/accounts_test.go
+++ b/internal/handlers/v1alpha1/accounts_test.go
@@ -353,6 +353,22 @@ var _ = Describe("accounts handler", Ordered, func() {
 				Expect(updated.Company).To(Equal("Acme"))
 			})
 
+			It("clears description and includes it in response", func() {
+				orgID := uuid.New()
+				tx := gormdb.Exec(fmt.Sprintf(insertAccountsHandlerGroupStm, orgID, "Org", "old desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+
+				empty := ""
+				body := v1alpha1.GroupUpdate{Description: &empty}
+				resp, err := srv.UpdateGroup(context.TODO(), server.UpdateGroupRequestObject{Id: orgID, Body: &body})
+				Expect(err).To(BeNil())
+				Expect(reflect.TypeOf(resp)).To(Equal(reflect.TypeOf(server.UpdateGroup200JSONResponse{})))
+
+				updated := resp.(server.UpdateGroup200JSONResponse)
+				Expect(updated.Description).ToNot(BeNil())
+				Expect(*updated.Description).To(BeEmpty())
+			})
+
 			It("returns 400 for empty company", func() {
 				orgID := uuid.New()
 				tx := gormdb.Exec(fmt.Sprintf(insertAccountsHandlerGroupStm, orgID, "Org", "desc", "partner", "icon", "Acme", "NULL"))

--- a/internal/handlers/v1alpha1/mappers/accounts_outbound.go
+++ b/internal/handlers/v1alpha1/mappers/accounts_outbound.go
@@ -17,9 +17,7 @@ func GroupToApi(group model.Group) api.Group {
 		CreatedAt: group.CreatedAt,
 	}
 
-	if group.Description != "" {
-		result.Description = &group.Description
-	}
+	result.Description = &group.Description
 	if group.UpdatedAt != nil {
 		result.UpdatedAt = *group.UpdatedAt
 	}

--- a/internal/store/accounts.go
+++ b/internal/store/accounts.go
@@ -88,7 +88,7 @@ func (s *AccountsStore) UpdateGroup(ctx context.Context, group model.Group) (mod
 
 	now := time.Now()
 	group.UpdatedAt = &now
-	if err := s.getDB(ctx).Model(&group).Updates(&group).Error; err != nil {
+	if err := s.getDB(ctx).Model(&group).Select("name", "description", "icon", "company", "updated_at").Updates(&group).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return model.Group{}, ErrDuplicateKey
 		}

--- a/internal/store/accounts_test.go
+++ b/internal/store/accounts_test.go
@@ -257,6 +257,29 @@ var _ = Describe("accounts store", Ordered, func() {
 				Expect(updated.UpdatedAt).ToNot(BeNil())
 			})
 
+			It("successfully clears description with empty string", func() {
+				orgID := uuid.New()
+
+				tx := gormdb.Exec(fmt.Sprintf(insertGroupStm, orgID, "Name", "Some desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+
+				org := model.Group{
+					ID:          orgID,
+					Name:        "Name",
+					Description: "",
+					Kind:        "partner",
+					Icon:        "icon",
+					Company:     "Acme",
+				}
+				updated, err := s.Accounts().UpdateGroup(context.TODO(), org)
+				Expect(err).To(BeNil())
+				Expect(updated.Description).To(BeEmpty())
+
+				var persisted model.Group
+				Expect(gormdb.First(&persisted, "id = ?", orgID).Error).To(BeNil())
+				Expect(persisted.Description).To(BeEmpty())
+			})
+
 			It("fails to update non-existent group", func() {
 				org := model.Group{
 					ID:   uuid.New(),


### PR DESCRIPTION
There is an inconsistency in the Group API regarding the description field between GET and PUT operations.

When retrieving a group, the description field is present. However, when updating the group with an empty description, the field is omitted from the response, and the update is not actually applied.

This leads to a silent failure and inconsistent API behavior.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed group description handling in update operations. Groups can now be properly updated with empty descriptions instead of preserving previous values. All description changes, including clearing to empty strings, are correctly persisted and reflected in API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->