### PR TITLE
ECO-4545 | fix: return descriptive error when member already exists

### DIFF
--- a/internal/handlers/v1alpha1/accounts.go
+++ b/internal/handlers/v1alpha1/accounts.go
@@ -346,7 +346,7 @@ func (h *ServiceHandler) CreateGroupMember(ctx context.Context, request server.C
 		case *service.ErrResourceNotFound:
 			return server.CreateGroupMember404JSONResponse{Message: "group not found"}, nil
 		case *service.ErrDuplicateKey:
-			return server.CreateGroupMember409JSONResponse{Message: "member already exists"}, nil
+			return server.CreateGroupMember409JSONResponse{Message: err.Error()}, nil
 		default:
 			logger.Error(err).Log()
 			return server.CreateGroupMember500JSONResponse{Message: fmt.Sprintf("failed to create member: %v", err)}, nil

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -274,6 +274,17 @@ func (s *AccountsService) CreateMember(ctx context.Context, member model.Member)
 		return model.Member{}, err
 	}
 
+	existing, lookupErr := s.store.Accounts().GetMember(ctx, member.Username)
+	if lookupErr == nil {
+		if existing.GroupID != member.GroupID {
+			return model.Member{}, NewErrMemberExistsInAnotherGroup(member.Username)
+		}
+		return model.Member{}, NewErrDuplicateKey("member", member.Username)
+	}
+	if !errors.Is(lookupErr, store.ErrRecordNotFound) {
+		return model.Member{}, fmt.Errorf("failed to check existing member: %w", lookupErr)
+	}
+
 	ctx, err := s.store.NewTransactionContext(ctx)
 	if err != nil {
 		return model.Member{}, err

--- a/internal/service/accounts_test.go
+++ b/internal/service/accounts_test.go
@@ -308,6 +308,29 @@ var _ = Describe("accounts service", Ordered, func() {
 				Expect(err).To(BeAssignableToTypeOf(dupKey))
 			})
 
+			It("returns descriptive error when member already belongs to another group", func() {
+				groupA := uuid.New()
+				groupB := uuid.New()
+
+				tx := gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, groupA, "Group A", "desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(fmt.Sprintf(insertAccountsGroupStm, groupB, "Group B", "desc", "partner", "icon", "Acme", "NULL"))
+				Expect(tx.Error).To(BeNil())
+				tx = gormdb.Exec(fmt.Sprintf(insertAccountsMemberStm, uuid.New(), "shareduser", "shared@acme.com", groupA))
+				Expect(tx.Error).To(BeNil())
+
+				member := model.Member{
+					Username: "shareduser",
+					Email:    "shared@acme.com",
+					GroupID:  groupB,
+				}
+				_, err := svc.CreateMember(context.TODO(), member)
+				Expect(err).ToNot(BeNil())
+				var dupKey *service.ErrDuplicateKey
+				Expect(err).To(BeAssignableToTypeOf(dupKey))
+				Expect(err.Error()).To(ContainSubstring("already belongs to another group"))
+			})
+
 			AfterEach(func() {
 				gormdb.Exec("DELETE FROM members;")
 				gormdb.Exec("DELETE FROM groups;")

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -119,6 +119,10 @@ func NewErrDuplicateKey(resourceType, name string) *ErrDuplicateKey {
 	return &ErrDuplicateKey{fmt.Errorf("%s with name %q already exists", resourceType, name)}
 }
 
+func NewErrMemberExistsInAnotherGroup(username string) *ErrDuplicateKey {
+	return &ErrDuplicateKey{fmt.Errorf("member %q already belongs to another group", username)}
+}
+
 func NewErrAssessmentDuplicateName(name string) *ErrDuplicateKey {
 	return NewErrDuplicateKey("assessment", name)
 }


### PR DESCRIPTION
When adding a partner to a group, if they already belong to a different group, the API now returns "member already belongs to another group" instead of the misleading "member already exists".

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced member management error reporting. When attempting to add a member to a group, the system now provides more specific error messages that distinguish whether the member already belongs to the current group or to another group, helping you better understand why the operation failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->