### PR TITLE
ECOPROJECT-4847 | fix: clear proxy fields when set to null in source update

### DIFF
--- a/internal/handlers/v1alpha1/mappers/inbound.go
+++ b/internal/handlers/v1alpha1/mappers/inbound.go
@@ -34,12 +34,16 @@ func mapProxyFields(proxy *v1alpha1.AgentProxy) (httpUrl, httpsUrl, noProxy stri
 		util.DerefString(proxy.NoProxy)
 }
 
-// mapProxyFieldsForUpdate extracts proxy fields for update form (returns pointers)
+// mapProxyFieldsForUpdate extracts proxy fields for update form (returns pointers).
+// When proxy is present, nil fields mean "clear" (not "skip"), matching create-path semantics.
 func mapProxyFieldsForUpdate(proxy *v1alpha1.AgentProxy) (httpUrl, httpsUrl, noProxy *string) {
 	if proxy == nil {
 		return nil, nil, nil
 	}
-	return proxy.HttpUrl, proxy.HttpsUrl, proxy.NoProxy
+	h := util.DerefString(proxy.HttpUrl)
+	hs := util.DerefString(proxy.HttpsUrl)
+	np := util.DerefString(proxy.NoProxy)
+	return &h, &hs, &np
 }
 
 func mapIpv4Fields(vmnetwork *v1alpha1.VmNetwork) (ipAddress, subnetMask, defaultGateway, dns string) {

--- a/internal/service/source_test.go
+++ b/internal/service/source_test.go
@@ -718,6 +718,51 @@ TZUUZpsP4or19B48WSqiV/eMdCB/PxnFZYT1SyFLlDBiXolb+30HbGeeaF0bEg+u
 			Expect(updatedSource.ImageInfra.NoProxyDomains).To(BeEmpty())
 		})
 
+		It("null proxy fields clear existing values", func() {
+			sourceID := uuid.NewString()
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))
+			Expect(tx.Error).To(BeNil())
+
+			initialImageInfra := model.ImageInfra{
+				SourceID:       uuid.MustParse(sourceID),
+				HttpProxyUrl:   "http://proxy.example.com",
+				HttpsProxyUrl:  "https://proxy.example.com",
+				NoProxyDomains: "test.example.com",
+			}
+			_, err := s.ImageInfra().Create(context.TODO(), initialImageInfra)
+			Expect(err).To(BeNil())
+
+			user := auth.User{
+				Username:     "admin",
+				Organization: "admin",
+			}
+			ctx := auth.NewTokenContext(context.TODO(), user)
+
+			srv := handlers.NewServiceHandler(service.NewSourceService(s, nil), service.NewAssessmentService(s, nil, nil), nil, service.NewSizerService(nil, s), nil, nil, nil)
+
+			enableProxy := true
+			httpUrl := "http://proxy.example.com"
+			resp, err := srv.UpdateSource(ctx, server.UpdateSourceRequestObject{
+				Id: uuid.MustParse(sourceID),
+				Body: &v1alpha1.SourceUpdate{
+					EnableProxy: &enableProxy,
+					Proxy: &v1alpha1.AgentProxy{
+						HttpUrl:  &httpUrl,
+						HttpsUrl: nil,
+						NoProxy:  nil,
+					},
+				},
+			})
+			Expect(err).To(BeNil())
+			Expect(reflect.TypeOf(resp).String()).To(Equal(reflect.TypeOf(server.UpdateSource200JSONResponse{}).String()))
+
+			updatedSource, err := s.Source().Get(ctx, uuid.MustParse(sourceID))
+			Expect(err).To(BeNil())
+			Expect(updatedSource.ImageInfra.HttpProxyUrl).To(Equal(httpUrl))
+			Expect(updatedSource.ImageInfra.HttpsProxyUrl).To(BeEmpty())
+			Expect(updatedSource.ImageInfra.NoProxyDomains).To(BeEmpty())
+		})
+
 		It("networkConfigType dhcp clears network fields", func() {
 			sourceID := uuid.NewString()
 			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))


### PR DESCRIPTION
`mapProxyFieldsForUpdate` returned raw `*string` pointers from the API struct, so both "field omitted" and "field explicitly set to null" mapped to `nil`. `ToImageInfra` skips nil fields to support partial updates — meaning null proxy values were silently preserved instead of cleared.

Fix: when proxy object is present in the request, deref nil fields to empty string pointers (same as the create path already does). Proxy object absent → nil → skip. Proxy object present with nil field → `&""` → clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating proxy settings now correctly clears previously saved proxy values when fields are left blank, instead of leaving old values in place.
  * Proxy updates now behave consistently with create flows when some proxy fields are omitted.
* **Tests**
  * Added coverage for proxy update behavior to verify blank fields clear stored values and provided values are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->