### PR TITLE
chore: widen Renovate schedule to all of Saturday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Renovate configuration for migration-planner - runs dependency updates weekly on Saturday mornings",
+  "description": "Renovate configuration for migration-planner - runs dependency updates weekly on Saturdays",
   "extends": [
     "config:recommended"
   ],
   "schedule": [
-    "before 6am on Saturday"
+    "on Saturday"
   ]
 }


### PR DESCRIPTION
MintMaker schedules tekton task updates for Saturday after 5am, but our schedule was "before 6am on Saturday" — only a ~1 hour overlap window. Widen to the full day so tekton PRs get created reliably.