### PR TITLE
NO-JIRA | fix: increase Kafka producer max batch size to 10 MiB

### DIFF
--- a/pkg/events/kafka_producer.go
+++ b/pkg/events/kafka_producer.go
@@ -15,6 +15,8 @@ type Writer interface {
 	Write(ctx context.Context, topic string, data []byte) error
 }
 
+const maxProducerBatchBytes = 10 * 1024 * 1024 // 10 MiB
+
 type KafkaProducer struct {
 	cl *kgo.Client
 }
@@ -29,6 +31,7 @@ func NewKafkaProducer(brokers []string, opts ...kgo.Opt) (*KafkaProducer, error)
 		kgo.SeedBrokers(brokers...),
 		kgo.ClientID(clientID),
 		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.ProducerBatchMaxBytes(maxProducerBatchBytes),
 		kgo.WithHooks(kprom.NewMetrics("kafka_producer")),
 	}
 


### PR DESCRIPTION
The default franz-go ProducerBatchMaxBytes of 1 MiB is too small for
assessment events that include full inventory payloads.

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Kafka producer batch configuration by increasing the maximum batch size limit to 10 MiB, enhancing message batching efficiency for improved data transmission performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->