### PR TITLE
ECOPROJECT-4859 | fix: validate compact mode fit before node count transformation

### DIFF
--- a/internal/service/sizer.go
+++ b/internal/service/sizer.go
@@ -419,6 +419,17 @@ func (s *SizerService) calculateSizingWithMultipliers(
 		return SizingResult{}, fmt.Errorf("sizer service returned empty response")
 	}
 
+	// Validate compact mode fit using raw sizer response (before transformation)
+	if compactMode {
+		smtMultiplier := 1.0
+		if params.WorkerNodeCPU > 0 && workerNodeThreads > 0 && workerNodeThreads > params.WorkerNodeCPU {
+			smtMultiplier = effectiveCPU / float64(params.WorkerNodeCPU)
+		}
+		if err := s.validateCompactModeFit(sizerResponse.Data.NodeCount, totalCPU, totalMemory, smtMultiplier, params.CpuOverCommitRatio, params.MemoryOverCommitRatio, controlPlaneCPU, controlPlaneMemory); err != nil {
+			return SizingResult{}, err
+		}
+	}
+
 	_, err = s.validateVMDistribution(sizerResponse, services, singleNode)
 	if err != nil {
 		return SizingResult{}, err
@@ -678,13 +689,8 @@ func (s *SizerService) CalculateClusterRequirements(
 		}
 	}
 
-	if compactMode {
-		controlPlaneCPU := extractControlPlaneCPU(&params)
-		controlPlaneMemory := extractControlPlaneMemory(&params)
-		if err := s.validateCompactModeFit(baselineResult.TotalNodes, totalCPU, totalMemory, smtMultiplier, params.CpuOverCommitRatio, params.MemoryOverCommitRatio, controlPlaneCPU, controlPlaneMemory); err != nil {
-			return nil, err
-		}
-	}
+	// Note: compact mode validation is now done inside calculateSizingWithMultipliers
+	// using the raw sizer response before transformation, so it's removed from here
 
 	logger.Operation("calculate_baseline").
 		WithString("cluster_id", calcReq.ClusterID).

--- a/internal/service/sizer_test.go
+++ b/internal/service/sizer_test.go
@@ -2400,20 +2400,21 @@ var _ = Describe("sizer service", func() {
 		})
 
 		Context("fit errors", func() {
-			It("succeeds even when sizer returns more than 3 nodes (current behavior)", func() {
+			It("fails when sizer returns more than 3 nodes (workload doesn't fit)", func() {
 				assessment := createTestAssessment(assessmentID, clusterID, 10, 40, 80)
 				mockStore.assessments[assessmentID] = assessment
+				// Sizer returns 5 nodes - workload is too large for compact mode
 				testServer = createTestSizerServer(createTestSizerResponse(5, 2, 3, 40, 80), http.StatusOK, false)
 				sizerClient = client.NewSizerClient(testServer.URL, 5*time.Second)
 				sizerService = service.NewSizerService(sizerClient, mockStore)
 
 				result, err := sizerService.CalculateClusterRequirements(ctx, assessmentID, request)
 
-				Expect(err).To(BeNil())
-				Expect(result).NotTo(BeNil())
-				Expect(result.ClusterSizing.TotalNodes).To(Equal(3))
-				Expect(result.ClusterSizing.ControlPlaneNodes).To(Equal(3))
-				Expect(result.ClusterSizing.WorkerNodes).To(Equal(0))
+				Expect(err).NotTo(BeNil())
+				_, ok := err.(*service.ErrInvalidRequest)
+				Expect(ok).To(BeTrue())
+				Expect(err.Error()).To(ContainSubstring("workload does not fit in compact mode"))
+				Expect(result).To(BeNil())
 			})
 
 			It("handles sizer schedulability error for compact mode", func() {


### PR DESCRIPTION
Move compact mode validation before transformation to check raw sizer response instead of already-transformed value. Previously, validation  always passed because it checked TotalNodes=3 after transformation had already forced it to 3, masking oversized workloads.

Now correctly rejects workloads requiring >3 nodes in compact mode.

Also fixes: [ECOPROJECT-4933](https://redhat.atlassian.net/browse/ECOPROJECT-4933)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact-mode sizing checks so oversized workloads now fail earlier with a clear “does not fit in compact mode” error.
  * Updated sizing validation to use the original sizing response, producing more accurate results for compact clusters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ECOPROJECT-4933]: https://redhat.atlassian.net/browse/ECOPROJECT-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