### PR TITLE
ECOPROJECT-5111 | fix: update e2e tests and ignition template for agent API v2

### DIFF
--- a/data/ignition.template
+++ b/data/ignition.template
@@ -247,6 +247,7 @@ storage:
         inline: |
           AGENT_SERVER_HTTP_PORT=3333
           AGENT_SERVER_MODE=prod
+          AGENT_API=v2
           AGENT_AUTHENTICATION_ENABLED=true
           AGENT_AUTHENTICATION_JWT_FILEPATH=/app/jwt.json
           AGENT_OPA_POLICIES_FOLDER=/app/policies

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -95,7 +95,7 @@ func (a *AgentApi) Status() (*AgentStatus, error) {
 		return nil, fmt.Errorf(" unexpected response code %d", res.StatusCode)
 	}
 
-	zap.S().Infof("mode: %s. Console connection: %s", result.Mode, result.ConsoleConnection)
+	zap.S().Infof("mode: %s. Console connection: %s", result.Mode, result.ConsoleConnection.Status)
 	return result, nil
 }
 

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -44,13 +44,14 @@ func (a *AgentApi) request(method string, path string, body []byte, result any) 
 
 	queryPath := a.baseURL + path
 
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
 	switch method {
-	case http.MethodGet:
-		req, err = http.NewRequest(http.MethodGet, queryPath, nil)
-	case http.MethodPost:
-		req, err = http.NewRequest(http.MethodPost, queryPath, bytes.NewReader(body))
-	case http.MethodPut:
-		req, err = http.NewRequest(http.MethodPut, queryPath, bytes.NewReader(body))
+	case http.MethodGet, http.MethodPost, http.MethodPut:
+		req, err = http.NewRequest(method, queryPath, bodyReader)
 	default:
 		return nil, fmt.Errorf("unsupported method: %s", method)
 	}
@@ -135,22 +136,31 @@ func (a *AgentApi) SetAgentMode(mode string) (*AgentStatus, error) {
 	return &status, nil
 }
 
