### PR TITLE
NO-JIRA | refactor: use typed per-action data in user action Kafka ev…

### DIFF
--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -192,7 +192,7 @@ func (s *Server) Run(ctx context.Context) error {
 		accountsSvc   service.AccountsServicer
 	)
 	partnerSvc = eventwrap.NewEventPartnerService(service.NewPartnerService(s.store, innerAccountsSvc), s.store)
-	assessmentSvc = eventwrap.NewEventAssessmentService(service.NewAssessmentService(s.store, s.opaValidator, innerAccountsSvc), s.store)
+	assessmentSvc = eventwrap.NewEventAssessmentService(service.NewAssessmentService(s.store, s.opaValidator, innerAccountsSvc), s.store, innerAccountsSvc)
 	accountsSvc = innerAccountsSvc
 
 	if s.cfg.Service.Auth.AuthenticationType != "none" {

--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -121,12 +121,7 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 
 	metrics.IncreaseOvaDownloadsTotalMetric("successful")
 
-	sourceIDStr := source.ID.String()
-	payload := events.NewUserActionPayload(events.UserActionData{
-		Username:  source.Username,
-		SourceID:  &sourceIDStr,
-		Timestamp: time.Now().UTC(),
-	})
+	payload := events.NewOVADownloadPayload(source.Username, source.ID.String())
 	ceBytes, err := events.BuildCloudEvent(events.DownloadOVAEventType, payload)
 	if err != nil {
 		zap.S().Warnw("failed to build download event", "source_id", source.ID, "error", err)

--- a/internal/service/assessment_test.go
+++ b/internal/service/assessment_test.go
@@ -43,8 +43,9 @@ var _ = Describe("assessment service", Ordered, func() {
 
 		s = store.NewStore(db)
 		gormdb = db
-		inner := service.NewAssessmentService(s, nil, service.NewAccountsService(s))
-		svc = eventwrap.NewEventAssessmentService(inner, s)
+		accountsSvc := service.NewAccountsService(s)
+		inner := service.NewAssessmentService(s, nil, accountsSvc)
+		svc = eventwrap.NewEventAssessmentService(inner, s, accountsSvc)
 	})
 
 	AfterAll(func() {

--- a/internal/service/eventwrap/event_assessment.go
+++ b/internal/service/eventwrap/event_assessment.go
@@ -2,7 +2,6 @@ package eventwrap
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/internal/auth"
@@ -14,13 +13,14 @@ import (
 )
 
 type EventAssessmentService struct {
-	inner  service.AssessmentServicer
-	store  store.Store
-	outbox *OutboxService
+	inner       service.AssessmentServicer
+	store       store.Store
+	outbox      *OutboxService
+	accountsSvc service.AccountsServicer
 }
 
-func NewEventAssessmentService(inner service.AssessmentServicer, s store.Store) service.AssessmentServicer {
-	return &EventAssessmentService{inner: inner, store: s, outbox: NewOutboxService(s)}
+func NewEventAssessmentService(inner service.AssessmentServicer, s store.Store, accountsSvc service.AccountsServicer) service.AssessmentServicer {
+	return &EventAssessmentService{inner: inner, store: s, outbox: NewOutboxService(s), accountsSvc: accountsSvc}
 }
 
 func (e *EventAssessmentService) ListAssessments(ctx context.Context, filter *service.AssessmentFilter) ([]model.Assessment, error) {
@@ -133,21 +133,16 @@ func (e *EventAssessmentService) ShareAssessment(ctx context.Context, id uuid.UU
 		_, _ = store.Rollback(ctx)
 	}()
 
-	assessment, err := e.inner.GetAssessment(ctx, id)
-	if err != nil {
-		return err
-	}
-
 	if err := e.inner.ShareAssessment(ctx, id); err != nil {
 		return err
 	}
 
-	assessmentID := assessment.ID.String()
-	payload := events.NewUserActionPayload(events.UserActionData{
-		Username:     user.Username,
-		AssessmentID: &assessmentID,
-		Timestamp:    time.Now().UTC(),
-	})
+	identity, err := e.accountsSvc.GetIdentity(ctx, user)
+	if err != nil {
+		return err
+	}
+
+	payload := events.NewShareAssessmentPayload(user.Username, id.String(), *identity.PartnerID)
 	ceBytes, err := events.BuildCloudEvent(events.ShareAssessmentEventType, payload)
 	if err != nil {
 		return err
@@ -174,21 +169,11 @@ func (e *EventAssessmentService) UnshareAssessment(ctx context.Context, id uuid.
 		_, _ = store.Rollback(ctx)
 	}()
 
-	assessment, err := e.inner.GetAssessment(ctx, id)
-	if err != nil {
-		return err
-	}
-
 	if err := e.inner.UnshareAssessment(ctx, id); err != nil {
 		return err
 	}
 
-	assessmentIDStr := assessment.ID.String()
-	payload := events.NewUserActionPayload(events.UserActionData{
-		Username:     user.Username,
-		AssessmentID: &assessmentIDStr,
-		Timestamp:    time.Now().UTC(),
-	})
+	payload := events.NewUnshareAssessmentPayload(user.Username, id.String())
 	ceBytes, err := events.BuildCloudEvent(events.UnshareAssessmentEventType, payload)
 	if err != nil {
 		return err

--- a/internal/service/eventwrap/event_estimation.go
+++ b/internal/service/eventwrap/event_estimation.go
@@ -2,7 +2,6 @@ package eventwrap
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/internal/service"
@@ -81,12 +80,7 @@ func (e *EventEstimationService) publishUserAction(ctx context.Context, assessme
 	if err != nil {
 		return err
 	}
-	assessmentIDStr := assessmentID.String()
-	payload := events.NewUserActionPayload(events.UserActionData{
-		Username:     assessment.Username,
-		AssessmentID: &assessmentIDStr,
-		Timestamp:    time.Now().UTC(),
-	})
+	payload := events.NewComplexityPayload(assessment.Username, assessmentID.String())
 	ceBytes, err := events.BuildCloudEvent(eventType, payload)
 	if err != nil {
 		return err

--- a/internal/service/eventwrap/event_sizer.go
+++ b/internal/service/eventwrap/event_sizer.go
@@ -2,7 +2,6 @@ package eventwrap
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	api "github.com/kubev2v/migration-planner/api/v1alpha1"
@@ -37,12 +36,7 @@ func (e *EventSizerService) CalculateClusterRequirements(
 		return nil, err
 	}
 
-	assessmentIDStr := assessmentID.String()
-	payload := events.NewUserActionPayload(events.UserActionData{
-		Username:     assessment.Username,
-		AssessmentID: &assessmentIDStr,
-		Timestamp:    time.Now().UTC(),
-	})
+	payload := events.NewSizingPayload(assessment.Username, assessmentID.String())
 	ceBytes, err := events.BuildCloudEvent(events.SizingEventType, payload)
 	if err != nil {
 		return nil, err

--- a/pkg/events/user_action.go
+++ b/pkg/events/user_action.go
@@ -7,13 +7,89 @@ type UserActionEventPayload struct {
 }
 
 type UserActionData struct {
-	Username     string    `json:"username"`
-	AssessmentID *string   `json:"assessment_id,omitempty"`
-	SourceID     *string   `json:"source_id,omitempty"`
-	PartnerID    *string   `json:"partner_id,omitempty"`
-	Timestamp    time.Time `json:"timestamp"`
+	Username  string    `json:"username"`
+	Timestamp time.Time `json:"timestamp"`
+	Data      any       `json:"data"`
 }
 
-func NewUserActionPayload(data UserActionData) UserActionEventPayload {
-	return UserActionEventPayload{UserAction: data}
+type ShareAssessmentActionData struct {
+	AssessmentID string `json:"assessment_id"`
+	PartnerID    string `json:"partner_id"`
+}
+
+type UnshareAssessmentActionData struct {
+	AssessmentID string `json:"assessment_id"`
+}
+
+type SizingActionData struct {
+	AssessmentID string `json:"assessment_id"`
+}
+
+type ComplexityActionData struct {
+	AssessmentID string `json:"assessment_id"`
+}
+
+type OVADownloadActionData struct {
+	SourceID string `json:"source_id"`
+}
+
+func NewShareAssessmentPayload(username, assessmentID, partnerID string) UserActionEventPayload {
+	return UserActionEventPayload{
+		UserAction: UserActionData{
+			Username:  username,
+			Timestamp: time.Now().UTC(),
+			Data: ShareAssessmentActionData{
+				AssessmentID: assessmentID,
+				PartnerID:    partnerID,
+			},
+		},
+	}
+}
+
+func NewUnshareAssessmentPayload(username, assessmentID string) UserActionEventPayload {
+	return UserActionEventPayload{
+		UserAction: UserActionData{
+			Username:  username,
+			Timestamp: time.Now().UTC(),
+			Data: UnshareAssessmentActionData{
+				AssessmentID: assessmentID,
+			},
+		},
+	}
+}
+
+func NewSizingPayload(username, assessmentID string) UserActionEventPayload {
+	return UserActionEventPayload{
+		UserAction: UserActionData{
+			Username:  username,
+			Timestamp: time.Now().UTC(),
+			Data: SizingActionData{
+				AssessmentID: assessmentID,
+			},
+		},
+	}
+}
+
+func NewComplexityPayload(username, assessmentID string) UserActionEventPayload {
+	return UserActionEventPayload{
+		UserAction: UserActionData{
+			Username:  username,
+			Timestamp: time.Now().UTC(),
+			Data: ComplexityActionData{
+				AssessmentID: assessmentID,
+			},
+		},
+	}
+}
+
+func NewOVADownloadPayload(username, sourceID string) UserActionEventPayload {
+	return UserActionEventPayload{
+		UserAction: UserActionData{
+			Username:  username,
+			Timestamp: time.Now().UTC(),
+			Data: OVADownloadActionData{
+				SourceID: sourceID,
+			},
+		},
+	}
 }


### PR DESCRIPTION
…ents

Replace generic pointer-based UserActionData with an envelope (username, timestamp) plus a typed Data field per action. Each action now carries exactly the fields it needs. Share assessment events now include the partner ID so consumers know which partner received the share.