### PR TITLE
ci: Pass build-args-file to build-planner-agent-container in push and tag pipelines

### DIFF
--- a/.tekton/migration-planner-rhcos-iso-push.yaml
+++ b/.tekton/migration-planner-rhcos-iso-push.yaml
@@ -198,6 +198,8 @@ spec:
         - $(params.build-args[*])
         - PLANNER_AGENT_GIT_COMMIT=$(tasks.clone-repository.results.commit)
         - PLANNER_AGENT_VERSION={{target_branch}}-$(tasks.clone-repository.results.short-commit)
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_URL

--- a/.tekton/migration-planner-rhcos-iso-tag.yaml
+++ b/.tekton/migration-planner-rhcos-iso-tag.yaml
@@ -198,6 +198,8 @@ spec:
         - $(params.build-args[*])
         - PLANNER_AGENT_GIT_COMMIT=$(tasks.clone-repository.results.commit)
         - PLANNER_AGENT_VERSION={{git_tag}}
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_URL


### PR DESCRIPTION
The pull-request pipeline passes BUILD_ARGS_FILE to the
build-planner-agent-container step, but the push and tag pipelines did
not. This caused those builds to fall back to default build args
(e.g. AGENT_UI_IMAGE_TAG=latest) instead of using the pinned values
from build/migration-planner-iso/config.
