### PR TITLE
ECOPROJECT-4707 | feat: add cluster requirement path to envoy

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -426,6 +426,15 @@ objects:
                                 regex: "^${SERVICE_API_PATH}/api/v1/image"
                               substitution: "/api/v1/image"
                         - match:
+                            prefix: "${SERVICE_API_PATH}/api/v1/cluster-requirements"
+                          route:
+                            cluster: backend-api
+                            timeout: 30s
+                            regex_rewrite:
+                              pattern:
+                                regex: "^${SERVICE_API_PATH}/api/v1/cluster-requirements"
+                              substitution: "/api/v1/cluster-requirements"
+                        - match:
                             prefix: "${SERVICE_API_PATH}/api/v1/assessments"
                           route:
                             cluster: backend-api


### PR DESCRIPTION
The standalone cluster sizing endpoint POST /api/v1/cluster-requirements was added to the API  but the Envoy configuration was missing the route, causing 404 errors in deployed environments.