### PR TITLE
ECOPROJECT-4910 | fix: include DeletedAt in assessment deleted event payload

### DIFF
--- a/internal/service/eventwrap/event_assessment.go
+++ b/internal/service/eventwrap/event_assessment.go
@@ -2,6 +2,7 @@ package eventwrap
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/internal/auth"
@@ -102,11 +103,13 @@ func (e *EventAssessmentService) DeleteAssessment(ctx context.Context, id uuid.U
 		return err
 	}
 
+	deletedAt := time.Now().UTC()
+
 	if err := e.inner.DeleteAssessment(ctx, id); err != nil {
 		return err
 	}
 
-	payload := events.NewAssessmentDeletedPayload(assessment.ID.String())
+	payload := events.NewAssessmentDeletedPayload(assessment.ID.String(), deletedAt)
 	ceBytes, err := events.BuildCloudEvent(events.AssessmentDeletedEventType, payload)
 	if err != nil {
 		return err

--- a/pkg/events/assessment.go
+++ b/pkg/events/assessment.go
@@ -28,6 +28,6 @@ func NewAssessmentCreatedPayload(data AssessmentData) AssessmentEventPayload {
 	return AssessmentEventPayload{Assessment: data}
 }
 
-func NewAssessmentDeletedPayload(assessmentID string) AssessmentEventPayload {
-	return AssessmentEventPayload{Assessment: AssessmentData{ID: assessmentID}}
+func NewAssessmentDeletedPayload(assessmentID string, deletedAt time.Time) AssessmentEventPayload {
+	return AssessmentEventPayload{Assessment: AssessmentData{ID: assessmentID, DeletedAt: &deletedAt}}
 }


### PR DESCRIPTION
## Summary
- `NewAssessmentDeletedPayload` was constructing an `AssessmentEventPayload` with only the assessment ID, leaving `DeletedAt` as nil
- The event streamer's `AssessmentDeletedProcessor` calls `event.Assessment.DeletedAt.Format(time.RFC3339)`, which causes a nil-pointer dereference when processing the event
- Fixed by adding a `deletedAt time.Time` parameter to `NewAssessmentDeletedPayload` and passing `time.Now().UTC()` from the caller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deletion records for assessments now include the exact deletion time, improving accuracy and traceability in activity history and event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->