### PR TITLE
ECOPROJECT-4703 | fix: Exclude networks with zero VMs from filtered inventories

### DIFF
--- a/pkg/duckdb_parser/builder.go
+++ b/pkg/duckdb_parser/builder.go
@@ -293,7 +293,7 @@ func (b *QueryBuilder) TotalHostMemoryQuery(filters Filters) (string, error) {
 func (b *QueryBuilder) VMCountByNetworkQuery(filters Filters) (string, error) {
 	params := queryParams{
 		ClusterFilter: filters.Cluster,
-		VMListFilter:  buildVMListFilter(filters.VMList, ""),
+		VMListFilter:  buildVMListFilter(filters.VMList, "i"),
 	}
 	return b.buildQuery("vm_count_by_network_query", mustGetTemplate("vm_count_by_network_query"), params)
 }

--- a/pkg/duckdb_parser/inventory_builder.go
+++ b/pkg/duckdb_parser/inventory_builder.go
@@ -381,19 +381,18 @@ func (p *Parser) buildInfraData(ctx context.Context, filters Filters) (*inventor
 	// Get VM count by network for enrichment
 	vmCountByNetwork, err := p.VMCountByNetwork(ctx, filters)
 	if err == nil && networkModels != nil {
-		networks := make([]inventory.Network, 0, len(networkModels))
+		networks := make([]inventory.Network, 0, len(vmCountByNetwork))
 		for _, n := range networkModels {
-			vmsCount := 0
+			// Only include networks that have VMs in the filtered set
 			if count, ok := vmCountByNetwork[n.Name]; ok {
-				vmsCount = count
+				networks = append(networks, inventory.Network{
+					Name:     n.Name,
+					Type:     n.Type,
+					Dvswitch: n.Dvswitch,
+					VlanId:   n.VlanId,
+					VmsCount: count,
+				})
 			}
-			networks = append(networks, inventory.Network{
-				Name:     n.Name,
-				Type:     n.Type,
-				Dvswitch: n.Dvswitch,
-				VlanId:   n.VlanId,
-				VmsCount: vmsCount,
-			})
 		}
 		infraData.Networks = networks
 	} else {

--- a/pkg/duckdb_parser/inventory_builder_test.go
+++ b/pkg/duckdb_parser/inventory_builder_test.go
@@ -1399,7 +1399,32 @@ func TestBuildInventory_VMListFilter(t *testing.T) {
 		{"Datacenter": "DC1", "Cluster": "Cluster-B", "# Cores": "16", "# CPU": "2", "Object ID": "host-002", "# Memory": "65536", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-2", "Config status": "green"},
 	}
 
-	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+	// Add vNetwork data to test network filtering
+	// - vm-001 and vm-002 on "VM Network"
+	// - vm-003 on "Storage Network"
+	// - vm-004 on "VM Network"
+	// - vm-005 on "Management Network"
+	vnetwork := []map[string]string{
+		{"VM ID": "vm-001", "Network": "VM Network", "Mac Address": "00:50:56:00:00:01", "Connected": "true", "NIC label": "Network adapter 1", "Adapter": "VMXNET3", "Switch": "vSwitch0", "Starts Connected": "true", "Type": "VirtualVmxnet3", "IPv4 Address": "", "IPv6 Address": "", "Cluster": "Cluster-A"},
+		{"VM ID": "vm-002", "Network": "VM Network", "Mac Address": "00:50:56:00:00:02", "Connected": "true", "NIC label": "Network adapter 1", "Adapter": "VMXNET3", "Switch": "vSwitch0", "Starts Connected": "true", "Type": "VirtualVmxnet3", "IPv4 Address": "", "IPv6 Address": "", "Cluster": "Cluster-A"},
+		{"VM ID": "vm-003", "Network": "Storage Network", "Mac Address": "00:50:56:00:00:03", "Connected": "true", "NIC label": "Network adapter 1", "Adapter": "VMXNET3", "Switch": "vSwitch1", "Starts Connected": "true", "Type": "VirtualVmxnet3", "IPv4 Address": "", "IPv6 Address": "", "Cluster": "Cluster-B"},
+		{"VM ID": "vm-004", "Network": "VM Network", "Mac Address": "00:50:56:00:00:04", "Connected": "true", "NIC label": "Network adapter 1", "Adapter": "VMXNET3", "Switch": "vSwitch0", "Starts Connected": "true", "Type": "VirtualVmxnet3", "IPv4 Address": "", "IPv6 Address": "", "Cluster": "Cluster-B"},
+		{"VM ID": "vm-005", "Network": "Management Network", "Mac Address": "00:50:56:00:00:05", "Connected": "true", "NIC label": "Network adapter 1", "Adapter": "VMXNET3", "Switch": "vSwitch2", "Starts Connected": "true", "Type": "VirtualVmxnet3", "IPv4 Address": "", "IPv6 Address": "", "Cluster": "Cluster-A"},
+	}
+	vnetworkHeaders := []string{"VM ID", "Network", "Mac Address", "NIC label", "Adapter", "Switch", "Connected", "Starts Connected", "Type", "IPv4 Address", "IPv6 Address", "Cluster"}
+
+	// Add dvPort data (network ports) - this is what the Networks() query reads
+	dvport := []map[string]string{
+		{"Port": "VM Network", "VLAN": "100", "Switch": "vSwitch0"},
+		{"Port": "Storage Network", "VLAN": "200", "Switch": "vSwitch1"},
+		{"Port": "Management Network", "VLAN": "300", "Switch": "vSwitch2"},
+	}
+	dvportHeaders := []string{"Port", "VLAN", "Switch"}
+
+	sheets := append(defaultStandardSheets(vms, hosts),
+		NewExcelSheet("vNetwork", vnetworkHeaders, vnetwork),
+		NewExcelSheet("dvPort", dvportHeaders, dvport))
+	tmpFile := createTestExcel(t, sheets...)
 
 	ctx := context.Background()
 	_, err := parser.IngestRvTools(ctx, tmpFile)
@@ -1474,6 +1499,31 @@ func TestBuildInventory_VMListFilter(t *testing.T) {
 	invNone, err := parser.BuildInventory(ctx, nonExistent)
 	require.NoError(t, err)
 	assert.Equal(t, 0, invNone.VCenter.VMs.Total, "Non-existent VMs should result in 0 count")
+
+	// Test 6: Verify networks are filtered - all networks should have VmsCount > 0
+	// This validates the fix for networks with zero VMs being excluded from filtered inventories
+	// Filter is: vm-001, vm-003, vm-005
+	// Expected networks: VM Network (vm-001), Storage Network (vm-003), Management Network (vm-005)
+	assert.Len(t, inv.VCenter.Infra.Networks, 3, "Filtered inventory should have 3 networks")
+
+	networkCounts := make(map[string]int)
+	for _, network := range inv.VCenter.Infra.Networks {
+		networkCounts[network.Name] = network.VmsCount
+		assert.Greater(t, network.VmsCount, 0,
+			"Network %s in filtered inventory should have VmsCount > 0 (no zero-count networks allowed)",
+			network.Name)
+	}
+	assert.Equal(t, 1, networkCounts["VM Network"], "VM Network should have 1 VM (vm-001)")
+	assert.Equal(t, 1, networkCounts["Storage Network"], "Storage Network should have 1 VM (vm-003)")
+	assert.Equal(t, 1, networkCounts["Management Network"], "Management Network should have 1 VM (vm-005)")
+
+	for clusterID, clusterInv := range inv.Clusters {
+		for _, network := range clusterInv.Infra.Networks {
+			assert.Greater(t, network.VmsCount, 0,
+				"Network %s in cluster %s filtered inventory should have VmsCount > 0",
+				network.Name, clusterID)
+		}
+	}
 }
 
 // TestBuildInventory_ClusterFeatures tests that cluster features including DrsEnabled


### PR DESCRIPTION
When BuildInventory is called with a filtered VM list, only include networks that have VMs in the filtered set. Previously all networks were returned with VmsCount set to 0 for unused networks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM filtering to correctly associate networks with filtered VMs. Networks without any VMs in the filtered set are now excluded from results, ensuring more accurate inventory data presentation when filtering by VM list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->