### PR TITLE
ECOPROJECT-5053 | fix: remove raw JWT tokens from auth error logs

### DIFF
--- a/internal/auth/agent_authenticator.go
+++ b/internal/auth/agent_authenticator.go
@@ -107,12 +107,12 @@ func (aa *AgentAuthenticator) Authenticate(token string) (AgentJWT, error) {
 		return &rsaPublicKey, nil
 	})
 	if err != nil {
-		zap.S().Errorw("failed to parse or the token is invalid", "token", token, "error", err)
+		zap.S().Errorw("failed to parse or the token is invalid", "error", err)
 		return AgentJWT{}, fmt.Errorf("failed to authenticate token: %w", err)
 	}
 
 	if !t.Valid {
-		zap.S().Errorw("failed to parse or the token is invalid", "token", token)
+		zap.S().Errorw("failed to parse or the token is invalid")
 		return AgentJWT{}, fmt.Errorf("failed to parse or validate token")
 	}
 

--- a/internal/auth/rhsso_authenticator.go
+++ b/internal/auth/rhsso_authenticator.go
@@ -53,17 +53,17 @@ func (rh *RHSSOAuthenticator) Authenticate(token string) (User, error) {
 	parser := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Name}), jwt.WithIssuedAt(), jwt.WithExpirationRequired())
 	t, err := parser.Parse(token, rh.keyFn)
 	if err != nil {
-		zap.S().Errorw("failed to parse or the token is invalid", "token", token, "error", err)
+		zap.S().Errorw("failed to parse or the token is invalid", "error", err)
 		return User{}, fmt.Errorf("failed to authenticate token: %w", err)
 	}
 
 	if !t.Valid {
-		zap.S().Errorw("failed to parse or the token is invalid", "token", token, "error", err)
+		zap.S().Errorw("failed to parse or the token is invalid", "error", err)
 		return User{}, fmt.Errorf("failed to parse or validate token")
 	}
 
 	if user, err = rh.parseToken(t); err != nil {
-		zap.S().Errorw("failed to parse or the token is invalid", "token", token, "error", err)
+		zap.S().Errorw("failed to parse or the token is invalid", "error", err)
 		return User{}, fmt.Errorf("failed to authenticate token: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Remove raw JWT token values from `Errorw` log calls in `rhsso_authenticator.go` (3 sites) and `agent_authenticator.go` (2 sites)
- When authentication fails, the error log lines included the full bearer token. Anyone with log access could extract valid credentials. The error details are retained — only the raw token value is removed.

Ref: [ECOPROJECT-5053](https://redhat.atlassian.net/browse/ECOPROJECT-5053)

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./internal/auth/...` — 0 issues
- [ ] Existing auth unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ECOPROJECT-5053]: https://redhat.atlassian.net/browse/ECOPROJECT-5053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