### PR TITLE
DO NOT MERGE | test: validate agent v2 nil EventService fix with e2e

### DIFF
--- a/data/ignition.template
+++ b/data/ignition.template
@@ -247,6 +247,7 @@ storage:
         inline: |
           AGENT_SERVER_HTTP_PORT=3333
           AGENT_SERVER_MODE=prod
+          AGENT_API=v2
           AGENT_AUTHENTICATION_ENABLED=true
           AGENT_AUTHENTICATION_JWT_FILEPATH=/app/jwt.json
           AGENT_OPA_POLICIES_FOLDER=/app/policies

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -44,13 +44,14 @@ func (a *AgentApi) request(method string, path string, body []byte, result any) 
 
 	queryPath := a.baseURL + path
 
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
 	switch method {
-	case http.MethodGet:
-		req, err = http.NewRequest(http.MethodGet, queryPath, nil)
-	case http.MethodPost:
-		req, err = http.NewRequest(http.MethodPost, queryPath, bytes.NewReader(body))
-	case http.MethodPut:
-		req, err = http.NewRequest(http.MethodPut, queryPath, bytes.NewReader(body))
+	case http.MethodGet, http.MethodPost, http.MethodPut:
+		req, err = http.NewRequest(method, queryPath, bodyReader)
 	default:
 		return nil, fmt.Errorf("unsupported method: %s", method)
 	}
@@ -135,22 +136,31 @@ func (a *AgentApi) SetAgentMode(mode string) (*AgentStatus, error) {
 	return &status, nil
 }
 
