### PR TITLE
ECOPROJECT-4704 | fix: make Parser transaction-aware via QueryInterceptor interface

### DIFF
--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kubev2v/migration-planner/pkg/duckdb_parser"
 	"github.com/kubev2v/migration-planner/pkg/inventory/converters"
 	"github.com/kubev2v/migration-planner/pkg/log"
+	pkgstore "github.com/kubev2v/migration-planner/pkg/store"
 )
 
 // RVToolsWorker processes RVTools assessment jobs.
@@ -49,7 +50,8 @@ func (w *RVToolsWorker) createParser() (*duckdb_parser.Parser, *sql.DB, error) {
 		_ = db.Close()
 		return nil, nil, fmt.Errorf("setting duckdb extension directory: %w", err)
 	}
-	parser := duckdb_parser.New(db, w.validator)
+	qi := pkgstore.NewQueryInterceptor(db)
+	parser := duckdb_parser.New(qi, w.validator)
 	if err := parser.Init(); err != nil {
 		_ = db.Close()
 		return nil, nil, fmt.Errorf("initializing duckdb schema: %w", err)

--- a/pkg/duckdb_parser/concern.go
+++ b/pkg/duckdb_parser/concern.go
@@ -2,11 +2,11 @@ package duckdb_parser
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
 	"github.com/kubev2v/migration-planner/pkg/duckdb_parser/models"
+	"github.com/kubev2v/migration-planner/pkg/store"
 )
 
 // ConcernValuesBuilder builds SQL VALUES for bulk inserting concerns.
@@ -48,7 +48,7 @@ func (cb *ConcernValuesBuilder) IsEmpty() bool {
 }
 
 // InsertConcerns executes the bulk insert of concerns into the database.
