### PR TITLE
ECOPROJECT-4729 | fix:  credentialUrl validator accepts javascript URL

### DIFF
--- a/internal/handlers/v1alpha1/agent.go
+++ b/internal/handlers/v1alpha1/agent.go
@@ -78,6 +78,7 @@ func (h *AgentHandler) UpdateAgentStatus(ctx context.Context, request agentServe
 
 	v := validator.NewValidator()
 	v.Register(validator.NewAgentValidationRules()...)
+	v.RegisterStructValidation(validator.AgentStatusUpdateValidator(), v1alpha1.AgentStatusUpdate{})
 	if err := v.Struct(form); err != nil {
 		return agentServer.UpdateAgentStatus400JSONResponse{Message: err.Error()}, nil
 	}

--- a/internal/handlers/validator/custom.go
+++ b/internal/handlers/validator/custom.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	agentV1alpha1 "github.com/kubev2v/migration-planner/api/v1alpha1/agent"
 )
 
 var (
@@ -231,6 +233,16 @@ func AssessmentFormValidator() validator.StructLevelFunc {
 		// If sourceType is "agent", validate that sourceId is provided
 		if val.SourceType == "agent" && val.SourceId == nil {
 			sl.ReportError("SourceType", "SourceType", "sourceType", "agent", "")
+		}
+	}
+}
+
+func AgentStatusUpdateValidator() validator.StructLevelFunc {
+	return func(sl validator.StructLevel) {
+		val, _ := sl.Current().Interface().(agentV1alpha1.AgentStatusUpdate)
+		u, err := url.Parse(val.CredentialUrl)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			sl.ReportError(val.CredentialUrl, "credentialUrl", "CredentialUrl", "credential_url", "")
 		}
 	}
 }

--- a/internal/handlers/validator/validator_test.go
+++ b/internal/handlers/validator/validator_test.go
@@ -282,6 +282,50 @@ func TestAgentUpdateFormValidators(t *testing.T) {
 			shouldFail: true,
 		},
 		{
+			name: "validation ko -- javascript: URL is an XSS vector",
+			form: agentApi.AgentStatusUpdate{
+				SourceId:      uuid.New(),
+				Status:        "waiting-for-credentials",
+				StatusInfo:    "someinfo",
+				CredentialUrl: "javascript:alert(document.cookie)",
+				Version:       "someversion",
+			},
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- data: URL is an XSS vector",
+			form: agentApi.AgentStatusUpdate{
+				SourceId:      uuid.New(),
+				Status:        "waiting-for-credentials",
+				StatusInfo:    "someinfo",
+				CredentialUrl: "data:text/html,<script>alert(1)</script>",
+				Version:       "someversion",
+			},
+			shouldFail: true,
+		},
+		{
+			name: "validation ko -- ftp: URL is not an allowed scheme",
+			form: agentApi.AgentStatusUpdate{
+				SourceId:      uuid.New(),
+				Status:        "waiting-for-credentials",
+				StatusInfo:    "someinfo",
+				CredentialUrl: "ftp://agent.com/credentials",
+				Version:       "someversion",
+			},
+			shouldFail: true,
+		},
+		{
+			name: "validation ok -- https URL passes",
+			form: agentApi.AgentStatusUpdate{
+				SourceId:      uuid.New(),
+				Status:        "waiting-for-credentials",
+				StatusInfo:    "someinfo",
+				CredentialUrl: "https://agent.com",
+				Version:       "someversion",
+			},
+			shouldFail: false,
+		},
+		{
 			name: "validation ko -- version has more than 20 characters",
 			form: agentApi.AgentStatusUpdate{
 				SourceId:      uuid.New(),
@@ -357,6 +401,7 @@ func TestAgentUpdateFormValidators(t *testing.T) {
 
 	v := NewValidator()
 	v.Register(NewAgentValidationRules()...)
+	v.RegisterStructValidation(AgentStatusUpdateValidator(), agentApi.AgentStatusUpdate{})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds a struct level validator for creds update on the agent handler. The validator rejects urls with any protocol different from http[s]

CVE-ID: CVE-2026-53472 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved agent credential URL validation to enforce secure HTTP/HTTPS schemes only, preventing potentially unsafe URL types.

* **Tests**
  * Added comprehensive test coverage for credential URL validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->