### PR TITLE
ECOPROJECT-4859 | fix: include compactMode in stored cluster-requirements input

### DIFF
--- a/internal/handlers/v1alpha1/mappers/outbound.go
+++ b/internal/handlers/v1alpha1/mappers/outbound.go
@@ -383,6 +383,7 @@ func ClusterRequirementsInputFormToAPI(form mappers.ClusterRequirementsInputForm
 		response.ControlPlaneNodeCount = &count
 	}
 	response.HostedControlPlane = form.HostedControlPlane
+	response.CompactMode = form.CompactMode
 
 	return response
 }


### PR DESCRIPTION
ClusterRequirementsInputFormToAPI omitted CompactMode when mapping the stored input form back to the API, so successful compact calculations returned stored-input without compactMode set.