### PR TITLE
NO-JIRA | fix: Clean up keys table in GetSourceDownloadURL test teardown

### DIFF
--- a/internal/handlers/v1alpha1/source_test.go
+++ b/internal/handlers/v1alpha1/source_test.go
@@ -1208,6 +1208,7 @@ var _ = Describe("source handler", Ordered, func() {
 		})
 
 		AfterEach(func() {
+			gormdb.Exec("DELETE FROM keys;")
 			gormdb.Exec("DELETE FROM image_infras;")
 			gormdb.Exec("DELETE FROM sources;")
 		})


### PR DESCRIPTION
    The GetSourceDownloadURL tests trigger ensureAgentToken which inserts
    into the keys table, but AfterEach only cleaned image_infras and
    sources. The leftover key row caused the key_store successfully

Signed-off-by: Aviel Segev <asegev@redhat.com>