-func InsertConcerns(ctx context.Context, db *sql.DB, builder *ConcernValuesBuilder) error {
+func InsertConcerns(ctx context.Context, db store.QueryInterceptor, builder *ConcernValuesBuilder) error {
 	valuesStr := builder.Build()
 	if valuesStr == "" {
 		return nil

--- a/pkg/duckdb_parser/ingest.go
+++ b/pkg/duckdb_parser/ingest.go
@@ -56,7 +56,7 @@ func (p *Parser) IngestRvTools(ctx context.Context, excelFile string) (Validatio
 	if err != nil {
 		return ValidationResult{}, fmt.Errorf("building rvtools ingestion query: %w", err)
 	}
-	if err := p.executeStatements(query); err != nil {
+	if err := p.executeStatements(ctx, query); err != nil {
 		return ValidationResult{}, fmt.Errorf("ingesting rvtools data: %w", err)
 	}
 
@@ -64,11 +64,13 @@ func (p *Parser) IngestRvTools(ctx context.Context, excelFile string) (Validatio
 	result := p.ValidateSchema(ctx, "vinfo_raw")
 
 	// Drop vinfo_raw now that validation is complete
-	p.dropVinfoRaw()
+	if err := p.dropVinfoRaw(ctx); err != nil {
+		return result, fmt.Errorf("dropping vinfo_raw: %w", err)
+	}
 
 	// Only run post-ingestion steps if schema is valid (we have VMs to process)
 	if result.IsValid() {
-		if err := p.populateComplexity(); err != nil {
+		if err := p.populateComplexity(ctx); err != nil {
 			return result, fmt.Errorf("populating complexity: %w", err)
 		}
 		if err := p.validateVMs(ctx); err != nil {
@@ -88,7 +90,7 @@ func (p *Parser) IngestSqlite(ctx context.Context, sqliteFile string) (Validatio
 	if err != nil {
 		return ValidationResult{}, fmt.Errorf("building sqlite ingestion query: %w", err)
 	}
-	if err := p.executeStatements(query); err != nil {
+	if err := p.executeStatements(ctx, query); err != nil {
 		return ValidationResult{}, fmt.Errorf("ingesting sqlite data: %w", err)
 	}
 
@@ -97,7 +99,7 @@ func (p *Parser) IngestSqlite(ctx context.Context, sqliteFile string) (Validatio
 
 	// Only run post-ingestion steps if schema is valid (we have VMs to process)
 	if result.IsValid() {
-		if err := p.populateComplexity(); err != nil {
+		if err := p.populateComplexity(ctx); err != nil {
 			return result, fmt.Errorf("populating complexity: %w", err)
 		}
 		if err := p.populateVCluster(ctx); err != nil {
@@ -161,21 +163,22 @@ func (p *Parser) populateVCluster(ctx context.Context) error {
 
 // dropVinfoRaw drops the temporary vinfo_raw table used during RVTools ingestion.
 // This table holds unfiltered data from the Excel file and is only needed for validation.
-func (p *Parser) dropVinfoRaw() {
-	_, _ = p.db.Exec("DROP TABLE IF EXISTS vinfo_raw")
+func (p *Parser) dropVinfoRaw(ctx context.Context) error {
+	_, err := p.db.ExecContext(ctx, "DROP TABLE IF EXISTS vinfo_raw")
+	return err
 }
 
 // executeStatements executes a multi-statement SQL string.
 // Critical statements (INSTALL, LOAD, CREATE TABLE vinfo) must succeed or an error is returned.
 // Non-critical statements (INSERT for optional sheets, ALTER for optional columns) are logged but don't fail.
-func (p *Parser) executeStatements(query string) error {
+func (p *Parser) executeStatements(ctx context.Context, query string) error {
 	stmts := stmtRegex.FindAllString(query, -1)
 	for _, stmt := range stmts {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue
 		}
-		if _, err := p.db.Exec(stmt); err != nil {
+		if _, err := p.db.ExecContext(ctx, stmt); err != nil {
 			if isCriticalStatement(stmt) {
 				return translateXLSXError(err)
 			}
@@ -187,12 +190,12 @@ func (p *Parser) executeStatements(query string) error {
 }
 
 // populateComplexity computes and stores per-VM migration complexity based on OS type and disk size.
-func (p *Parser) populateComplexity() error {
+func (p *Parser) populateComplexity(ctx context.Context) error {
 	query, err := p.builder.PopulateComplexityQuery()
 	if err != nil {
 		return fmt.Errorf("building complexity query: %w", err)
 	}
-	if _, err := p.db.Exec(query); err != nil {
+	if _, err := p.db.ExecContext(ctx, query); err != nil {
 		return fmt.Errorf("executing complexity query: %w", err)
 	}
 	return nil

--- a/pkg/duckdb_parser/parser.go
+++ b/pkg/duckdb_parser/parser.go
@@ -2,10 +2,10 @@ package duckdb_parser
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/kubev2v/migration-planner/pkg/duckdb_parser/models"
+	"github.com/kubev2v/migration-planner/pkg/store"
 )
 
 // Validator interface for OPA validation.
@@ -16,13 +16,13 @@ type Validator interface {
 
 // Parser provides methods for parsing and querying VMware inventory data.
 type Parser struct {
-	db        *sql.DB
+	db        store.QueryInterceptor
 	builder   *QueryBuilder
 	validator Validator
 }
 
 // New creates a new Parser with optional validator.
-func New(db *sql.DB, validator Validator) *Parser {
+func New(db store.QueryInterceptor, validator Validator) *Parser {
 	return &Parser{
 		db:        db,
 		builder:   NewBuilder(),
@@ -43,6 +43,7 @@ func (p *Parser) createSchema() error {
 	if err != nil {
 		return err
 	}
-	_, err = p.db.Exec(q)
+	// Use background context for schema creation (not transactional)
+	_, err = p.db.ExecContext(context.Background(), q)
 	return err
 }

--- a/pkg/store/interceptor.go
+++ b/pkg/store/interceptor.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// QueryInterceptor provides database query methods with transaction awareness.
+// Implementations route queries through an active transaction if present in context.
+//
+// NOTE: The default implementation (queryInterceptor) is DuckDB-specific. It uses:
+// - Mutex serialization in ExecContext to satisfy DuckDB's single-connection constraint
+// - FORCE CHECKPOINT after non-transactional writes to flush DuckDB's WAL to the main file
+//
+// If supporting other databases, a separate implementation would be needed without
+// these DuckDB-specific behaviors.
+type QueryInterceptor interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+type queryInterceptor struct {
+	db     *sql.DB
+	logger *zap.SugaredLogger
+	mu     sync.Mutex
+}
+
+func NewQueryInterceptor(db *sql.DB) QueryInterceptor {
+	return &queryInterceptor{
+		db:     db,
+		logger: zap.S().Named("store"),
+	}
+}
+
+func (q *queryInterceptor) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	q.logger.Debugw("query_row", "query", query, "args", args)
+
+	tx, ok := q.txFromContext(ctx)
+	if ok {
+		return tx.QueryRowContext(ctx, query, args...)
+	}
+
+	return q.db.QueryRowContext(ctx, query, args...)
+}
+
+func (q *queryInterceptor) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	q.logger.Debugw("query", "query", query, "args", args)
+
+	tx, ok := q.txFromContext(ctx)
+	if ok {
+		return tx.QueryContext(ctx, query, args...)
+	}
+
+	return q.db.QueryContext(ctx, query, args...)
+}
+
+func (q *queryInterceptor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	// Serialize all exec calls to satisfy DuckDB's single-connection constraint.
+	// DuckDB only allows one write operation at a time on a single connection.
+	// Without this mutex, concurrent ExecContext calls would fail with "database is locked" errors.
+	// This represents a concurrency bottleneck but is required for DuckDB correctness.
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.logger.Debugw("exec", "query", query, "args", args)
+
+	tx, ok := q.txFromContext(ctx)
+	if ok {
+		return tx.ExecContext(ctx, query, args...)
+	}
+
+	result, err := q.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return result, err
+	}
+
+	// Issue a DuckDB-specific FORCE CHECKPOINT to flush the write-ahead log (WAL) to the main database file.
+	// This ensures durability for non-transactional writes by persisting changes immediately.
+	// FORCE CHECKPOINT is DuckDB-specific SQL and would fail on other databases.
+	// We only checkpoint on the non-transaction path; transactions handle their own durability on commit.
+	if _, cpErr := q.db.ExecContext(ctx, "FORCE CHECKPOINT"); cpErr != nil {
+		q.logger.Warnw("checkpoint failed", "error", cpErr)
+	}
+	return result, nil
+}
+
+func (q *queryInterceptor) txFromContext(ctx context.Context) (*sql.Tx, bool) {
+	tx, ok := ctx.Value(txKey).(*sql.Tx)
+	return tx, ok
+}

--- a/pkg/store/interceptor_test.go
+++ b/pkg/store/interceptor_test.go
@@ -1,0 +1,196 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/marcboeker/go-duckdb/v2"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+	})
+	return db
+}
+
+func TestQueryInterceptor_DirectDBAccess(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+
+	ctx := context.Background()
+
+	if _, err := qi.ExecContext(ctx, "CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	if _, err := qi.ExecContext(ctx, "INSERT INTO test VALUES (1, 'foo')"); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	row := qi.QueryRowContext(ctx, "SELECT name FROM test WHERE id = ?", 1)
+	var name string
+	if err := row.Scan(&name); err != nil {
+		t.Fatalf("failed to query row: %v", err)
+	}
+
+	if name != "foo" {
+		t.Errorf("expected 'foo', got '%s'", name)
+	}
+}
+
+func TestQueryInterceptor_TransactionRouting(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+	transactor := NewTransactor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		if _, err := qi.ExecContext(txCtx, "INSERT INTO test VALUES (1, 'inside_tx')"); err != nil {
+			return err
+		}
+
+		row := qi.QueryRowContext(txCtx, "SELECT name FROM test WHERE id = ?", 1)
+		var name string
+		if err := row.Scan(&name); err != nil {
+			return err
+		}
+
+		if name != "inside_tx" {
+			t.Errorf("expected 'inside_tx', got '%s'", name)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("transaction failed: %v", err)
+	}
+
+	row := qi.QueryRowContext(context.Background(), "SELECT name FROM test WHERE id = ?", 1)
+	var name string
+	if err := row.Scan(&name); err != nil {
+		t.Fatalf("failed to query after commit: %v", err)
+	}
+
+	if name != "inside_tx" {
+		t.Errorf("expected committed value 'inside_tx', got '%s'", name)
+	}
+}
+
+func TestQueryInterceptor_TransactionRollback(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+	transactor := NewTransactor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	expectedErr := sql.ErrNoRows
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		if _, err := qi.ExecContext(txCtx, "INSERT INTO test VALUES (1, 'should_rollback')"); err != nil {
+			return err
+		}
+		return expectedErr
+	})
+
+	if err != expectedErr {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+
+	row := qi.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM test")
+	var count int
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+
+	if count != 0 {
+		t.Errorf("expected 0 rows after rollback, got %d", count)
+	}
+}
+
+func TestQueryInterceptor_DirectExecSucceeds(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	if _, err := qi.ExecContext(context.Background(), "INSERT INTO test VALUES (1)"); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+}
+
+func TestQueryInterceptor_TransactionExecSucceeds(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+	transactor := NewTransactor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		_, err := qi.ExecContext(txCtx, "INSERT INTO test VALUES (1)")
+		return err
+	})
+
+	if err != nil {
+		t.Fatalf("transaction failed: %v", err)
+	}
+}
+
+func TestQueryInterceptor_SerializedExec(t *testing.T) {
+	db := setupTestDB(t)
+	qi := NewQueryInterceptor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	done := make(chan bool, 2)
+
+	go func() {
+		for i := range 10 {
+			if _, err := qi.ExecContext(context.Background(), "INSERT INTO test VALUES (?)", i); err != nil {
+				t.Errorf("failed to insert: %v", err)
+			}
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := range 10 {
+			if _, err := qi.ExecContext(context.Background(), "INSERT INTO test VALUES (?)", i+10); err != nil {
+				t.Errorf("failed to insert: %v", err)
+			}
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+
+	row := qi.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM test")
+	var count int
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+
+	if count != 20 {
+		t.Errorf("expected 20 rows, got %d", count)
+	}
+}

--- a/pkg/store/transactor.go
+++ b/pkg/store/transactor.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// txKey is a private key for storing transactions in context.
+// Uses unexported type to prevent collisions with other packages.
+type contextKey int
+
+const txKey contextKey = 0
+
+// Transactor provides transaction management.
+type Transactor interface {
+	WithTx(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+type dbTransactor struct {
+	db *sql.DB
+}
+
+func NewTransactor(db *sql.DB) Transactor {
+	return &dbTransactor{db: db}
+}
+
+func (t *dbTransactor) WithTx(ctx context.Context, fn func(ctx context.Context) error) (err error) {
+	if ctx.Value(txKey) != nil {
+		return errors.New("nested transactions not supported")
+	}
+
+	tx, err := t.db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+
+	var committed bool
+	defer func() {
+		if p := recover(); p != nil {
+			// On panic, attempt rollback (unless we already committed)
+			if !committed {
+				if rbErr := tx.Rollback(); rbErr != nil {
+					err = errors.Join(errors.New("panic during transaction"), rbErr)
+				} else {
+					err = errors.New("panic during transaction")
+				}
+			}
+			panic(p)
+		} else if err != nil && !committed {
+			// On error return from fn, rollback (unless we already committed).
+			// Skip rollback if commit was attempted to avoid confusing error messages
+			// like "primary key violation" + "sql: transaction has already been committed or rolled back".
+			if rbErr := tx.Rollback(); rbErr != nil {
+				err = errors.Join(err, rbErr)
+			}
+		}
+	}()
+
+	txContext := context.WithValue(ctx, txKey, tx)
+
+	if err = fn(txContext); err != nil {
+		return err
+	}
+
+	committed = true
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/store/transactor_test.go
+++ b/pkg/store/transactor_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "github.com/marcboeker/go-duckdb/v2"
+)
+
+func TestTransactor_BasicCommit(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		tx := txCtx.Value(txKey).(*sql.Tx)
+		_, err := tx.Exec("INSERT INTO test VALUES (1, 'committed')")
+		return err
+	})
+
+	if err != nil {
+		t.Fatalf("transaction failed: %v", err)
+	}
+
+	var name string
+	if err := db.QueryRow("SELECT name FROM test WHERE id = 1").Scan(&name); err != nil {
+		t.Fatalf("failed to query after commit: %v", err)
+	}
+
+	if name != "committed" {
+		t.Errorf("expected 'committed', got '%s'", name)
+	}
+}
+
+func TestTransactor_Rollback(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	expectedErr := errors.New("intentional error")
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		tx := txCtx.Value(txKey).(*sql.Tx)
+		if _, err := tx.Exec("INSERT INTO test VALUES (1, 'should_rollback')"); err != nil {
+			return err
+		}
+		return expectedErr
+	})
+
+	if err != expectedErr {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM test").Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+
+	if count != 0 {
+		t.Errorf("expected 0 rows after rollback, got %d", count)
+	}
+}
+
+func TestTransactor_NestedTransactionBlocked(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	err := transactor.WithTx(context.Background(), func(outerCtx context.Context) error {
+		return transactor.WithTx(outerCtx, func(innerCtx context.Context) error {
+			return nil
+		})
+	})
+
+	if err == nil || err.Error() != "nested transactions not supported" {
+		t.Errorf("expected 'nested transactions not supported' error, got %v", err)
+	}
+}
+
+func TestTransactor_PanicRollback(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic to propagate")
+		}
+	}()
+
+	_ = transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		tx := txCtx.Value(txKey).(*sql.Tx)
+		if _, err := tx.Exec("INSERT INTO test VALUES (1, 'panic')"); err != nil {
+			return err
+		}
+		panic("intentional panic")
+	})
+}
+
+func TestTransactor_PanicRollbackVerifyNoData(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER, name VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+
+		_ = transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+			tx := txCtx.Value(txKey).(*sql.Tx)
+			if _, err := tx.Exec("INSERT INTO test VALUES (1, 'panic')"); err != nil {
+				return err
+			}
+			panic("intentional panic")
+		})
+	}()
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM test").Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+
+	if count != 0 {
+		t.Errorf("expected 0 rows after panic rollback, got %d", count)
+	}
+}
+
+func TestTransactor_CommitError(t *testing.T) {
+	db := setupTestDB(t)
+	transactor := NewTransactor(db)
+
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	if _, err := db.Exec("INSERT INTO test VALUES (1)"); err != nil {
+		t.Fatalf("failed to insert initial row: %v", err)
+	}
+
+	err := transactor.WithTx(context.Background(), func(txCtx context.Context) error {
+		tx := txCtx.Value(txKey).(*sql.Tx)
+		_, err := tx.Exec("INSERT INTO test VALUES (1)")
+		return err
+	})
+
+	if err == nil {
+		t.Error("expected commit error due to constraint violation")
+	}
+}


### PR DESCRIPTION
- Add pkg/store with shared QueryInterceptor and Transactor
- Change Parser to accept QueryInterceptor instead of *sql.DB
- Update all Parser methods to use ExecContext with context
- Enables atomic group operations in assisted-migration-agent

This allows Parser.BuildInventory() to participate in transactions without deadlocking on DuckDB's single-connection constraint.

Key Pattern: The interceptor checks context for an active transaction (stored via private key). If present, queries route through the transaction; otherwise they execute directly on the database. This enables transparent transaction support without modifying existing query code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made DB execution context-aware across ingestion, added transaction management, serialized writes with checkpointing, and stricter error handling (schema/drop failures now treated as fatal) to improve reliability and stability.
* **Tests**
  * Added comprehensive tests covering transactional commit/rollback, nested-transaction blocking, panic handling, and concurrent execution to harden correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->