-func (a *AgentApi) StartCollector(vcenterURL, username, password string) (*CollectorStatus, int, error) {
-	body := CollectorStartRequest{
+func (a *AgentApi) PutCredentials(vcenterURL, username, password string) (int, error) {
+	body := CredentialsRequest{
 		URL:      vcenterURL,
 		Username: username,
 		Password: password,
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
-		return nil, 1, fmt.Errorf("marshaling request: %w", err)
+		return 0, fmt.Errorf("marshaling request: %w", err)
 	}
 
+	res, err := a.request(http.MethodPut, "credentials", data, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to put credentials: %v", err)
+	}
+
+	return res.StatusCode, nil
+}
+
+func (a *AgentApi) StartCollector() (*CollectorStatus, int, error) {
 	var status CollectorStatus
 
-	res, err := a.request(http.MethodPost, "collector", data, &status)
+	res, err := a.request(http.MethodPost, "collector", nil, &status)
 	if err != nil {
-		return nil, 1, fmt.Errorf("failed to start collector: %v", err)
+		return nil, 0, fmt.Errorf("failed to start collector: %v", err)
 	}
 
 	return &status, res.StatusCode, nil

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -94,7 +94,7 @@ func (a *AgentApi) Status() (*AgentStatus, error) {
 		return nil, fmt.Errorf(" unexpected response code %d", res.StatusCode)
 	}
 
-	zap.S().Infof("mode: %s. Console connection: %s", result.Mode, result.ConsoleConnection)
+	zap.S().Infof("mode: %s. Console connection: %s", result.Mode, result.ConsoleConnection.Status)
 	return result, nil
 }
 

--- a/test/e2e/agent/model.go
+++ b/test/e2e/agent/model.go
@@ -4,10 +4,14 @@ type AgentModeRequest struct {
 	Mode string `json:"mode"`
 }
 
+type ConsoleConnectionStatus struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
 type AgentStatus struct {
-	Mode              string `json:"mode"`
-	ConsoleConnection string `json:"console_connection"`
-	Error             string `json:"error,omitempty"`
+	Mode              string                  `json:"mode"`
+	ConsoleConnection ConsoleConnectionStatus `json:"consoleConnection"`
 }
 
 type CollectorStartRequest struct {

--- a/test/e2e/agent/model.go
+++ b/test/e2e/agent/model.go
@@ -14,7 +14,7 @@ type AgentStatus struct {
 	ConsoleConnection ConsoleConnectionStatus `json:"consoleConnection"`
 }
 
-type CollectorStartRequest struct {
+type CredentialsRequest struct {
 	URL      string `json:"url"`
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/test/e2e/e2e_connected.go
+++ b/test/e2e/e2e_connected.go
@@ -110,30 +110,34 @@ var _ = Describe("e2e", func() {
 		It("start collecting only when credentials are valid", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			_, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"", "pass")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
-			_, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"user", "")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
 			// Invalid credentials are now validated eagerly by Store() and rejected synchronously
-			_, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"invalid", "cred")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
 			// Bad URL is also rejected synchronously during credential verification
-			_, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%d/badUrl", config.Cfg.Infra.HostIP, config.Cfg.Infra.Vcsim[0].Port),
+			resCode, err = e2eAgent.Api.PutCredentials(fmt.Sprintf("https://%s:%d/badUrl", config.Cfg.Infra.HostIP, config.Cfg.Infra.Vcsim[0].Port),
 				"user", "pass")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
 			var s *CollectorStatus
-			s, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			s, resCode, err = e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -157,7 +161,11 @@ var _ = Describe("e2e", func() {
 		It("Up to date", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -186,8 +194,12 @@ var _ = Describe("e2e", func() {
 		It("Source removal", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -223,8 +235,12 @@ var _ = Describe("e2e", func() {
 		It("Two agents, Two VSphere's", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -303,8 +319,12 @@ var _ = Describe("e2e", func() {
 				Should(Equal(v1alpha1.AgentStatusWaitingForCredentials))
 
 			// Start collector for Vcsim2
-			s, resCode, err = agent2.Api.StartCollector(config.Cfg.Infra.Vcsim[1].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = agent2.Api.PutCredentials(config.Cfg.Infra.Vcsim[1].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[1].Username, config.Cfg.Infra.Vcsim[1].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err = agent2.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -339,8 +359,12 @@ var _ = Describe("e2e", func() {
 		It("VM reboot", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -424,8 +448,12 @@ var _ = Describe("e2e", func() {
 		It("Test Assessment Endpoints With inventory", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))

--- a/test/e2e/e2e_connected.go
+++ b/test/e2e/e2e_connected.go
@@ -50,7 +50,7 @@ var _ = Describe("e2e", func() {
 		}, "3m", "2s").Should(BeNil())
 		zap.S().Infof("agent ip is: %s", agentIP)
 
-		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 		e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 		zap.S().Infof("agent Api base url: %s", agentApiBaseUrl)
 
@@ -73,7 +73,7 @@ var _ = Describe("e2e", func() {
 			if err != nil {
 				return ""
 			}
-			return s.ConsoleConnection
+			return s.ConsoleConnection.Status
 		}, "3m", "2s").Should(Equal(string(AgentModeConnected)))
 
 		Eventually(func() v1alpha1.AgentStatus {
@@ -265,7 +265,7 @@ var _ = Describe("e2e", func() {
 				return nil
 			}, "3m", "2s").Should(BeNil())
 
-			agent2ApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP2)
+			agent2ApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP2)
 			agent2.Api = DefaultAgentApi(agent2ApiBaseUrl)
 			zap.S().Infof("Agent2 Api base url: %s", agent2ApiBaseUrl)
 
@@ -287,7 +287,7 @@ var _ = Describe("e2e", func() {
 				if err != nil {
 					return ""
 				}
-				return agent2Status.ConsoleConnection
+				return agent2Status.ConsoleConnection.Status
 			}, "1m", "2s").Should(Equal(string(AgentModeConnected)))
 
 			Eventually(func() v1alpha1.AgentStatus {
@@ -376,7 +376,7 @@ var _ = Describe("e2e", func() {
 
 			// wait for the agent API to be up
 			var agentStatus *AgentStatus
-			agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+			agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 			e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 
 			zap.S().Info("Wait for planner-agent to be running...")
@@ -399,7 +399,7 @@ var _ = Describe("e2e", func() {
 				if err != nil {
 					return ""
 				}
-				return agentStatus.ConsoleConnection
+				return agentStatus.ConsoleConnection.Status
 			}, "3m", "2s").Should(Equal(string(AgentModeConnected)))
 
 			// Restart VM should keep the inventory

--- a/test/e2e/e2e_disconnected_env.go
+++ b/test/e2e/e2e_disconnected_env.go
@@ -53,7 +53,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 		}, "3m", "2s").Should(BeNil())
 		zap.S().Infof("agent ip is: %s", agentIP)
 
-		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 		e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 		zap.S().Infof("agent Api base url: %s", agentApiBaseUrl)
 
@@ -113,7 +113,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 
 			statusReply, err := e2eAgent.Api.Status()
 			Expect(err).To(BeNil())
-			Expect(statusReply.ConsoleConnection).To(Equal("disconnected"))
+			Expect(statusReply.ConsoleConnection.Status).To(Equal("disconnected"))
 
 			// agent shouldn't be created in the api
 			so, err := svc.GetSource(source.Id)

--- a/test/e2e/e2e_disconnected_env.go
+++ b/test/e2e/e2e_disconnected_env.go
@@ -96,7 +96,11 @@ var _ = Describe("e2e-disconnected-environment", func() {
 				"bash -c 'echo \"%s vcenter.com\" >> /etc/hosts'", config.Cfg.Infra.HostIP))
 			Expect(err).To(BeNil(), "Failed to enable connection to Vsphere")
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL("vcenter.com"), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL("vcenter.com"), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))


### PR DESCRIPTION
## Summary

Temporary PR to validate the agent v2 fix via CI e2e tests.

- Updates `agent-v2` submodule to include nil EventService guard (kubev2v/assisted-migration-agent#362)
- Cherry-picks e2e test updates to use `/api/v2/` endpoints and updated response models

**Do not merge** — this is for CI validation only. Once e2e passes, the real PRs are:
- Agent fix: https://github.com/kubev2v/assisted-migration-agent/pull/362
- Submodule update: will be a separate PR after the agent fix is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent status reporting now includes structured console connection details, including status and optional error information.
  * Planner-agent endpoints now use the API v2 path.
  * Credentials can be configured separately before starting collection.

* **Bug Fixes**
  * Improved connection-status validation and logging across connected, disconnected, and reboot scenarios.
  * Updated the agent integration to the latest version.
  * Improved handling of collector request errors and credential validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->