### PR TITLE
ECOPROJECT-4784 | fix: improve validation error messages for standalone cluster sizing

### DIFF
--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -65,7 +65,46 @@ func New(
 
 const oldSchemaErrorMessage = "The uploaded file is using an old schema version and cannot be parsed. Generate a new OVA file, import to your vSphere environment and then try to upload it again."
 
+var standaloneFieldNames = map[string]string{
+	"totalVMs":                "Total VMs",
+	"totalCPU":                "Total CPU cores",
+	"totalMemory":             "Total memory (GB)",
+	"workerNodeCPU":           "Worker node CPU (cores)",
+	"workerNodeMemory":        "Worker node memory (GB)",
+	"workerNodeThreads":       "Worker node threads",
+	"controlPlaneCPU":         "Control plane CPU (cores)",
+	"controlPlaneMemory":      "Control plane memory (GB)",
+	"controlPlaneNodeCount":   "Control plane node count",
+	"controlPlaneSchedulable": "Control plane schedulable",
+	"hostedControlPlane":      "Hosted control plane",
+	"cpuOverCommitRatio":      "CPU over-commit ratio",
+	"memoryOverCommitRatio":   "Memory over-commit ratio",
+}
+
+func parseStandaloneValidationError(message string) (string, bool) {
+	for fieldName, friendlyName := range standaloneFieldNames {
+		fieldPattern := fmt.Sprintf(`Error at "/%s":`, fieldName)
+		idx := strings.Index(message, fieldPattern)
+		if idx == -1 {
+			continue
+		}
+
+		constraint := strings.TrimSpace(message[idx+len(fieldPattern):])
+		constraint = strings.TrimPrefix(constraint, "number ")
+		constraint = strings.TrimPrefix(constraint, "value ")
+
+		return fmt.Sprintf("%s %s", friendlyName, constraint), true
+	}
+
+	return "", false
+}
+
 func oapiErrorHandler(w http.ResponseWriter, message string, statusCode int) {
+	if friendlyMsg, ok := parseStandaloneValidationError(message); ok {
+		http.Error(w, friendlyMsg, statusCode)
+		return
+	}
+
 	http.Error(w, fmt.Sprintf("API Error: %s", message), statusCode)
 }
 

--- a/internal/api_server/server_test.go
+++ b/internal/api_server/server_test.go
@@ -1,0 +1,118 @@
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseStandaloneValidationError(t *testing.T) {
+	tests := []struct {
+		name           string
+		errorMessage   string
+		expectedOutput string
+		expectedOK     bool
+	}{
+		{
+			name:           "number prefix with long schema path",
+			errorMessage:   `request body has an error: doesn't match schema #/components/schemas/StandaloneClusterRequirementsRequest: Error at "/totalVMs": number must be at most 10000`,
+			expectedOutput: "Total VMs must be at most 10000",
+			expectedOK:     true,
+		},
+		{
+			name:           "value prefix for enum constraint",
+			errorMessage:   `Error at "/cpuOverCommitRatio": value is not one of the allowed values`,
+			expectedOutput: "CPU over-commit ratio is not one of the allowed values",
+			expectedOK:     true,
+		},
+		{
+			name:           "control plane enum validation",
+			errorMessage:   `Error at "/controlPlaneNodeCount": value must be one of: 1, 3`,
+			expectedOutput: "Control plane node count must be one of: 1, 3",
+			expectedOK:     true,
+		},
+		{
+			name:           "non-standalone field",
+			errorMessage:   `Error at "/name": string does not match pattern`,
+			expectedOutput: "",
+			expectedOK:     false,
+		},
+		{
+			name:           "generic API error",
+			errorMessage:   "Internal server error",
+			expectedOutput: "",
+			expectedOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, ok := parseStandaloneValidationError(tt.errorMessage)
+
+			if ok != tt.expectedOK {
+				t.Errorf("parseStandaloneValidationError() ok = %v, want %v", ok, tt.expectedOK)
+			}
+
+			if output != tt.expectedOutput {
+				t.Errorf("parseStandaloneValidationError() output = %q, want %q", output, tt.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestOapiErrorHandler(t *testing.T) {
+	tests := []struct {
+		name               string
+		errorMessage       string
+		statusCode         int
+		expectedBody       string
+		expectedStatusCode int
+	}{
+		{
+			name:               "recognized standalone validation error",
+			errorMessage:       `Error at "/totalVMs": number must be at most 10000`,
+			statusCode:         http.StatusBadRequest,
+			expectedBody:       "Total VMs must be at most 10000\n",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "unrecognized error falls back to API Error prefix",
+			errorMessage:       "Internal server error",
+			statusCode:         http.StatusInternalServerError,
+			expectedBody:       "API Error: Internal server error\n",
+			expectedStatusCode: http.StatusInternalServerError,
+		},
+		{
+			name:               "non-standalone field error falls back",
+			errorMessage:       `Error at "/name": string does not match pattern`,
+			statusCode:         http.StatusBadRequest,
+			expectedBody:       "API Error: Error at \"/name\": string does not match pattern\n",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:               "recognized enum constraint error",
+			errorMessage:       `Error at "/cpuOverCommitRatio": value is not one of the allowed values`,
+			statusCode:         http.StatusBadRequest,
+			expectedBody:       "CPU over-commit ratio is not one of the allowed values\n",
+			expectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			oapiErrorHandler(w, tt.errorMessage, tt.statusCode)
+
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("oapiErrorHandler() status = %v, want %v", w.Code, tt.expectedStatusCode)
+			}
+
+			body := w.Body.String()
+			if !strings.Contains(body, strings.TrimSpace(tt.expectedBody)) {
+				t.Errorf("oapiErrorHandler() body = %q, want to contain %q", body, tt.expectedBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Transform technical OpenAPI validation errors into user-friendly messages for the standalone cluster sizing endpoint. Field names are now displayed with clear labels (e.g., "Total VMs" instead of "/totalVMs") and technical prefixes are removed from constraint messages.

Before: "API Error: request body has an error: doesn't match schema #/components/schemas/StandaloneClusterRequirementsRequest: Error at  "/totalVMs": number must be at most 10000"

After: "Total VMs must be at most 10000"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation error messages with user-friendly field labels for improved clarity and better error reporting experience.

* **Tests**
  * Added unit tests for validation error message parsing across multiple error formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->