### PR TITLE
chore: add gomodTidy to Renovate postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,8 @@
   ],
   "schedule": [
     "on Saturday"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `"postUpdateOptions": ["gomodTidy"]` to `renovate.json` so Mintmaker explicitly runs `go mod tidy` after dependency updates
- Fixes the issue where Mintmaker PRs update `go.mod` without regenerating `go.sum`, leaving PRs in a non-buildable state
- This is a known Mintmaker issue (KONFLUX-8098, [KFLUXSPRT-8235](https://redhat.atlassian.net/browse/KFLUXSPRT-8235)) where the backend `renovate/artifacts` step fails silently

## Test plan

- [ ] Verify next Mintmaker dependency update PR includes both `go.mod` and `go.sum` changes
- [ ] Confirm existing CI passes on this config change

🤖 Generated with [Claude Code](https://claude.ai/code)

[KFLUXSPRT-8235]: https://redhat.atlassian.net/browse/KFLUXSPRT-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates now run Go module cleanup after updates, helping keep dependency metadata consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->