### PR TITLE
NO-JIRA | chore: Change CODEOWNERS to use kubev2v/migration-planner-backend-reviewers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @kubev2v/migration-planner-reviewers
+*       @kubev2v/migration-planner-backend-reviewers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository review routing for backend-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->