### PR TITLE
ECOPROJECT-4546 | fix: prevent customers requests from being added as group members

### DIFF
--- a/internal/handlers/v1alpha1/accounts.go
+++ b/internal/handlers/v1alpha1/accounts.go
@@ -347,6 +347,8 @@ func (h *ServiceHandler) CreateGroupMember(ctx context.Context, request server.C
 			return server.CreateGroupMember404JSONResponse{Message: "group not found"}, nil
 		case *service.ErrDuplicateKey:
 			return server.CreateGroupMember409JSONResponse{Message: err.Error()}, nil
+		case *service.ErrActiveRequestExists:
+			return server.CreateGroupMember400JSONResponse{Message: err.Error()}, nil
 		default:
 			logger.Error(err).Log()
 			return server.CreateGroupMember500JSONResponse{Message: fmt.Sprintf("failed to create member: %v", err)}, nil

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -268,7 +268,8 @@ func (s *AccountsService) ListGroupMembers(ctx context.Context, groupID uuid.UUI
 	return s.store.Accounts().ListMembers(ctx, store.NewMemberQueryFilter().ByGroupID(groupID))
 }
 
-// CreateMember creates a new member. Verifies the group exists.
+// CreateMember creates a new member. Verifies the group exists and the user
+// has no active customer relationship (pending or accepted).
 func (s *AccountsService) CreateMember(ctx context.Context, member model.Member) (model.Member, error) {
 	if _, err := s.GetGroup(ctx, member.GroupID); err != nil {
 		return model.Member{}, err
@@ -292,6 +293,15 @@ func (s *AccountsService) CreateMember(ctx context.Context, member model.Member)
 	defer func() {
 		_, _ = store.Rollback(ctx)
 	}()
+
+	active, err := s.store.PartnerCustomer().List(ctx,
+		store.NewPartnerQueryFilter().ByUsername(member.Username).ByActiveStatus())
+	if err != nil {
+		return model.Member{}, err
+	}
+	if len(active) > 0 {
+		return model.Member{}, NewErrActiveRequestExists(member.Username)
+	}
 
 	created, err := s.store.Accounts().CreateMember(ctx, member)
 	if err != nil {
@@ -351,6 +361,14 @@ func (s *AccountsService) UpdateGroupMember(ctx context.Context, groupID uuid.UU
 // RemoveGroupMember removes a member from the specified group.
 // Since a backend member must always belong to a group, this deletes the member.
 func (s *AccountsService) RemoveGroupMember(ctx context.Context, groupID uuid.UUID, username string) error {
+	ctx, err := s.store.NewTransactionContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = store.Rollback(ctx)
+	}()
+
 	if _, err := s.GetGroup(ctx, groupID); err != nil {
 		return err
 	}
@@ -363,14 +381,6 @@ func (s *AccountsService) RemoveGroupMember(ctx context.Context, groupID uuid.UU
 	if member.GroupID != groupID {
 		return NewErrMembershipMismatch(username, groupID)
 	}
-
-	ctx, err = s.store.NewTransactionContext(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_, _ = store.Rollback(ctx)
-	}()
 
 	if err := s.store.Accounts().DeleteMember(ctx, member.ID); err != nil {
 		return err

--- a/internal/service/accounts_test.go
+++ b/internal/service/accounts_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	insertAccountsGroupStm  = "INSERT INTO groups (id, name, description, kind, icon, company, parent_id) VALUES ('%s', '%s', '%s', '%s', '%s', '%s', %s);"
-	insertAccountsMemberStm = "INSERT INTO members (id, username, email, group_id) VALUES ('%s', '%s', '%s', '%s');"
+	insertAccountsGroupStm           = "INSERT INTO groups (id, name, description, kind, icon, company, parent_id) VALUES ('%s', '%s', '%s', '%s', '%s', '%s', %s);"
+	insertAccountsMemberStm          = "INSERT INTO members (id, username, email, group_id) VALUES ('%s', '%s', '%s', '%s');"
+	insertAccountsPartnerCustomerStm = "INSERT INTO partners_customers (id, username, partner_id, request_status, name, contact_name, contact_phone, email, location) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"
 )
 
 var _ = Describe("accounts service", Ordered, func() {
@@ -331,7 +332,73 @@ var _ = Describe("accounts service", Ordered, func() {
 				Expect(err.Error()).To(ContainSubstring("already belongs to another group"))
 			})
 
+			It("returns ErrActiveRequestExists when user has an accepted partner customer request", func() {
+				partnerGroupID := uuid.New()
+				targetGroupID := uuid.New()
+
+				tx := gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, targetGroupID, "Admin Org", "desc", "admin", "icon", "Red Hat", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(insertAccountsPartnerCustomerStm, uuid.New(), "customeruser", partnerGroupID, "accepted", "Cust", "Contact", "555", "c@e.com", "Loc")
+				Expect(tx.Error).To(BeNil())
+
+				member := model.Member{
+					Username: "customeruser",
+					Email:    "c@e.com",
+					GroupID:  targetGroupID,
+				}
+				_, err := svc.CreateMember(context.TODO(), member)
+				Expect(err).ToNot(BeNil())
+				var activeReq *service.ErrActiveRequestExists
+				Expect(err).To(BeAssignableToTypeOf(activeReq))
+			})
+
+			It("returns ErrActiveRequestExists when user has a pending partner customer request", func() {
+				partnerGroupID := uuid.New()
+				targetGroupID := uuid.New()
+
+				tx := gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, targetGroupID, "Admin Org", "desc", "admin", "icon", "Red Hat", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(insertAccountsPartnerCustomerStm, uuid.New(), "pendinguser", partnerGroupID, "pending", "Cust", "Contact", "555", "p@e.com", "Loc")
+				Expect(tx.Error).To(BeNil())
+
+				member := model.Member{
+					Username: "pendinguser",
+					Email:    "p@e.com",
+					GroupID:  targetGroupID,
+				}
+				_, err := svc.CreateMember(context.TODO(), member)
+				Expect(err).ToNot(BeNil())
+				var activeReq *service.ErrActiveRequestExists
+				Expect(err).To(BeAssignableToTypeOf(activeReq))
+			})
+
+			It("allows creating a member when user has only rejected/cancelled requests", func() {
+				partnerGroupID := uuid.New()
+				targetGroupID := uuid.New()
+
+				tx := gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, targetGroupID, "Admin Org", "desc", "admin", "icon", "Red Hat", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(insertAccountsPartnerCustomerStm, uuid.New(), "rejecteduser", partnerGroupID, "rejected", "Cust", "Contact", "555", "r@e.com", "Loc")
+				Expect(tx.Error).To(BeNil())
+
+				member := model.Member{
+					Username: "rejecteduser",
+					Email:    "r@e.com",
+					GroupID:  targetGroupID,
+				}
+				created, err := svc.CreateMember(context.TODO(), member)
+				Expect(err).To(BeNil())
+				Expect(created.Username).To(Equal("rejecteduser"))
+			})
+
 			AfterEach(func() {
+				gormdb.Exec("DELETE FROM partners_customers;")
 				gormdb.Exec("DELETE FROM members;")
 				gormdb.Exec("DELETE FROM groups;")
 			})

--- a/internal/store/options.go
+++ b/internal/store/options.go
@@ -116,6 +116,13 @@ func (f *PartnerQueryFilter) ByStatus(status model.RequestStatus) *PartnerQueryF
 	return f
 }
 
+func (f *PartnerQueryFilter) ByActiveStatus() *PartnerQueryFilter {
+	f.QueryFn = append(f.QueryFn, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("request_status IN ?", []model.RequestStatus{model.RequestStatusPending, model.RequestStatusAccepted})
+	})
+	return f
+}
+
 type AssessmentQueryFilter struct {
 	QueryFn []func(*gorm.DB) *gorm.DB
 }


### PR DESCRIPTION
CreateMember now checks for pending/accepted PartnerCustomer requests before adding a user to any group, returning ErrActiveRequestExists if one is found.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation that blocks adding a group member when there is an existing active customer relationship (pending or accepted).

* **Bug Fixes**
  * Improved group member creation error responses to return a clear client error when an active request already exists.

* **Tests**
  * Added new test cases covering accepted/pending active requests and the rejected-only scenario, including updated test data cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->