### PR TITLE
ECOPROJECT-4898 | fix: Add Envoy routes for new agent API inventory endpoints

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -445,6 +445,15 @@ objects:
                                 regex: "^${SERVICE_API_PATH}/api/v1/sources/([0-9a-f-]+)/status$"
                               substitution: "/api/v1/sources/\\1/status"
                         - match:
+                            safe_regex:
+                              regex: "^${SERVICE_API_PATH}/api/v1/sources/([0-9a-f-]+)/subset/([0-9a-f-]+)$"
+                          route:
+                            cluster: backend-agent-api
+                            regex_rewrite:
+                              pattern:
+                                regex: "^${SERVICE_API_PATH}/api/v1/sources/([0-9a-f-]+)/subset/([0-9a-f-]+)$"
+                              substitution: "/api/v1/sources/\\1/subset/\\2"
+                        - match:
                             prefix: "${SERVICE_API_PATH}/api/v1/agents"
                           route:
                             cluster: backend-agent-api


### PR DESCRIPTION
- Add Envoy routes for subset endpoints (/subset/{subsetId})

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the source update request path to use the inventory endpoint.
  * Added routing support for additional source inventory and subset API paths.

* **Bug Fixes**
  * Aligned client and server request handling so updates are sent to the correct endpoint.
  * Kept request formats and response handling unchanged while correcting path routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->