### PR TITLE
ECOPROJECT-4991 | fix: sqlite hard coded sioc values instead of reading from forklift

### DIFF
--- a/pkg/duckdb_parser/ingest_sqlite_test.go
+++ b/pkg/duckdb_parser/ingest_sqlite_test.go
@@ -79,7 +79,7 @@ func createTestSQLite(t *testing.T, instanceUUID string, clusters []sqliteCluste
 		`CREATE TABLE dst.Network (ID VARCHAR PRIMARY KEY, Name VARCHAR, DVSwitch VARCHAR, VlanId VARCHAR)`,
 
 		// Datastore
-		`CREATE TABLE dst.Datastore (ID VARCHAR PRIMARY KEY, Name VARCHAR, Free BIGINT, Capacity BIGINT, MaintenanceMode VARCHAR, Type VARCHAR, BackingDevicesNames VARCHAR)`,
+		`CREATE TABLE dst.Datastore (ID VARCHAR PRIMARY KEY, Name VARCHAR, Free BIGINT, Capacity BIGINT, MaintenanceMode VARCHAR, Type VARCHAR, BackingDevicesNames VARCHAR, IORMEnabled BOOLEAN, IORMCongestionThreshold INTEGER, IORMCongestionThresholdMode VARCHAR, IORMPercentOfPeakThroughput INTEGER)`,
 	}
 
 	for _, stmt := range stmts {
@@ -388,4 +388,43 @@ func TestIngestSqlite_PopulateVCluster_SkipsWhenAlreadyPopulated(t *testing.T) {
 	var objectID string
 	require.NoError(t, db.QueryRowContext(ctx, `SELECT "Object ID" FROM vcluster WHERE "Name" = 'existing-cluster'`).Scan(&objectID))
 	assert.Equal(t, "sentinel-id", objectID, "pre-existing row must not be overwritten")
+}
+
+func TestIngestSqlite_DatastoreIORMValues(t *testing.T) {
+	ctx := context.Background()
+	parser, db, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	clusters := []sqliteCluster{
+		{id: "domain-c1", name: "cluster1", datacenter: "dc1"},
+	}
+	vms := []sqliteVM{
+		{id: "vm-001", name: "vm-1", clusterName: "cluster1"},
+	}
+	sqlitePath := createTestSQLite(t, "vcenter-uuid-001", clusters, vms)
+
+	// Insert a datastore with non-default IORM values into the SQLite file.
+	srcDB, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	_, err = srcDB.Exec(fmt.Sprintf("ATTACH '%s' AS dst (TYPE sqlite)", sqlitePath))
+	require.NoError(t, err)
+	_, err = srcDB.Exec(`INSERT INTO dst.Datastore (ID, Name, Free, Capacity, MaintenanceMode, Type, BackingDevicesNames, IORMEnabled, IORMCongestionThreshold) VALUES ('ds-1', 'datastore-1', 1073741824, 2147483648, 'False', 'VMFS', '[]', true, 50)`)
+	require.NoError(t, err)
+	_, err = srcDB.Exec("DETACH dst")
+	require.NoError(t, err)
+	require.NoError(t, srcDB.Close())
+
+	result, err := parser.IngestSqlite(ctx, sqlitePath)
+	require.NoError(t, err)
+	require.True(t, result.IsValid())
+
+	var siocEnabled bool
+	var congestionThreshold int
+	err = db.QueryRowContext(ctx,
+		`SELECT "SIOC Enabled", "SIOC Congestion Threshold" FROM vdatastore WHERE "Object ID" = 'ds-1'`).
+		Scan(&siocEnabled, &congestionThreshold)
+	require.NoError(t, err)
+
+	assert.True(t, siocEnabled, "SIOC Enabled should be true")
+	assert.Equal(t, 50, congestionThreshold, "SIOC Congestion Threshold should be 50, not the default 30")
 }

--- a/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
+++ b/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
@@ -201,17 +201,19 @@ SELECT
     ds.Capacity / 1048576,
     ds.Type,
     COALESCE(ds.BackingDevicesNames, '[]'),
-    false,
-    30,
-    'automatic',
-    90
+    COALESCE(ds.IORMEnabled, false),
+    COALESCE(ds.IORMCongestionThreshold, 30),
+    COALESCE(ds.IORMCongestionThresholdMode, 'automatic'),
+    COALESCE(ds.IORMPercentOfPeakThroughput, 90)
 FROM src.Datastore ds
 LEFT JOIN (
     SELECT h.ID, h.Cluster, dsref->>'id' AS datastore_id
     FROM src.Host h,
     LATERAL unnest(from_json(h.Datastores, '[{"kind":"VARCHAR","id":"VARCHAR"}]')) AS t(dsref)
 ) h ON h.datastore_id = ds.ID
-GROUP BY ds.ID, ds.Name, ds.Free, ds.Capacity, ds.MaintenanceMode, ds.Type, ds.BackingDevicesNames;
+GROUP BY ds.ID, ds.Name, ds.Free, ds.Capacity, ds.MaintenanceMode, ds.Type, ds.BackingDevicesNames,
+    COALESCE(ds.IORMEnabled, false), COALESCE(ds.IORMCongestionThreshold, 30),
+    COALESCE(ds.IORMCongestionThresholdMode, 'automatic'), COALESCE(ds.IORMPercentOfPeakThroughput, 90);
 
 INSERT INTO dvport ("Port", "VLAN")
 SELECT


### PR DESCRIPTION
Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite datastore ingestion now preserves IORM settings from the source datastore.
  * Missing IORM values continue to use appropriate defaults, improving consistency in the target datastore records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->