### PR TITLE
ECOPROJECT-4806 | fix: sanitize dots in hostname for River queue name

### DIFF
--- a/internal/rvtools/jobs/client.go
+++ b/internal/rvtools/jobs/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -49,11 +51,21 @@ func NewClient(pool *pgxpool.Pool, s store.Store, opaValidator *opa.Validator) (
 	}, nil
 }
 
+var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
 func podQueueName() string {
 	if hostname, err := os.Hostname(); err == nil && hostname != "" {
-		return fmt.Sprintf("rvtools-%s", hostname)
+		return sanitizeQueueName(hostname)
 	}
 	return river.QueueDefault
+}
+
+func sanitizeQueueName(hostname string) string {
+	s := strings.Trim(nonAlnum.ReplaceAllString(strings.ToLower(hostname), "-"), "-")
+	if s == "" {
+		return river.QueueDefault
+	}
+	return "rvtools-" + s
 }
 
 func (c *Client) Stop(ctx context.Context) error {

--- a/internal/rvtools/jobs/client_test.go
+++ b/internal/rvtools/jobs/client_test.go
@@ -1,0 +1,39 @@
+package jobs
+
+import (
+	"regexp"
+	"testing"
+)
+
+var riverQueueRegex = regexp.MustCompile(`^[a-z0-9]+([_-]?[a-z0-9]+)*$`)
+
+func TestSanitizeQueueName(t *testing.T) {
+	tests := []struct {
+		hostname string
+		want     string
+	}{
+		{"simple-pod", "rvtools-simple-pod"},
+		{"pod.namespace.svc.cluster.local", "rvtools-pod-namespace-svc-cluster-local"},
+		{"MyHost.Example.COM", "rvtools-myhost-example-com"},
+		{"host_name", "rvtools-host-name"},
+		{"host:8080", "rvtools-host-8080"},
+		{"pod@node!#1", "rvtools-pod-node-1"},
+		{".leading.dot", "rvtools-leading-dot"},
+		{"trailing.", "rvtools-trailing"},
+		{"host-.example.com", "rvtools-host-example-com"},
+		{"...", "default"},
+		{"@#$", "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			got := sanitizeQueueName(tt.hostname)
+			if got != tt.want {
+				t.Errorf("sanitizeQueueName(%q) = %q, want %q", tt.hostname, got, tt.want)
+			}
+			if !riverQueueRegex.MatchString(got) {
+				t.Errorf("sanitizeQueueName(%q) = %q, does not match River queue regex", tt.hostname, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`podQueueName()` uses `os.Hostname()` directly in the queue name (`rvtools-<hostname>`), but River's queue name validation only allows `[a-z0-9_-]`. Pods with dots in their hostname (common in OpenShift) crash on River client creation.

Fix: replace dots with hyphens before building the queue name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job queue naming by sanitizing the machine hostname (invalid characters are normalized, separators are collapsed/trimmed, and an empty result falls back to the default queue).

* **Tests**
  * Added table-driven coverage for hostname sanitization, including edge cases (dots, mixed case, ports, and special characters), and verifies output matches the expected queue-name format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->