### PR TITLE
ECOPROJECT-4893 | fix: align e2e test with eager credential validation

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -119,32 +119,19 @@ var _ = Describe("e2e", func() {
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
+			// Invalid credentials are now validated eagerly by Store() and rejected synchronously
 			_, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%s/sdk", SystemIP, Vsphere1Port),
 				"invalid", "cred")
 			Expect(err).To(BeNil())
-			Expect(resCode).To(Equal(http.StatusAccepted))
+			Expect(resCode).To(Equal(http.StatusBadRequest))
 
-			var s *CollectorStatus
-			Eventually(func() string {
-				s, err = e2eAgent.Api.GetCollectorStatus()
-				if err != nil {
-					return ""
-				}
-				return s.Status
-			}, "30s", "2s").Should(Equal(string(CollectorStatusError)))
-
-			s, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%s/badUrl", SystemIP, Vsphere1Port),
+			// Bad URL is also rejected synchronously during credential verification
+			_, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%s/badUrl", SystemIP, Vsphere1Port),
 				"user", "pass")
 			Expect(err).To(BeNil())
-			Expect(resCode).To(Equal(http.StatusAccepted))
-			Eventually(func() string {
-				s, err = e2eAgent.Api.GetCollectorStatus()
-				if err != nil {
-					return ""
-				}
-				return s.Status
-			}, "30s", "2s").Should(Equal(string(CollectorStatusError)))
+			Expect(resCode).To(Equal(http.StatusBadRequest))
 
+			var s *CollectorStatus
 			s, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%s/sdk", SystemIP, Vsphere1Port), "core", "123456")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))


### PR DESCRIPTION
## What

Updates the e2e test `start collecting only when credentials are valid` to match the agent's new behavior where credentials are validated eagerly via `Store()`.

Companion to agent PR: https://github.com/kubev2v/assisted-migration-agent/pull/291

## Changes

- Invalid creds (`"invalid", "cred"`) now expect `400` instead of `202` — agent validates against vCenter synchronously
- Bad URL (`/badUrl`) now expects `400` instead of `202` — same reason
- Removed `Eventually` polling for `CollectorStatusError` on those cases — errors are synchronous, no async polling needed

## Test plan

- [x] `go vet ./test/e2e/...` — compiles
- [x] `make lint` — 0 issues
- [ ] e2e CI — requires agent image with kubev2v/assisted-migration-agent#291 merged