### PR TITLE
ECOPROJECT-4731 | fix: Prevent newline injection in SSH key and name validators

### DIFF
--- a/internal/handlers/validator/custom.go
+++ b/internal/handlers/validator/custom.go
@@ -15,15 +15,16 @@ import (
 )
 
 var (
+	// Use ( [^\r\n]*)? instead of (\s.*)? to prevent newline injection in SSH keys.
 	sshRegex = []*regexp.Regexp{
-		regexp.MustCompile(`^ssh-rsa AAAAB3NzaC1yc2[0-9A-Za-z+/]+[=]{0,3}(\s.*)?$`),
-		regexp.MustCompile(`^ssh-ed25519 AAAAC3NzaC1lZDI1NTE5[0-9A-Za-z+/]+[=]{0,3}(\s.*)?$`),
-		regexp.MustCompile(`^ssh-dss AAAAB3NzaC1kc3[0-9A-Za-z+/]+[=]{0,3}(\s.*)?$`),
-		regexp.MustCompile(`^ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT[0-9A-Za-z+/]+[=]{0,3}(\\s.*)?$`),
+		regexp.MustCompile(`\Assh-rsa AAAAB3NzaC1yc2[0-9A-Za-z+/]+[=]{0,3}( [^\r\n]*)?\z`),
+		regexp.MustCompile(`\Assh-ed25519 AAAAC3NzaC1lZDI1NTE5[0-9A-Za-z+/]+[=]{0,3}( [^\r\n]*)?\z`),
+		regexp.MustCompile(`\Assh-dss AAAAB3NzaC1kc3[0-9A-Za-z+/]+[=]{0,3}( [^\r\n]*)?\z`),
+		regexp.MustCompile(`\Aecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT[0-9A-Za-z+/]+[=]{0,3}( [^\r\n]*)?\z`),
 	}
 
-	nameValidRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,100}$`)
-	labelRegex     = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
+	nameValidRegex = regexp.MustCompile(`\A[a-zA-Z0-9_.-]{1,100}\z`)
+	labelRegex     = regexp.MustCompile(`\A[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?\z`)
 	xlsxMagicBytes = []byte{0x50, 0x4B, 0x03, 0x04}
 )
 

--- a/internal/handlers/validator/validator_test.go
+++ b/internal/handlers/validator/validator_test.go
@@ -71,6 +71,22 @@ func TestSourceCreateFormValidators(t *testing.T) {
 			shouldFail: true,
 		},
 		{
+			name: "validation ko -- name with newline injection (security)",
+			form: v1alpha1.SourceCreate{
+				Name: "validname\n",
+			},
+			message:    "name with trailing newline should be rejected",
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- name with CRLF injection (security)",
+			form: v1alpha1.SourceCreate{
+				Name: "validname\r\n",
+			},
+			message:    "name with CRLF should be rejected",
+			shouldFail: true,
+		},
+		{
 			name: "validation ok -- with rsa sshKey",
 			form: v1alpha1.SourceCreate{
 				Name:         "test",
@@ -101,6 +117,33 @@ func TestSourceCreateFormValidators(t *testing.T) {
 				SshPublicKey: ptr(invalidKey),
 			},
 			message:    "invalid ssh key",
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- ssh key with newline injection (security)",
+			form: v1alpha1.SourceCreate{
+				Name:         "test",
+				SshPublicKey: ptr("ssh-rsa AAAAB3NzaC1yc2AAAA\n"),
+			},
+			message:    "ssh key with trailing newline should be rejected",
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- ssh key with embedded newline injection (security)",
+			form: v1alpha1.SourceCreate{
+				Name:         "test",
+				SshPublicKey: ptr("ssh-rsa AAAAB3NzaC1yc2AAAA comment\npassword_hash: evil"),
+			},
+			message:    "ssh key with embedded newline should be rejected",
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- ssh ed25519 key with newline (security)",
+			form: v1alpha1.SourceCreate{
+				Name:         "test",
+				SshPublicKey: ptr("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILzKjzTWXASL\n"),
+			},
+			message:    "ed25519 key with trailing newline should be rejected",
 			shouldFail: true,
 		},
 		{
@@ -393,6 +436,16 @@ func TestLabelValidator(t *testing.T) {
 		{
 			name:       "invalid only special characters",
 			label:      "---",
+			shouldPass: false,
+		},
+		{
+			name:       "invalid label with newline (security)",
+			label:      "valid\n",
+			shouldPass: false,
+		},
+		{
+			name:       "invalid label with CRLF (security)",
+			label:      "valid\r\n",
 			shouldPass: false,
 		},
 	}


### PR DESCRIPTION
Fix regex anchors to prevent template injection attacks via newline characters in SSH keys, source names, and labels.

  - Replace ^ and $ with \A and \z for strict string boundaries
  - Replace (\s.*)? with ( [^\r\n]*)? in SSH key patterns
  - Prevents attacker from injecting password_hash into ignition template
  - Add security regression tests for all three validators

1. (\s.*)? → ( [^\r\n]*)?
    - Require a space before comment
    - [^\r\n]* = any chars EXCEPT newlines
2. ^...$ → \A...\z
    - More explicit "absolute string boundary" semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for SSH public keys, resource names, and label values to properly reject invalid data and prevent edge case bypass scenarios.

* **Tests**
  * Added comprehensive test cases covering input validation edge cases and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->