### PR TITLE
ECOPROJECT-5213 | fix: Deadlock between collector mutex and tx

### DIFF
--- a/pkg/store/interceptor.go
+++ b/pkg/store/interceptor.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"database/sql"
-	"sync"
 
 	"go.uber.org/zap"
 )
@@ -26,7 +25,6 @@ type QueryInterceptor interface {
 type queryInterceptor struct {
 	db     *sql.DB
 	logger *zap.SugaredLogger
-	mu     sync.Mutex
 }
 
 func NewQueryInterceptor(db *sql.DB) QueryInterceptor {
@@ -59,13 +57,6 @@ func (q *queryInterceptor) QueryContext(ctx context.Context, query string, args 
 }
 
 func (q *queryInterceptor) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	// Serialize all exec calls to satisfy DuckDB's single-connection constraint.
-	// DuckDB only allows one write operation at a time on a single connection.
-	// Without this mutex, concurrent ExecContext calls would fail with "database is locked" errors.
-	// This represents a concurrency bottleneck but is required for DuckDB correctness.
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
 	q.logger.Debugw("exec", "query", query, "args", args)
 
 	tx, ok := q.txFromContext(ctx)


### PR DESCRIPTION
Deadlock between queryInterceptor.ExecContext mutex and *sql.DB connection pool (MaxOpenConns(1)).

ExecContext held q.mu for the entire method, including FORCE CHECKPOINT which needed a pool connection. When a concurrent BeginTx grabbed the only connection between the main query returning and CHECKPOINT requesting one, neither side could proceed: CHECKPOINT held the mutex waiting for a connection, and the tx held the connection waiting for the mutex.

Fix: remove the mutex entirely — MaxOpenConns(1) already serializes access at the pool level.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved concurrent query execution by removing unnecessary serialization between execution calls.
  * Query routing, checkpointing, and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->