### PR TITLE
ECOPROJECT-4693 | fix: Handle existing members during admin group initialization

### DIFF
--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -190,12 +190,24 @@ func (s *AccountsService) Initialize(ctx context.Context, adminGroup AdminGroup)
 	}
 
 	for _, m := range adminGroup.Members {
+		// Try to get existing member
+		existingMember, err := s.store.Accounts().GetMember(ctx, m.Username)
+		if err != nil && !errors.Is(err, store.ErrRecordNotFound) {
+			return fmt.Errorf("looking up admin member %s: %w", m.Username, err)
+		}
+		if err == nil {
+			// Member exists, delete before recreation
+			if err := s.store.Accounts().DeleteMember(ctx, existingMember.ID); err != nil {
+				return fmt.Errorf("deleting existing admin member %s: %w", m.Username, err)
+			}
+		}
+		// At this point we sure member doesn't exist, create new one
 		if _, err := s.store.Accounts().CreateMember(ctx, model.Member{
 			Username: m.Username,
 			Email:    m.Email,
 			GroupID:  group.ID,
-		}); err != nil {
-			return fmt.Errorf("adding admin member %s: %w", m.Username, err)
+		}); err != nil && !errors.Is(err, store.ErrDuplicateKey) {
+			return fmt.Errorf("creating admin member %s: %w", m.Username, err)
 		}
 	}
 

--- a/internal/service/accounts_test.go
+++ b/internal/service/accounts_test.go
@@ -618,4 +618,79 @@ var _ = Describe("accounts service", Ordered, func() {
 			})
 		})
 	})
+
+	Context("Initialize - Member Reconciliation", func() {
+		It("creates admin group and adds members", func() {
+			ag := service.AdminGroup{
+				Name: "reconciliation-admins",
+				Members: []service.AdminGroupMember{
+					{Username: "admin1", Email: "admin1@example.com"},
+					{Username: "admin2", Email: "admin2@example.com"},
+					{Username: "admin3", Email: "admin3@example.com"},
+				},
+			}
+
+			err := svc.Initialize(context.TODO(), ag)
+			Expect(err).To(BeNil())
+
+			groups, err := svc.ListGroups(context.TODO(), store.NewGroupQueryFilter().ByName("reconciliation-admins"))
+			Expect(err).To(BeNil())
+			Expect(groups).To(HaveLen(1))
+			Expect(groups[0].Kind).To(Equal("admin"))
+			Expect(groups[0].Members).To(HaveLen(3))
+
+			member1, err := svc.GetMember(context.TODO(), "admin1")
+			Expect(err).To(BeNil())
+			Expect(member1.Email).To(Equal("admin1@example.com"))
+			Expect(member1.GroupID).To(Equal(groups[0].ID))
+
+			member2, err := svc.GetMember(context.TODO(), "admin2")
+			Expect(err).To(BeNil())
+			Expect(member2.Email).To(Equal("admin2@example.com"))
+
+			member3, err := svc.GetMember(context.TODO(), "admin3")
+			Expect(err).To(BeNil())
+			Expect(member3.Email).To(Equal("admin3@example.com"))
+		})
+
+		It("reconciles existing members from other groups", func() {
+			partnerGroupID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+			Expect(tx.Error).To(BeNil())
+			tx = gormdb.Exec(fmt.Sprintf(insertAccountsMemberStm, uuid.New(), "existinguser", "old@acme.com", partnerGroupID))
+			Expect(tx.Error).To(BeNil())
+
+			ag := service.AdminGroup{
+				Name: "reconcile-admins",
+				Members: []service.AdminGroupMember{
+					{Username: "existinguser", Email: "new@redhat.com"},
+					{Username: "newuser", Email: "newuser@redhat.com"},
+				},
+			}
+
+			err := svc.Initialize(context.TODO(), ag)
+			Expect(err).To(BeNil())
+
+			member, err := svc.GetMember(context.TODO(), "existinguser")
+			Expect(err).To(BeNil())
+			Expect(member.Email).To(Equal("new@redhat.com"))
+
+			adminGroups, err := svc.ListGroups(context.TODO(), store.NewGroupQueryFilter().ByName("reconcile-admins"))
+			Expect(err).To(BeNil())
+			Expect(adminGroups).To(HaveLen(1))
+			Expect(member.GroupID).To(Equal(adminGroups[0].ID))
+			Expect(member.Group.Kind).To(Equal("admin"))
+			Expect(member.Group.Name).To(Equal("reconcile-admins"))
+
+			newMember, err := svc.GetMember(context.TODO(), "newuser")
+			Expect(err).To(BeNil())
+			Expect(newMember.Email).To(Equal("newuser@redhat.com"))
+			Expect(newMember.GroupID).To(Equal(member.GroupID))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE FROM members;")
+			gormdb.Exec("DELETE FROM groups;")
+		})
+	})
 })


### PR DESCRIPTION
The Initialize method now uses a get-or-create pattern for admin members instead of attempting to create them directly. This prevents duplicate key errors when members already exist in the database from previous runs or other groups.

- Check if member exists before creating
- Update existing member's group assignment and email if found
- Create new member only if not found

Fixes server startup failure: "failed to initialize admin group: adding
admin member oma-user-admin-ci-qe: already exists"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin-group initialization now tolerates existing members: existing entries are reconciled and updated instead of causing initialization to fail; new members are created and assigned to the admin group as needed.

* **Tests**
  * Added end-to-end tests covering member reconciliation during initialization, including updates for existing members and creation of new members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->