### PR TITLE
ECOPROJECT-4151 | fix: environment status stuck on "Uploaded manually" after agent connects

### DIFF
--- a/internal/handlers/v1alpha1/mappers/outbound.go
+++ b/internal/handlers/v1alpha1/mappers/outbound.go
@@ -78,6 +78,11 @@ func SourceToApi(s model.Source) (api.Source, error) {
 		Name:       s.Name,
 	}
 
+	if s.UpdateType != "" {
+		ut := api.SourceUpdateType(s.UpdateType)
+		source.UpdateType = &ut
+	}
+
 	if len(s.Inventory) > 0 {
 		v := util.GetInventoryVersion(s.Inventory)
 		switch v {

--- a/internal/handlers/v1alpha1/mappers/outbound_test.go
+++ b/internal/handlers/v1alpha1/mappers/outbound_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	api "github.com/kubev2v/migration-planner/api/v1alpha1"
 	"github.com/kubev2v/migration-planner/internal/handlers/v1alpha1/mappers"
 	"github.com/kubev2v/migration-planner/internal/service"
+	"github.com/kubev2v/migration-planner/internal/store/model"
 	"github.com/kubev2v/migration-planner/pkg/estimations/complexity"
 	"github.com/kubev2v/migration-planner/pkg/estimations/engines"
 	"github.com/kubev2v/migration-planner/pkg/estimations/estimation"
@@ -17,6 +20,31 @@ func TestMappers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Mappers Suite")
 }
+
+var _ = Describe("SourceToApi", func() {
+	It("maps UpdateType when set", func() {
+		source := model.Source{
+			ID:         uuid.New(),
+			Name:       "test-source",
+			UpdateType: "auto",
+		}
+		result, err := mappers.SourceToApi(source)
+		Expect(err).To(BeNil())
+		Expect(result.UpdateType).NotTo(BeNil())
+		Expect(*result.UpdateType).To(Equal(api.SourceUpdateType("auto")))
+	})
+
+	It("omits UpdateType when empty", func() {
+		source := model.Source{
+			ID:         uuid.New(),
+			Name:       "test-source",
+			UpdateType: "",
+		}
+		result, err := mappers.SourceToApi(source)
+		Expect(err).To(BeNil())
+		Expect(result.UpdateType).To(BeNil())
+	})
+})
 
 var _ = Describe("MigrationComplexityResultToAPI", func() {
 	It("maps complexityByDisk, complexityByOS, complexityByOSName, diskSizeRatings, osRatings", func() {

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -68,6 +68,7 @@ func (as *AgentService) UpdateSourceInventory(ctx context.Context, updateForm ma
 	}
 
 	source = mappers.UpdateSourceFromApi(source, updateForm.VCenterID, updateForm.Inventory)
+	source.UpdateType = "auto"
 	updatedSource, err := as.store.Source().Update(ctx, *source)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update source: %w", err)
@@ -221,7 +222,7 @@ func (as *AgentService) DeleteSourceSubset(ctx context.Context, sourceID, subset
 // UpdateAgentStatus updates or creates a new agent resource
 // If the source has not agent than the agent is created.
 func (as *AgentService) UpdateAgentStatus(ctx context.Context, updateForm mappers.AgentUpdateForm) (*model.Agent, bool, error) {
-	_, err := as.store.Source().Get(ctx, updateForm.SourceID)
+	source, err := as.store.Source().Get(ctx, updateForm.SourceID)
 	if err != nil {
 		if errors.Is(err, store.ErrRecordNotFound) {
 			return nil, false, NewErrSourceNotFound(updateForm.SourceID)
@@ -235,6 +236,17 @@ func (as *AgentService) UpdateAgentStatus(ctx context.Context, updateForm mapper
 	}
 
 	if agent == nil {
+		// Delete only placeholder agents for this source (created during manual
+		// inventory upload with empty Status); preserve already-connected agents.
+		for _, existing := range source.Agents {
+			if existing.Status != "" {
+				continue
+			}
+			if err := as.store.Agent().Delete(ctx, existing.ID); err != nil {
+				return nil, false, fmt.Errorf("failed to delete placeholder agent: %w", err)
+			}
+		}
+
 		a, err := as.store.Agent().Create(ctx, updateForm.ToModel())
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to create the agent: %w", err)

--- a/internal/service/agent_test.go
+++ b/internal/service/agent_test.go
@@ -125,6 +125,53 @@ var _ = Describe("agent service", Ordered, func() {
 			Expect(credsUrl).To(Equal("creds-url"))
 		})
 
+		It("replaces placeholder agent but preserves connected agents", func() {
+			sourceID := uuid.New()
+			placeholderAgentID := uuid.New()
+			connectedAgentID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))
+			Expect(tx.Error).To(BeNil())
+			// Insert a placeholder agent (empty status, as created by manual inventory upload)
+			tx = gormdb.Exec(fmt.Sprintf("INSERT INTO agents (id, status, status_info, cred_url, source_id, version) VALUES ('%s', '', '', '', '%s', '');", placeholderAgentID, sourceID))
+			Expect(tx.Error).To(BeNil())
+			// Insert an already-connected agent (non-empty status)
+			tx = gormdb.Exec(fmt.Sprintf("INSERT INTO agents (id, status, status_info, cred_url, source_id, version) VALUES ('%s', 'up-to-date', 'running', 'url', '%s', 'v1');", connectedAgentID, sourceID))
+			Expect(tx.Error).To(BeNil())
+
+			realAgentID := uuid.New()
+			srv := service.NewAgentService(s)
+			agent, created, err := srv.UpdateAgentStatus(context.TODO(), mappers.AgentUpdateForm{
+				ID:         realAgentID,
+				Status:     "waiting-for-credentials",
+				StatusInfo: "waiting-for-credentials",
+				CredUrl:    "creds-url",
+				Version:    "version-1",
+				SourceID:   sourceID,
+			})
+			Expect(err).To(BeNil())
+			Expect(created).To(BeTrue())
+			Expect(agent).ToNot(BeNil())
+			Expect(agent.ID).To(Equal(realAgentID))
+
+			// Verify placeholder was deleted but connected agent was preserved
+			count := -1
+			tx = gormdb.Raw(fmt.Sprintf("SELECT COUNT(*) FROM agents WHERE source_id = '%s';", sourceID)).Scan(&count)
+			Expect(tx.Error).To(BeNil())
+			Expect(count).To(Equal(2))
+
+			// Verify the placeholder is gone
+			var placeholderCount int
+			tx = gormdb.Raw(fmt.Sprintf("SELECT COUNT(*) FROM agents WHERE id = '%s';", placeholderAgentID)).Scan(&placeholderCount)
+			Expect(tx.Error).To(BeNil())
+			Expect(placeholderCount).To(Equal(0))
+
+			// Verify the connected agent is still there
+			var connectedCount int
+			tx = gormdb.Raw(fmt.Sprintf("SELECT COUNT(*) FROM agents WHERE id = '%s';", connectedAgentID)).Scan(&connectedCount)
+			Expect(tx.Error).To(BeNil())
+			Expect(connectedCount).To(Equal(1))
+		})
+
 		It("failed to update agent -- source is missing", func() {
 			sourceID := uuid.NewString()
 			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))
@@ -321,6 +368,47 @@ var _ = Describe("agent service", Ordered, func() {
 			Expect(err).ToNot(BeNil())
 			_, ok := err.(*service.ErrResourceNotFound)
 			Expect(ok).To(BeTrue())
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE FROM agents;")
+			gormdb.Exec("DELETE FROM sources;")
+		})
+	})
+
+	Context("UpdateSourceInventory sets update_type", func() {
+		It("sets update_type to auto", func() {
+			sourceID := uuid.New()
+			agentID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertSourceWithUsernameStm, sourceID, "admin", "admin"))
+			Expect(tx.Error).To(BeNil())
+			tx = gormdb.Exec(fmt.Sprintf(insertAgentStm, agentID, "not-connected", "status-info-1", "cred_url-1", sourceID))
+			Expect(tx.Error).To(BeNil())
+
+			// Set update_type to manual first (simulate manual upload)
+			tx = gormdb.Exec(fmt.Sprintf("UPDATE sources SET update_type = 'manual' WHERE id = '%s';", sourceID))
+			Expect(tx.Error).To(BeNil())
+
+			inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+				VcenterId: "vcenter",
+			})
+
+			srv := service.NewAgentService(s)
+			source, err := srv.UpdateSourceInventory(context.TODO(), mappers.InventoryUpdateForm{
+				SourceID:  sourceID,
+				AgentID:   agentID,
+				VCenterID: "vcenter",
+				Inventory: inventoryJSON,
+			})
+			Expect(err).To(BeNil())
+			Expect(source).NotTo(BeNil())
+			Expect(source.UpdateType).To(Equal("auto"))
+
+			// Verify in database
+			updateType := ""
+			tx = gormdb.Raw(fmt.Sprintf("SELECT update_type FROM sources WHERE id = '%s';", sourceID)).Scan(&updateType)
+			Expect(tx.Error).To(BeNil())
+			Expect(updateType).To(Equal("auto"))
 		})
 
 		AfterEach(func() {

--- a/internal/store/agent.go
+++ b/internal/store/agent.go
@@ -24,6 +24,7 @@ type Agent interface {
 	Get(ctx context.Context, id uuid.UUID) (*model.Agent, error)
 	Update(ctx context.Context, agent model.Agent) (*model.Agent, error)
 	Create(ctx context.Context, agent model.Agent) (*model.Agent, error)
+	Delete(ctx context.Context, id uuid.UUID) error
 }
 
 type AgentStore struct {
@@ -92,6 +93,16 @@ func (a *AgentStore) Get(ctx context.Context, id uuid.UUID) (*model.Agent, error
 	}
 
 	return agent, nil
+}
+
+// Delete deletes an agent by its id.
+func (a *AgentStore) Delete(ctx context.Context, id uuid.UUID) error {
+	agent := model.Agent{ID: id}
+	result := a.getDB(ctx).Unscoped().Delete(&agent)
+	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return result.Error
+	}
+	return nil
 }
 
 func (a *AgentStore) getDB(ctx context.Context) *gorm.DB {


### PR DESCRIPTION
## Summary

Fixes the bug where environment status stays on "Uploaded manually" after an agent switches to connected mode.

**Root cause:** Three issues contributed:

1. **Duplicate agents** — Manual inventory upload created a placeholder agent with a random UUID. When the real agent connected, `UpdateAgentStatus` didn't find it (different UUID) and created a second agent. Now existing placeholder agents are deleted before creating the real one.

2. **Old endpoint didn't reset UpdateType** — `UpdateSourceInventory` preserved the "manual" UpdateType even when called by an agent. Now it sets `UpdateType = "auto"`.

3. **UpdateType missing from API response** — `SourceToApi` never mapped the `UpdateType` field, so the frontend couldn't see the status regardless of what was stored. Now it's mapped, matching the pattern already used for subset inventories.

## Changes

- `internal/store/agent.go` — Add `Delete` method to Agent store interface/implementation
- `internal/service/agent.go` — Fix `UpdateAgentStatus` to replace placeholder agents; fix `UpdateSourceInventory` to set `UpdateType = "auto"`
- `internal/handlers/v1alpha1/mappers/outbound.go` — Map `UpdateType` in `SourceToApi`
- `internal/service/agent_test.go` — Add tests for agent replacement and UpdateType reset

Fixes: [ECOPROJECT-4151](https://redhat.atlassian.net/browse/ECOPROJECT-4151)

## Testing

- [x] New test: `UpdateAgentStatus` replaces placeholder agent (verifies only 1 agent with real ID remains)
- [x] New test: `UpdateSourceInventory` resets `update_type` from "manual" to "auto"
- [x] All existing unit tests pass
- [x] Lint passes

[ECOPROJECT-4151]: https://redhat.atlassian.net/browse/ECOPROJECT-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source responses now correctly include the update type.
  * Automatic inventory updates are marked as “auto.”
  * Replaced placeholder agents are cleaned up to prevent duplicate entries.

* **Tests**
  * Added coverage verifying update type changes and placeholder agent replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->