-func (a *AgentApi) StartCollector(vcenterURL, username, password string) (*CollectorStatus, int, error) {
-	body := CollectorStartRequest{
+func (a *AgentApi) PutCredentials(vcenterURL, username, password string) (int, error) {
+	body := CredentialsRequest{
 		URL:      vcenterURL,
 		Username: username,
 		Password: password,
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
-		return nil, 1, fmt.Errorf("marshaling request: %w", err)
+		return 0, fmt.Errorf("marshaling request: %w", err)
 	}
 
+	res, err := a.request(http.MethodPut, "credentials", data, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to put credentials: %v", err)
+	}
+
+	return res.StatusCode, nil
+}
+
+func (a *AgentApi) StartCollector() (*CollectorStatus, int, error) {
 	var status CollectorStatus
 
-	res, err := a.request(http.MethodPost, "collector", data, &status)
+	res, err := a.request(http.MethodPost, "collector", nil, &status)
 	if err != nil {
-		return nil, 1, fmt.Errorf("failed to start collector: %v", err)
+		return nil, 0, fmt.Errorf("failed to start collector: %v", err)
 	}
 
 	return &status, res.StatusCode, nil

--- a/test/e2e/agent/agent_api.go
+++ b/test/e2e/agent/agent_api.go
@@ -57,7 +57,7 @@ func (a *AgentApi) request(method string, path string, body []byte, result any) 
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %v", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -65,18 +65,18 @@ func (a *AgentApi) request(method string, path string, body []byte, result any) 
 	zap.S().Infof("[Agent-API] %s [Method: %s]", req.URL.String(), req.Method)
 	res, err := a.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error getting response from local server: %v", err)
+		return nil, fmt.Errorf("error getting response from local server: %w", err)
 	}
 	defer func() { _ = res.Body.Close() }()
 
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error reading response body: %v", err)
+		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
 	if result != nil {
 		if err := json.Unmarshal(resBody, &result); err != nil {
-			return nil, fmt.Errorf("error decoding JSON: %v", err)
+			return nil, fmt.Errorf("error decoding JSON: %w", err)
 		}
 	}
 
@@ -88,7 +88,7 @@ func (a *AgentApi) Status() (*AgentStatus, error) {
 	result := &AgentStatus{}
 	res, err := a.request(http.MethodGet, "agent", nil, result)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get status: %v", err)
+		return nil, fmt.Errorf("failed to get status: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -105,7 +105,7 @@ func (a *AgentApi) Inventory() (*v1alpha1.Inventory, error) {
 
 	res, err := a.request(http.MethodGet, "inventory", nil, &inv)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get inventory: %v", err)
+		return nil, fmt.Errorf("failed to get inventory: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -126,7 +126,7 @@ func (a *AgentApi) SetAgentMode(mode string) (*AgentStatus, error) {
 
 	res, err := a.request(http.MethodPost, "agent", data, &status)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set agent mode: %v", err)
+		return nil, fmt.Errorf("failed to set agent mode: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -149,7 +149,7 @@ func (a *AgentApi) PutCredentials(vcenterURL, username, password string) (int, e
 
 	res, err := a.request(http.MethodPut, "credentials", data, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to put credentials: %v", err)
+		return 0, fmt.Errorf("failed to put credentials: %w", err)
 	}
 
 	return res.StatusCode, nil
@@ -160,7 +160,7 @@ func (a *AgentApi) StartCollector() (*CollectorStatus, int, error) {
 
 	res, err := a.request(http.MethodPost, "collector", nil, &status)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to start collector: %v", err)
+		return nil, 0, fmt.Errorf("failed to start collector: %w", err)
 	}
 
 	return &status, res.StatusCode, nil
@@ -171,7 +171,7 @@ func (a *AgentApi) GetCollectorStatus() (*CollectorStatus, error) {
 
 	res, err := a.request(http.MethodGet, "collector", nil, &status)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get collector status: %v", err)
+		return nil, fmt.Errorf("failed to get collector status: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/test/e2e/agent/agent_api_test.go
+++ b/test/e2e/agent/agent_api_test.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPutCredentials(t *testing.T) {
+	var gotMethod string
+	var gotPath string
+	var gotBody CredentialsRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	api := NewAgentApi(server.URL+"/", server.Client())
+	statusCode, err := api.PutCredentials("https://vcenter.example.com", "admin", "secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("expected method PUT, got %s", gotMethod)
+	}
+	if gotPath != "/credentials" {
+		t.Errorf("expected path /credentials, got %s", gotPath)
+	}
+	if statusCode != http.StatusNoContent {
+		t.Errorf("expected status %d, got %d", http.StatusNoContent, statusCode)
+	}
+	if gotBody.URL != "https://vcenter.example.com" {
+		t.Errorf("expected URL %q, got %q", "https://vcenter.example.com", gotBody.URL)
+	}
+	if gotBody.Username != "admin" {
+		t.Errorf("expected username %q, got %q", "admin", gotBody.Username)
+	}
+	if gotBody.Password != "secret" {
+		t.Errorf("expected password %q, got %q", "secret", gotBody.Password)
+	}
+}
+
+func TestStartCollector(t *testing.T) {
+	var gotMethod string
+	var gotPath string
+	var gotBodyBytes []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBodyBytes, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"collected"}`))
+	}))
+	defer server.Close()
+
+	api := NewAgentApi(server.URL+"/", server.Client())
+	status, statusCode, err := api.StartCollector()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected method POST, got %s", gotMethod)
+	}
+	if gotPath != "/collector" {
+		t.Errorf("expected path /collector, got %s", gotPath)
+	}
+	if len(gotBodyBytes) != 0 {
+		t.Errorf("expected empty request body, got %q", string(gotBodyBytes))
+	}
+	if statusCode != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, statusCode)
+	}
+	if status.Status != "collected" {
+		t.Errorf("expected status %q, got %q", "collected", status.Status)
+	}
+}

--- a/test/e2e/agent/model.go
+++ b/test/e2e/agent/model.go
@@ -10,7 +10,7 @@ type AgentStatus struct {
 	Error             string `json:"error,omitempty"`
 }
 
-type CollectorStartRequest struct {
+type CredentialsRequest struct {
 	URL      string `json:"url"`
 	Username string `json:"username"`
 	Password string `json:"password"`

--- a/test/e2e/agent/model.go
+++ b/test/e2e/agent/model.go
@@ -4,10 +4,14 @@ type AgentModeRequest struct {
 	Mode string `json:"mode"`
 }
 
+type ConsoleConnectionStatus struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
 type AgentStatus struct {
-	Mode              string `json:"mode"`
-	ConsoleConnection string `json:"console_connection"`
-	Error             string `json:"error,omitempty"`
+	Mode              string                  `json:"mode"`
+	ConsoleConnection ConsoleConnectionStatus `json:"consoleConnection"`
 }
 
 type CredentialsRequest struct {

--- a/test/e2e/e2e_connected.go
+++ b/test/e2e/e2e_connected.go
@@ -110,30 +110,34 @@ var _ = Describe("e2e", func() {
 		It("start collecting only when credentials are valid", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			_, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"", "pass")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
-			_, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"user", "")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
 			// Invalid credentials are now validated eagerly by Store() and rejected synchronously
-			_, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				"invalid", "cred")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
 			// Bad URL is also rejected synchronously during credential verification
-			_, resCode, err = e2eAgent.Api.StartCollector(fmt.Sprintf("https://%s:%d/badUrl", config.Cfg.Infra.HostIP, config.Cfg.Infra.Vcsim[0].Port),
+			resCode, err = e2eAgent.Api.PutCredentials(fmt.Sprintf("https://%s:%d/badUrl", config.Cfg.Infra.HostIP, config.Cfg.Infra.Vcsim[0].Port),
 				"user", "pass")
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusBadRequest))
 
+			resCode, err = e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
 			var s *CollectorStatus
-			s, resCode, err = e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			s, resCode, err = e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -157,7 +161,11 @@ var _ = Describe("e2e", func() {
 		It("Up to date", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -186,8 +194,12 @@ var _ = Describe("e2e", func() {
 		It("Source removal", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -223,8 +235,12 @@ var _ = Describe("e2e", func() {
 		It("Two agents, Two VSphere's", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -303,8 +319,12 @@ var _ = Describe("e2e", func() {
 				Should(Equal(v1alpha1.AgentStatusWaitingForCredentials))
 
 			// Start collector for Vcsim2
-			s, resCode, err = agent2.Api.StartCollector(config.Cfg.Infra.Vcsim[1].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err = agent2.Api.PutCredentials(config.Cfg.Infra.Vcsim[1].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[1].Username, config.Cfg.Infra.Vcsim[1].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err = agent2.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -339,8 +359,12 @@ var _ = Describe("e2e", func() {
 		It("VM reboot", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
@@ -424,8 +448,12 @@ var _ = Describe("e2e", func() {
 		It("Test Assessment Endpoints With inventory", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL(config.Cfg.Infra.HostIP),
 				config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))

--- a/test/e2e/e2e_connected.go
+++ b/test/e2e/e2e_connected.go
@@ -330,7 +330,7 @@ var _ = Describe("e2e", func() {
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))
 
 			Eventually(func() string {
-				s, err = e2eAgent.Api.GetCollectorStatus()
+				s, err = agent2.Api.GetCollectorStatus()
 				if err != nil {
 					return ""
 				}

--- a/test/e2e/e2e_connected.go
+++ b/test/e2e/e2e_connected.go
@@ -50,7 +50,7 @@ var _ = Describe("e2e", func() {
 		}, "3m", "2s").Should(BeNil())
 		zap.S().Infof("agent ip is: %s", agentIP)
 
-		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 		e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 		zap.S().Infof("agent Api base url: %s", agentApiBaseUrl)
 
@@ -73,7 +73,7 @@ var _ = Describe("e2e", func() {
 			if err != nil {
 				return ""
 			}
-			return s.ConsoleConnection
+			return s.ConsoleConnection.Status
 		}, "3m", "2s").Should(Equal(string(AgentModeConnected)))
 
 		Eventually(func() v1alpha1.AgentStatus {
@@ -281,7 +281,7 @@ var _ = Describe("e2e", func() {
 				return nil
 			}, "3m", "2s").Should(BeNil())
 
-			agent2ApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP2)
+			agent2ApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP2)
 			agent2.Api = DefaultAgentApi(agent2ApiBaseUrl)
 			zap.S().Infof("Agent2 Api base url: %s", agent2ApiBaseUrl)
 
@@ -303,7 +303,7 @@ var _ = Describe("e2e", func() {
 				if err != nil {
 					return ""
 				}
-				return agent2Status.ConsoleConnection
+				return agent2Status.ConsoleConnection.Status
 			}, "1m", "2s").Should(Equal(string(AgentModeConnected)))
 
 			Eventually(func() v1alpha1.AgentStatus {
@@ -400,7 +400,7 @@ var _ = Describe("e2e", func() {
 
 			// wait for the agent API to be up
 			var agentStatus *AgentStatus
-			agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+			agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 			e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 
 			zap.S().Info("Wait for planner-agent to be running...")
@@ -423,7 +423,7 @@ var _ = Describe("e2e", func() {
 				if err != nil {
 					return ""
 				}
-				return agentStatus.ConsoleConnection
+				return agentStatus.ConsoleConnection.Status
 			}, "3m", "2s").Should(Equal(string(AgentModeConnected)))
 
 			// Restart VM should keep the inventory

--- a/test/e2e/e2e_disconnected_env.go
+++ b/test/e2e/e2e_disconnected_env.go
@@ -96,7 +96,11 @@ var _ = Describe("e2e-disconnected-environment", func() {
 				"bash -c 'echo \"%s vcenter.com\" >> /etc/hosts'", config.Cfg.Infra.HostIP))
 			Expect(err).To(BeNil(), "Failed to enable connection to Vsphere")
 
-			s, resCode, err := e2eAgent.Api.StartCollector(config.Cfg.Infra.Vcsim[0].SdkURL("vcenter.com"), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			resCode, err := e2eAgent.Api.PutCredentials(config.Cfg.Infra.Vcsim[0].SdkURL("vcenter.com"), config.Cfg.Infra.Vcsim[0].Username, config.Cfg.Infra.Vcsim[0].Password)
+			Expect(err).To(BeNil())
+			Expect(resCode).To(Equal(http.StatusOK))
+
+			s, resCode, err := e2eAgent.Api.StartCollector()
 			Expect(err).To(BeNil())
 			Expect(resCode).To(Equal(http.StatusAccepted))
 			Expect(s.Status).ToNot(Equal(CollectorStatusError))

--- a/test/e2e/e2e_disconnected_env.go
+++ b/test/e2e/e2e_disconnected_env.go
@@ -53,7 +53,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 		}, "3m", "2s").Should(BeNil())
 		zap.S().Infof("agent ip is: %s", agentIP)
 
-		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v1/", agentIP)
+		agentApiBaseUrl := fmt.Sprintf("https://%s:3333/api/v2/", agentIP)
 		e2eAgent.Api = DefaultAgentApi(agentApiBaseUrl)
 		zap.S().Infof("agent Api base url: %s", agentApiBaseUrl)
 
@@ -117,7 +117,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 
 			statusReply, err := e2eAgent.Api.Status()
 			Expect(err).To(BeNil())
-			Expect(statusReply.ConsoleConnection).To(Equal("disconnected"))
+			Expect(statusReply.ConsoleConnection.Status).To(Equal("disconnected"))
 
 			// agent shouldn't be created in the api
 			so, err := svc.GetSource(source.Id)


### PR DESCRIPTION
  ## Summary

  The agent submodule now defaults to API v2, which changes both the endpoint
  paths and the credential/collector workflow. This PR updates the planner side
  to match:

  - **Ignition template**: add `AGENT_API=v2` to agent env so the VM agent
    serves `/api/v2` endpoints
  - **E2e test URLs**: switch base URL from `/api/v1/` to `/api/v2/`
  - **E2e test models**: update `AgentStatus.ConsoleConnection` from a plain
  - **E2e collector flow**: v2 separates credential storage from collector start —
    credentials are now stored via `PUT /credentials` before calling
    `POST /collector` (which takes no body). Updated the `AgentApi` helper and
    all test call sites accordingly.
  - **Agent submodule**: updated to include the default-status fix for the
    console connection loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Agent API v2.
  - Credentials can now be stored separately before starting data collection.
  - Collection startup now provides clearer status and response information.

- **Bug Fixes**
  - Improved console connection status reporting, including optional error details.
  - Updated end-to-end workflows to validate invalid, incomplete, and valid credentials consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->