### PR TITLE
Update releasing skill to pull app-interface master before creating MR

### DIFF
--- a/skills/releasing.md
+++ b/skills/releasing.md
@@ -78,7 +78,8 @@ an active clone of those repos and ask the user either to clone them, or give yo
      HEAD SHA: <sha>
      ```
 5. Prepare an MR for app-interface to update the stable environments with the new tag SHAs:
-   - In the app-interface repository, locate the files named `saas-service.yaml` and `saas-ui.yaml` that are related to assisted-migration
+   - In the app-interface repository, pull the latest master branch from downstream remote: `git pull <downstream-remote> master`
+   - Locate the files named `saas-service.yaml` and `saas-ui.yaml` that are related to assisted-migration
    - Review the git log and last merged MRs for these files to understand the pattern used in previous releases
    - **Important**: The number of environments and their configuration may vary between releases, so always check the latest MRs to identify all environments that need updating
    - Update the SHA values for stable environments to match the HEAD sha of the newly created tags


### PR DESCRIPTION
## Summary
- Add step to pull latest master branch from downstream remote in app-interface repository before creating release MR

## Why
During the v0.13.4 release, we encountered merge conflicts in the app-interface MR because the local branch wasn't up to date with the latest master. This change ensures the release branch is based on the latest upstream state.

## Test plan
- [x] Updated skills/releasing.md with new step 5 to pull master before locating saas files

🤖 Generated with [Claude Code](https://claude.com/claude-code)