### PR TITLE
ECOPROJECT-5215 | feat: implement mechanism to send events to notification service

### DIFF
--- a/cmd/planner-api/backfill.go
+++ b/cmd/planner-api/backfill.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/handlers/v1alpha1/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -57,7 +57,7 @@ var backfillCmd = &cobra.Command{
 	},
 }
 
-func backfillAssessments(ctx context.Context, s store.Store, writer events.Writer, writerClose func()) error {
+func backfillAssessments(ctx context.Context, s store.Store, writer kafka.Writer, writerClose func()) error {
 	defer writerClose()
 
 	assessments, err := s.Assessment().List(ctx, nil)
@@ -94,7 +94,7 @@ func backfillAssessments(ctx context.Context, s store.Store, writer events.Write
 			continue
 		}
 
-		payload := events.NewAssessmentCreatedPayload(events.AssessmentData{
+		payload := kafka.NewAssessmentCreatedPayload(kafka.AssessmentData{
 			ID:         assessment.ID.String(),
 			SnapshotID: assessment.Snapshots[0].ID,
 			Inventory:  inventory,
@@ -107,14 +107,14 @@ func backfillAssessments(ctx context.Context, s store.Store, writer events.Write
 			UpdatedAt:  assessment.UpdatedAt,
 		})
 
-		ceBytes, err := events.BuildCloudEvent(events.AssessmentCreatedEventType, payload)
+		ceBytes, err := kafka.BuildCloudEvent(kafka.AssessmentCreatedEventType, payload)
 		if err != nil {
 			zap.S().Errorw("building cloud event", "id", assessment.ID, "error", err)
 			eventBuildErrors++
 			continue
 		}
 
-		if err := writer.Write(ctx, events.GenericTopic, ceBytes); err != nil {
+		if err := writer.Write(ctx, kafka.GenericTopic, ceBytes); err != nil {
 			zap.S().Errorw("publishing event", "id", assessment.ID, "error", err)
 			publishErrors++
 			continue

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -26,7 +26,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/migrations"
 	"github.com/kubev2v/migration-planner/pkg/version"
@@ -98,7 +99,7 @@ var runCmd = &cobra.Command{
 		var wg sync.WaitGroup // Responsible for keeping the main thread waiting for all goroutines to shut down gracefully
 
 		// Create Kafka producer and event writer
-		var writer events.Writer = events.NewNoOpWriter()
+		var writer kafka.Writer = kafka.NewNoOpWriter()
 
 		if cfg.Kafka.Enabled {
 			var cleanup func()
@@ -111,7 +112,8 @@ var runCmd = &cobra.Command{
 		}
 
 		// Start outbox dispatcher
-		dispatcher := eventwrap.NewOutboxDispatcher(store, writer, 5*time.Second)
+		notifier := createNotificationWriter(cfg)
+		dispatcher := eventwrap.NewOutboxDispatcher(store, writer, notifier, 5*time.Second)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -178,7 +180,7 @@ func newListener(address string) (net.Listener, error) {
 	return net.Listen("tcp", address)
 }
 
-func createEventWriter(ctx context.Context, cfg *config.Config) (events.Writer, func(), error) {
+func createEventWriter(ctx context.Context, cfg *config.Config) (kafka.Writer, func(), error) {
 	brokers := strings.Split(cfg.Kafka.Brokers, ",")
 	var kafkaOpts []kgo.Opt
 
@@ -196,9 +198,9 @@ func createEventWriter(ctx context.Context, cfg *config.Config) (events.Writer, 
 
 	noop := func() {}
 
-	producer, err := events.NewKafkaProducer(brokers, kafkaOpts...)
+	producer, err := kafka.NewKafkaProducer(brokers, kafkaOpts...)
 	if err != nil {
-		return events.NewNoOpWriter(), noop, err
+		return kafka.NewNoOpWriter(), noop, err
 	}
 
 	pingCtx, pingCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -206,12 +208,32 @@ func createEventWriter(ctx context.Context, cfg *config.Config) (events.Writer, 
 
 	if err := producer.Ping(pingCtx); err != nil {
 		producer.Close()
-		return events.NewNoOpWriter(), noop, fmt.Errorf("kafka broker unreachable: %w", err)
+		return kafka.NewNoOpWriter(), noop, fmt.Errorf("kafka broker unreachable: %w", err)
 	}
 
 	zap.S().Infow("kafka producer connected", "brokers", cfg.Kafka.Brokers)
 
 	return producer, producer.Close, nil
+}
+
+func createNotificationWriter(cfg *config.Config) notification.Writer {
+	if cfg.Notification.ClientCert == "" || cfg.Notification.ClientKey == "" {
+		zap.S().Info("notification service client certificate not configured, logging notifications to stdout")
+		return notification.NewStdoutWriter()
+	}
+
+	writer, err := notification.NewHTTPWriter(
+		cfg.Notification.URL,
+		[]byte(cfg.Notification.ClientCert),
+		[]byte(cfg.Notification.ClientKey),
+	)
+	if err != nil {
+		zap.S().Warnw("failed to create notification service client, logging notifications to stdout", "error", err)
+		return notification.NewStdoutWriter()
+	}
+
+	zap.S().Infow("notification service client initialized", "url", cfg.Notification.URL)
+	return writer
 }
 
 func ensureIsoExist(path string) error {

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -68,6 +68,19 @@ parameters:
   - name: KAFKA_PASSWORD_SECRET_KEY
     description: Key in the credentials secret for the password
     value: "password"
+  # Notification service config values
+  - name: NOTIFICATION_URL
+    description: URL of the console notifications service
+    value: "https://mtls.internal.cloud.stage.redhat.com/api/notifications-gw/notifications"
+  - name: NOTIFICATION_CERT_SECRET_NAME
+    description: Kubernetes secret containing the notification service mTLS client certificate and key
+    value: "notifications-cert"
+  - name: NOTIFICATION_CLIENT_CERT_SECRET_KEY
+    description: Key in the notification cert secret for the client certificate (PEM)
+    value: "notifications.crt"
+  - name: NOTIFICATION_CLIENT_KEY_SECRET_KEY
+    description: Key in the notification cert secret for the client private key (PEM)
+    value: "notifications.key"
   - name: PERSISTENT_DISK_DEVICE
     value: /dev/sda
   - name: INSECURE_REGISTRY
@@ -766,6 +779,21 @@ objects:
                     secretKeyRef:
                       name: ${KAFKA_CREDENTIALS_SECRET_NAME}
                       key: ${KAFKA_PASSWORD_SECRET_KEY}
+                      optional: true
+                # Notification service config values
+                - name: NOTIFICATION_URL
+                  value: "${NOTIFICATION_URL}"
+                - name: NOTIFICATION_CLIENT_CERT
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NOTIFICATION_CERT_SECRET_NAME}
+                      key: ${NOTIFICATION_CLIENT_CERT_SECRET_KEY}
+                      optional: true
+                - name: NOTIFICATION_CLIENT_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NOTIFICATION_CERT_SECRET_NAME}
+                      key: ${NOTIFICATION_CLIENT_KEY_SECRET_KEY}
                       optional: true
               volumeMounts:
                 - name: migration-planner-dir

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,9 +7,10 @@ import (
 var singleConfig *Config = nil
 
 type Config struct {
-	Database *dbConfig
-	Service  *svcConfig
-	Kafka    *Kafka
+	Database     *dbConfig
+	Service      *svcConfig
+	Kafka        *Kafka
+	Notification *Notification
 }
 
 type dbConfig struct {
@@ -55,6 +56,16 @@ type Kafka struct {
 	SASLUsername string `envconfig:"KAFKA_SASL_USERNAME" default:""`
 	SASLPassword string `envconfig:"KAFKA_SASL_PASSWORD" default:""`
 	UseTLS       bool   `envconfig:"KAFKA_USE_TLS" default:"false"`
+}
+
+// Notification configures the mTLS client used to deliver notifications to
+// the console notifications service. ClientCert/ClientKey are PEM-encoded
+// and are expected to be sourced from a Kubernetes secret; when either is
+// unset, notifications fall back to being logged to stdout.
+type Notification struct {
+	URL        string `envconfig:"NOTIFICATION_URL" default:""`
+	ClientCert string `envconfig:"NOTIFICATION_CLIENT_CERT" default:""`
+	ClientKey  string `envconfig:"NOTIFICATION_CLIENT_KEY" default:""`
 }
 
 func New() (*Config, error) {

--- a/internal/handlers/v1alpha1/image.go
+++ b/internal/handlers/v1alpha1/image.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
 	"github.com/kubev2v/migration-planner/pkg/version"
 	"go.uber.org/zap"
@@ -121,11 +121,11 @@ func (h *ImageHandler) GetImageByToken(ctx context.Context, req imageServer.GetI
 
 	metrics.IncreaseOvaDownloadsTotalMetric("successful")
 
-	payload := events.NewOVADownloadPayload(source.Username, source.ID.String())
-	ceBytes, err := events.BuildCloudEvent(events.DownloadOVAEventType, payload)
+	payload := kafka.NewOVADownloadPayload(source.Username, source.ID.String())
+	ceBytes, err := kafka.BuildCloudEvent(kafka.DownloadOVAEventType, payload)
 	if err != nil {
 		zap.S().Warnw("failed to build download event", "source_id", source.ID, "error", err)
-	} else if err := h.outbox.Insert(ctx, events.DownloadOVAEventType, ceBytes); err != nil {
+	} else if err := h.outbox.Insert(ctx, kafka.DownloadOVAEventType, ceBytes); err != nil {
 		zap.S().Warnw("failed to write download event to outbox", "source_id", source.ID, "error", err)
 	}
 

--- a/internal/rvtools/jobs/worker.go
+++ b/internal/rvtools/jobs/worker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
 	"github.com/kubev2v/migration-planner/pkg/duckdb_parser"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 	"github.com/kubev2v/migration-planner/pkg/inventory/converters"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	pkgstore "github.com/kubev2v/migration-planner/pkg/store"
@@ -180,7 +180,7 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 		logger.Error(err).WithString("step", "update_completed_status").Log()
 	}
 
-	cePayload := events.NewAssessmentCreatedPayload(events.AssessmentData{
+	cePayload := kafka.NewAssessmentCreatedPayload(kafka.AssessmentData{
 		ID:         createdAssessment.ID.String(),
 		SnapshotID: createdAssessment.Snapshots[0].ID,
 		Inventory:  createdAssessment.Snapshots[0].Inventory,
@@ -191,11 +191,11 @@ func (w *RVToolsWorker) Work(ctx context.Context, job *river.Job[RVToolsJobArgs]
 		CreatedAt:  createdAssessment.CreatedAt,
 		UpdatedAt:  createdAssessment.UpdatedAt,
 	})
-	ceBytes, err := events.BuildCloudEvent(events.AssessmentCreatedEventType, cePayload)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.AssessmentCreatedEventType, cePayload)
 	if err != nil {
 		return fmt.Errorf("failed to build outbox event: %w", err)
 	}
-	if err := w.store.Outbox().Insert(ctx, model.OutboxEvent{EventType: events.AssessmentCreatedEventType, Payload: ceBytes}); err != nil {
+	if err := w.store.Outbox().Insert(ctx, model.OutboxEvent{EventType: kafka.AssessmentCreatedEventType, Payload: ceBytes}); err != nil {
 		return fmt.Errorf("failed to write outbox event: %w", err)
 	}
 

--- a/internal/service/assessment_test.go
+++ b/internal/service/assessment_test.go
@@ -17,7 +17,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 )
 
 const (
@@ -77,7 +78,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			}
 
 			var count int64
-			gormdb.Raw(countOutboxByTypeStm, events.VisitorEventType).Scan(&count)
+			gormdb.Raw(countOutboxByTypeStm, kafka.VisitorEventType).Scan(&count)
 			Expect(count).To(Equal(int64(1)))
 		})
 
@@ -226,7 +227,7 @@ var _ = Describe("assessment service", Ordered, func() {
 				Expect(*assessment.OwnerLastName).To(Equal("Johnson"))
 
 				var count int64
-				gormdb.Raw(countOutboxByTypeStm, events.AssessmentCreatedEventType).Scan(&count)
+				gormdb.Raw(countOutboxByTypeStm, kafka.AssessmentCreatedEventType).Scan(&count)
 				Expect(count).To(Equal(int64(1)))
 			})
 
@@ -458,6 +459,95 @@ var _ = Describe("assessment service", Ordered, func() {
 				tx = gormdb.Raw("SELECT version FROM snapshots WHERE assessment_id = ?", testAssessmentID).Scan(&snapshotVersion)
 				Expect(tx.Error).To(BeNil())
 				Expect(snapshotVersion).To(Equal(2)) // V2
+			})
+		})
+
+		Context("notification for assessments created on behalf of a customer", func() {
+			AfterEach(func() {
+				gormdb.Exec("DELETE FROM members;")
+				gormdb.Exec("DELETE FROM groups;")
+			})
+
+			DescribeTable("emits a notification event when the creator is a partner or admin",
+				func(groupKind string) {
+					groupID := uuid.New()
+					tx := gormdb.Exec(fmt.Sprintf("INSERT INTO groups (id, name, description, kind, icon, company, parent_id) VALUES ('%s', 'Group', 'desc', '%s', 'icon', 'Acme', NULL);", groupID, groupKind))
+					Expect(tx.Error).To(BeNil())
+					tx = gormdb.Exec(fmt.Sprintf("INSERT INTO members (id, username, email, group_id) VALUES ('%s', 'creator1', 'creator1@test.com', '%s');", uuid.New(), groupID))
+					Expect(tx.Error).To(BeNil())
+
+					inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+						VcenterId: "test-vcenter",
+						Vcenter: &v1alpha1.InventoryData{
+							Vms:   v1alpha1.VMs{Total: 10},
+							Infra: v1alpha1.Infra{TotalHosts: 5},
+						},
+					})
+
+					testAssessmentID := uuid.New()
+					createForm := mappers.AssessmentCreateForm{
+						ID:        testAssessmentID,
+						Name:      "Assessment For Customer",
+						OrgID:     "org1",
+						Username:  "customer1",
+						Source:    service.SourceTypeInventory,
+						Inventory: inventoryJSON,
+					}
+
+					ctx := ctxWithUser("creator1", "org1")
+					assessment, err := svc.CreateAssessment(ctx, createForm)
+					Expect(err).To(BeNil())
+					Expect(assessment).ToNot(BeNil())
+
+					var count int64
+					gormdb.Raw(countOutboxByTypeStm, notification.AssessmentCreatedEventType).Scan(&count)
+					Expect(count).To(Equal(int64(1)))
+
+					var payload string
+					tx = gormdb.Raw("SELECT payload FROM outbox_events WHERE event_type = ?", notification.AssessmentCreatedEventType).Scan(&payload)
+					Expect(tx.Error).To(BeNil())
+
+					var n notification.Notification
+					Expect(json.Unmarshal([]byte(payload), &n)).To(Succeed())
+					Expect(n.EventType).To(Equal(notification.AssessmentCreatedEventType))
+					Expect(n.OrgID).To(Equal("org1"))
+					Expect(n.Context["assessment_id"]).To(Equal(testAssessmentID.String()))
+					Expect(n.Recipients).To(HaveLen(1))
+					Expect(n.Recipients[0].Users).To(ConsistOf("customer1"))
+					Expect(n.Recipients[0].IgnoreUserPreferences).To(BeTrue())
+
+					Expect(n.Events).To(HaveLen(1))
+				},
+				Entry("creator is a partner", "partner"),
+				Entry("creator is an admin", "admin"),
+			)
+
+			It("does not emit a notification event when the creator is a regular authenticated user", func() {
+				inventoryJSON, _ := json.Marshal(v1alpha1.Inventory{
+					VcenterId: "test-vcenter",
+					Vcenter: &v1alpha1.InventoryData{
+						Vms:   v1alpha1.VMs{Total: 10},
+						Infra: v1alpha1.Infra{TotalHosts: 5},
+					},
+				})
+
+				createForm := mappers.AssessmentCreateForm{
+					ID:        uuid.New(),
+					Name:      "Assessment By Regular User",
+					OrgID:     "org1",
+					Username:  "regular-user",
+					Source:    service.SourceTypeInventory,
+					Inventory: inventoryJSON,
+				}
+
+				ctx := ctxWithUser("regular-user", "org1")
+				assessment, err := svc.CreateAssessment(ctx, createForm)
+				Expect(err).To(BeNil())
+				Expect(assessment).ToNot(BeNil())
+
+				var count int64
+				gormdb.Raw(countOutboxByTypeStm, notification.AssessmentCreatedEventType).Scan(&count)
+				Expect(count).To(Equal(int64(0)))
 			})
 		})
 
@@ -748,7 +838,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			Expect(count).To(Equal(0))
 
 			var outboxCount int64
-			gormdb.Raw(countOutboxByTypeStm, events.AssessmentDeletedEventType).Scan(&outboxCount)
+			gormdb.Raw(countOutboxByTypeStm, kafka.AssessmentDeletedEventType).Scan(&outboxCount)
 			Expect(outboxCount).To(Equal(int64(1)))
 		})
 
@@ -984,8 +1074,23 @@ var _ = Describe("assessment service", Ordered, func() {
 			Expect(count).To(Equal(int64(1)))
 
 			var outboxCount int64
-			gormdb.Raw(countOutboxByTypeStm, events.ShareAssessmentEventType).Scan(&outboxCount)
+			gormdb.Raw(countOutboxByTypeStm, kafka.ShareAssessmentEventType).Scan(&outboxCount)
 			Expect(outboxCount).To(Equal(int64(1)))
+
+			gormdb.Raw(countOutboxByTypeStm, notification.AssessmentSharedEventType).Scan(&outboxCount)
+			Expect(outboxCount).To(Equal(int64(1)))
+
+			var payload string
+			tx = gormdb.Raw("SELECT payload FROM outbox_events WHERE event_type = ?", notification.AssessmentSharedEventType).Scan(&payload)
+			Expect(tx.Error).To(BeNil())
+
+			var n notification.Notification
+			Expect(json.Unmarshal([]byte(payload), &n)).To(Succeed())
+			Expect(n.EventType).To(Equal(notification.AssessmentSharedEventType))
+			Expect(n.Context["assessment_id"]).To(Equal(assessmentID.String()))
+			Expect(n.Recipients).To(HaveLen(1))
+			Expect(n.Recipients[0].OnlyAdmins).To(BeTrue())
+			Expect(n.Recipients[0].IgnoreUserPreferences).To(BeTrue())
 		})
 
 		It("is idempotent — sharing twice does not error", func() {
@@ -1074,7 +1179,7 @@ var _ = Describe("assessment service", Ordered, func() {
 			Expect(count).To(Equal(int64(0)))
 
 			var outboxCount int64
-			gormdb.Raw(countOutboxByTypeStm, events.UnshareAssessmentEventType).Scan(&outboxCount)
+			gormdb.Raw(countOutboxByTypeStm, kafka.UnshareAssessmentEventType).Scan(&outboxCount)
 			Expect(outboxCount).To(Equal(int64(1)))
 		})
 

--- a/internal/service/estimation_test.go
+++ b/internal/service/estimation_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/store/model"
 	"github.com/kubev2v/migration-planner/pkg/estimations/engines"
 	"github.com/kubev2v/migration-planner/pkg/estimations/estimation"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -248,7 +248,7 @@ var _ = Describe("EstimationService", func() {
 				Expect(result.ComplexityByOS).To(HaveLen(5))
 				Expect(result.ComplexityByDisk).To(HaveLen(4))
 
-				outboxCount := countOutboxEventsByType(mockStore.outboxEvents, events.MigrationComplexityEventType)
+				outboxCount := countOutboxEventsByType(mockStore.outboxEvents, kafka.MigrationComplexityEventType)
 				Expect(outboxCount).To(Equal(1))
 			})
 
@@ -597,7 +597,7 @@ var _ = Describe("EstimationService", func() {
 				Expect(results[engines.SchemaNetworkBased].MaxTotalDuration).To(BeNumerically(">=", results[engines.SchemaNetworkBased].MinTotalDuration))
 				Expect(results[engines.SchemaNetworkBased].Breakdown).NotTo(BeEmpty())
 
-				outboxCount := countOutboxEventsByType(mockStore.outboxEvents, events.MigrationTimeEstimationEventType)
+				outboxCount := countOutboxEventsByType(mockStore.outboxEvents, kafka.MigrationTimeEstimationEventType)
 				Expect(outboxCount).To(Equal(1))
 			})
 

--- a/internal/service/eventwrap/dispatcher.go
+++ b/internal/service/eventwrap/dispatcher.go
@@ -5,20 +5,31 @@ import (
 	"time"
 
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 	"go.uber.org/zap"
 )
 
 type OutboxDispatcher struct {
 	store    store.Store
-	writer   events.Writer
+	writer   kafka.Writer
+	notifier notification.Writer
 	interval time.Duration
 }
 
-func NewOutboxDispatcher(s store.Store, writer events.Writer, interval time.Duration) *OutboxDispatcher {
+type writerType int
+
+const (
+	writerTypeUnknown writerType = iota
+	writerTypeKafka
+	writerTypeNotification
+)
+
+func NewOutboxDispatcher(s store.Store, writer kafka.Writer, notifier notification.Writer, interval time.Duration) *OutboxDispatcher {
 	return &OutboxDispatcher{
 		store:    s,
 		writer:   writer,
+		notifier: notifier,
 		interval: interval,
 	}
 }
@@ -59,7 +70,18 @@ func (d *OutboxDispatcher) processBatch(ctx context.Context) {
 
 	var published []int
 	for _, outboxEvent := range outboxEvents {
-		if err := d.writer.Write(ctx, events.GenericTopic, outboxEvent.Payload); err != nil {
+		var err error
+		switch writerTypeForEventType(outboxEvent.EventType) {
+		case writerTypeKafka:
+			err = d.writer.Write(ctx, kafka.GenericTopic, outboxEvent.Payload)
+		case writerTypeNotification:
+			err = d.notifier.Write(ctx, outboxEvent.Payload)
+		default:
+			zap.S().Errorw("outbox dispatcher: no writer registered for event type, will retry",
+				"id", outboxEvent.ID, "event_type", outboxEvent.EventType)
+			continue
+		}
+		if err != nil {
 			zap.S().Errorw("outbox dispatcher: failed to write event, will retry",
 				"id", outboxEvent.ID, "event_type", outboxEvent.EventType, "error", err)
 			continue
@@ -73,5 +95,22 @@ func (d *OutboxDispatcher) processBatch(ctx context.Context) {
 
 	if _, err := store.Commit(ctx); err != nil {
 		zap.S().Errorw("outbox dispatcher: failed to commit transaction", "error", err)
+	}
+}
+
+// writerTypeForEventType classifies an outbox event type so the dispatcher
+// knows which writer to hand it to.
+func writerTypeForEventType(eventType string) writerType {
+	switch eventType {
+	case kafka.AssessmentCreatedEventType, kafka.AssessmentDeletedEventType, kafka.PartnerCustomerEventType,
+		kafka.ShareAssessmentEventType, kafka.UnshareAssessmentEventType, kafka.SizingEventType,
+		kafka.MigrationComplexityEventType, kafka.MigrationTimeEstimationEventType,
+		kafka.DownloadOVAEventType, kafka.VisitorEventType:
+		return writerTypeKafka
+	case notification.PartnershipRequestEventType, notification.PartnershipResponseEventType,
+		notification.AssessmentSharedEventType, notification.AssessmentCreatedEventType:
+		return writerTypeNotification
+	default:
+		return writerTypeUnknown
 	}
 }

--- a/internal/service/eventwrap/dispatcher_test.go
+++ b/internal/service/eventwrap/dispatcher_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -96,21 +98,36 @@ func (m *mockWriter) Write(_ context.Context, _ string, data []byte) error {
 	return nil
 }
 
+type mockNotifier struct {
+	written  [][]byte
+	writeErr error
+}
+
+func (m *mockNotifier) Write(_ context.Context, data []byte) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	m.written = append(m.written, data)
+	return nil
+}
+
 var _ = Describe("OutboxDispatcher", func() {
 	var (
-		outbox *mockOutbox
-		s      *mockStore
-		writer *mockWriter
+		outbox   *mockOutbox
+		s        *mockStore
+		writer   *mockWriter
+		notifier *mockNotifier
 	)
 
 	BeforeEach(func() {
 		outbox = &mockOutbox{}
 		s = &mockStore{outbox: outbox}
 		writer = &mockWriter{}
+		notifier = &mockNotifier{}
 	})
 
 	runOneTick := func() {
-		dispatcher := eventwrap.NewOutboxDispatcher(s, writer, 10*time.Millisecond)
+		dispatcher := eventwrap.NewOutboxDispatcher(s, writer, notifier, 10*time.Millisecond)
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
 		dispatcher.Run(ctx)
@@ -118,7 +135,7 @@ var _ = Describe("OutboxDispatcher", func() {
 
 	It("writes events and deletes them from outbox", func() {
 		outbox.events = []model.OutboxEvent{
-			{ID: 1, EventType: "test.event", Payload: []byte("event-data-1")},
+			{ID: 1, EventType: kafka.VisitorEventType, Payload: []byte("event-data-1")},
 		}
 
 		runOneTick()
@@ -137,7 +154,7 @@ var _ = Describe("OutboxDispatcher", func() {
 
 	It("skips events that fail to write and retains them", func() {
 		outbox.events = []model.OutboxEvent{
-			{ID: 1, EventType: "test.event", Payload: []byte("event-data-1")},
+			{ID: 1, EventType: kafka.VisitorEventType, Payload: []byte("event-data-1")},
 		}
 		writer.writeErr = fmt.Errorf("kafka unavailable")
 
@@ -149,13 +166,40 @@ var _ = Describe("OutboxDispatcher", func() {
 
 	It("writes multiple events and bulk-deletes", func() {
 		outbox.events = []model.OutboxEvent{
-			{ID: 1, EventType: "test.event.1", Payload: []byte("event-data-1")},
-			{ID: 2, EventType: "test.event.2", Payload: []byte("event-data-2")},
+			{ID: 1, EventType: kafka.VisitorEventType, Payload: []byte("event-data-1")},
+			{ID: 2, EventType: kafka.SizingEventType, Payload: []byte("event-data-2")},
 		}
 
 		runOneTick()
 
 		Expect(writer.written).To(HaveLen(2))
 		Expect(outbox.events).To(BeEmpty())
+	})
+
+	It("routes notification-service events to the notifier, not the Kafka writer", func() {
+		outbox.events = []model.OutboxEvent{
+			{ID: 1, EventType: notification.PartnershipRequestEventType, Payload: []byte("notification-data")},
+			{ID: 2, EventType: kafka.VisitorEventType, Payload: []byte("event-data")},
+		}
+
+		runOneTick()
+
+		Expect(notifier.written).To(HaveLen(1))
+		Expect(notifier.written[0]).To(Equal([]byte("notification-data")))
+		Expect(writer.written).To(HaveLen(1))
+		Expect(writer.written[0]).To(Equal([]byte("event-data")))
+		Expect(outbox.events).To(BeEmpty())
+	})
+
+	It("skips and retains events with an unrecognized event type", func() {
+		outbox.events = []model.OutboxEvent{
+			{ID: 1, EventType: "some.unknown.type", Payload: []byte("event-data")},
+		}
+
+		runOneTick()
+
+		Expect(writer.written).To(BeNil())
+		Expect(notifier.written).To(BeNil())
+		Expect(outbox.events).To(HaveLen(1))
 	})
 })

--- a/internal/service/eventwrap/event_assessment.go
+++ b/internal/service/eventwrap/event_assessment.go
@@ -10,7 +10,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 )
 
 type EventAssessmentService struct {
@@ -30,12 +31,12 @@ func (e *EventAssessmentService) ListAssessments(ctx context.Context, filter *se
 		return nil, err
 	}
 
-	payload := events.NewVisitorPayload(filter.Username, filter.OrgID)
-	ceBytes, err := events.BuildCloudEvent(events.VisitorEventType, payload)
+	payload := kafka.NewVisitorPayload(filter.Username, filter.OrgID)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.VisitorEventType, payload)
 	if err != nil {
 		return nil, err
 	}
-	if err := e.outbox.Insert(ctx, events.VisitorEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.VisitorEventType, ceBytes); err != nil {
 		return nil, err
 	}
 	return assessments, nil
@@ -59,7 +60,7 @@ func (e *EventAssessmentService) CreateAssessment(ctx context.Context, createFor
 		return nil, err
 	}
 
-	payload := events.NewAssessmentCreatedPayload(events.AssessmentData{
+	payload := kafka.NewAssessmentCreatedPayload(kafka.AssessmentData{
 		ID:         assessment.ID.String(),
 		SnapshotID: assessment.Snapshots[0].ID,
 		Inventory:  assessment.Snapshots[0].Inventory,
@@ -70,12 +71,37 @@ func (e *EventAssessmentService) CreateAssessment(ctx context.Context, createFor
 		CreatedAt:  assessment.CreatedAt,
 		UpdatedAt:  assessment.UpdatedAt,
 	})
-	ceBytes, err := events.BuildCloudEvent(events.AssessmentCreatedEventType, payload)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.AssessmentCreatedEventType, payload)
 	if err != nil {
 		return nil, err
 	}
-	if err := e.outbox.Insert(ctx, events.AssessmentCreatedEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.AssessmentCreatedEventType, ceBytes); err != nil {
 		return nil, err
+	}
+
+	// When a new assessment is created on behalf of a customer by a partner
+	// notify the customer by firing an email notification
+	if user, ok := auth.UserFromContext(ctx); ok {
+		identity, err := e.accountsSvc.GetIdentity(ctx, user)
+		if err != nil {
+			return nil, err
+		}
+		if identity.Kind == service.KindPartner || identity.Kind == service.KindAdmin {
+			notificationBytes, err := notification.Build(
+				notification.AssessmentCreatedEventType,
+				assessment.OrgID,
+				notification.SeverityImportant,
+				map[string]string{"assessment_id": assessment.ID.String()},
+				nil,
+				notification.Recipient{Users: []string{assessment.Username}, IgnoreUserPreferences: true},
+			)
+			if err != nil {
+				return nil, err
+			}
+			if err := e.outbox.Insert(ctx, notification.AssessmentCreatedEventType, notificationBytes); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if _, err := store.Commit(ctx); err != nil {
@@ -109,12 +135,12 @@ func (e *EventAssessmentService) DeleteAssessment(ctx context.Context, id uuid.U
 		return err
 	}
 
-	payload := events.NewAssessmentDeletedPayload(assessment.ID.String(), deletedAt)
-	ceBytes, err := events.BuildCloudEvent(events.AssessmentDeletedEventType, payload)
+	payload := kafka.NewAssessmentDeletedPayload(assessment.ID.String(), deletedAt)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.AssessmentDeletedEventType, payload)
 	if err != nil {
 		return err
 	}
-	if err := e.outbox.Insert(ctx, events.AssessmentDeletedEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.AssessmentDeletedEventType, ceBytes); err != nil {
 		return err
 	}
 
@@ -145,12 +171,44 @@ func (e *EventAssessmentService) ShareAssessment(ctx context.Context, id uuid.UU
 		return err
 	}
 
-	payload := events.NewShareAssessmentPayload(user.Username, id.String(), *identity.PartnerID)
-	ceBytes, err := events.BuildCloudEvent(events.ShareAssessmentEventType, payload)
+	// Because of ShareAssessment success Must be a consumer with a PartnerID
+	partnerGID, err := uuid.Parse(*identity.PartnerID)
 	if err != nil {
 		return err
 	}
-	if err := e.outbox.Insert(ctx, events.ShareAssessmentEventType, ceBytes); err != nil {
+
+	group, err := e.store.Accounts().GetGroup(ctx, partnerGID)
+	if err != nil {
+		return err
+	}
+
+	var notifiedUsers []string
+	for _, m := range group.Members {
+		notifiedUsers = append(notifiedUsers, m.Username)
+	}
+
+	payload := kafka.NewShareAssessmentPayload(user.Username, id.String(), *identity.PartnerID)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.ShareAssessmentEventType, payload)
+	if err != nil {
+		return err
+	}
+	if err := e.outbox.Insert(ctx, kafka.ShareAssessmentEventType, ceBytes); err != nil {
+		return err
+	}
+
+	// Notify a partner when a customer shared an assessment with him
+	notificationBytes, err := notification.Build(
+		notification.AssessmentSharedEventType,
+		group.Company,
+		notification.SeverityImportant,
+		map[string]string{"assessment_id": id.String()},
+		nil,
+		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
+	)
+	if err != nil {
+		return err
+	}
+	if err := e.outbox.Insert(ctx, notification.AssessmentSharedEventType, notificationBytes); err != nil {
 		return err
 	}
 
@@ -176,12 +234,12 @@ func (e *EventAssessmentService) UnshareAssessment(ctx context.Context, id uuid.
 		return err
 	}
 
-	payload := events.NewUnshareAssessmentPayload(user.Username, id.String())
-	ceBytes, err := events.BuildCloudEvent(events.UnshareAssessmentEventType, payload)
+	payload := kafka.NewUnshareAssessmentPayload(user.Username, id.String())
+	ceBytes, err := kafka.BuildCloudEvent(kafka.UnshareAssessmentEventType, payload)
 	if err != nil {
 		return err
 	}
-	if err := e.outbox.Insert(ctx, events.UnshareAssessmentEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.UnshareAssessmentEventType, ceBytes); err != nil {
 		return err
 	}
 

--- a/internal/service/eventwrap/event_estimation.go
+++ b/internal/service/eventwrap/event_estimation.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/pkg/estimations/engines"
 	"github.com/kubev2v/migration-planner/pkg/estimations/estimation"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 )
 
 type EventEstimationService struct {
@@ -34,7 +34,7 @@ func (e *EventEstimationService) CalculateMigrationEstimation(
 		return nil, err
 	}
 
-	if err := e.publishUserAction(ctx, assessmentID, events.MigrationTimeEstimationEventType); err != nil {
+	if err := e.publishUserAction(ctx, assessmentID, kafka.MigrationTimeEstimationEventType); err != nil {
 		return nil, err
 	}
 	return results, nil
@@ -50,7 +50,7 @@ func (e *EventEstimationService) CalculateMigrationComplexity(
 		return nil, err
 	}
 
-	if err := e.publishUserAction(ctx, assessmentID, events.MigrationComplexityEventType); err != nil {
+	if err := e.publishUserAction(ctx, assessmentID, kafka.MigrationComplexityEventType); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -85,20 +85,20 @@ func (e *EventEstimationService) publishUserAction(ctx context.Context, assessme
 	if err != nil {
 		return err
 	}
-	ceBytes, err := events.BuildCloudEvent(eventType, payload)
+	ceBytes, err := kafka.BuildCloudEvent(eventType, payload)
 	if err != nil {
 		return err
 	}
 	return e.outbox.Insert(ctx, eventType, ceBytes)
 }
 
-func buildEstimationPayload(eventType, username, assessmentID string) (events.UserActionEventPayload, error) {
+func buildEstimationPayload(eventType, username, assessmentID string) (kafka.UserActionEventPayload, error) {
 	switch eventType {
-	case events.MigrationComplexityEventType:
-		return events.NewComplexityPayload(username, assessmentID), nil
-	case events.MigrationTimeEstimationEventType:
-		return events.NewTimeEstimationPayload(username, assessmentID), nil
+	case kafka.MigrationComplexityEventType:
+		return kafka.NewComplexityPayload(username, assessmentID), nil
+	case kafka.MigrationTimeEstimationEventType:
+		return kafka.NewTimeEstimationPayload(username, assessmentID), nil
 	default:
-		return events.UserActionEventPayload{}, fmt.Errorf("unknown estimation event type: %s", eventType)
+		return kafka.UserActionEventPayload{}, fmt.Errorf("unknown estimation event type: %s", eventType)
 	}
 }

--- a/internal/service/eventwrap/event_partner.go
+++ b/internal/service/eventwrap/event_partner.go
@@ -8,7 +8,8 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 )
 
 type EventPartnerService struct {
@@ -35,7 +36,7 @@ func (e *EventPartnerService) CreateRequest(ctx context.Context, user auth.User,
 		return nil, err
 	}
 
-	payload := events.NewPartnerCustomerPayload(events.PartnerCustomerData{
+	payload := kafka.NewPartnerCustomerPayload(kafka.PartnerCustomerData{
 		ID:               created.ID.String(),
 		CustomerUsername: created.Username,
 		PartnerID:        created.PartnerID,
@@ -45,13 +46,35 @@ func (e *EventPartnerService) CreateRequest(ctx context.Context, user auth.User,
 		TerminatedAt:     created.TerminatedAt,
 		CreatedAt:        created.CreatedAt,
 	})
-	ceBytes, err := events.BuildCloudEvent(events.PartnerCustomerEventType, payload)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.PartnerCustomerEventType, payload)
 	if err != nil {
 		return nil, err
 	}
-	if err := e.outbox.Insert(ctx, events.PartnerCustomerEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.PartnerCustomerEventType, ceBytes); err != nil {
 		return nil, err
 	}
+
+	var notifiedUsers []string
+	for _, m := range created.Partner.Members {
+		notifiedUsers = append(notifiedUsers, m.Username)
+	}
+
+	// Notify the partner when a customer sent a partnership request
+	notificationBytes, err := notification.Build(
+		notification.PartnershipRequestEventType,
+		created.Partner.Company,
+		notification.SeverityImportant,
+		nil,
+		nil,
+		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.outbox.Insert(ctx, notification.PartnershipRequestEventType, notificationBytes); err != nil {
+		return nil, err
+	}
+
 	return created, nil
 }
 
@@ -73,7 +96,7 @@ func (e *EventPartnerService) CancelRequest(ctx context.Context, user auth.User,
 		return err
 	}
 
-	payload := events.NewPartnerCustomerPayload(events.PartnerCustomerData{
+	payload := kafka.NewPartnerCustomerPayload(kafka.PartnerCustomerData{
 		ID:               pc.ID.String(),
 		CustomerUsername: pc.Username,
 		PartnerID:        pc.PartnerID,
@@ -83,11 +106,11 @@ func (e *EventPartnerService) CancelRequest(ctx context.Context, user auth.User,
 		TerminatedAt:     pc.TerminatedAt,
 		CreatedAt:        pc.CreatedAt,
 	})
-	ceBytes, err := events.BuildCloudEvent(events.PartnerCustomerEventType, payload)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.PartnerCustomerEventType, payload)
 	if err != nil {
 		return err
 	}
-	if err := e.outbox.Insert(ctx, events.PartnerCustomerEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.PartnerCustomerEventType, ceBytes); err != nil {
 		return err
 	}
 
@@ -123,7 +146,7 @@ func (e *EventPartnerService) LeavePartner(ctx context.Context, user auth.User, 
 			return err
 		}
 
-		payload := events.NewPartnerCustomerPayload(events.PartnerCustomerData{
+		payload := kafka.NewPartnerCustomerPayload(kafka.PartnerCustomerData{
 			ID:               refreshed.ID.String(),
 			CustomerUsername: refreshed.Username,
 			PartnerID:        refreshed.PartnerID,
@@ -133,11 +156,11 @@ func (e *EventPartnerService) LeavePartner(ctx context.Context, user auth.User, 
 			TerminatedAt:     refreshed.TerminatedAt,
 			CreatedAt:        refreshed.CreatedAt,
 		})
-		ceBytes, err := events.BuildCloudEvent(events.PartnerCustomerEventType, payload)
+		ceBytes, err := kafka.BuildCloudEvent(kafka.PartnerCustomerEventType, payload)
 		if err != nil {
 			return err
 		}
-		if err := e.outbox.Insert(ctx, events.PartnerCustomerEventType, ceBytes); err != nil {
+		if err := e.outbox.Insert(ctx, kafka.PartnerCustomerEventType, ceBytes); err != nil {
 			return err
 		}
 	}
@@ -159,7 +182,7 @@ func (e *EventPartnerService) UpdateRequest(ctx context.Context, user auth.User,
 		return nil, err
 	}
 
-	payload := events.NewPartnerCustomerPayload(events.PartnerCustomerData{
+	payload := kafka.NewPartnerCustomerPayload(kafka.PartnerCustomerData{
 		ID:               updated.ID.String(),
 		CustomerUsername: updated.Username,
 		PartnerID:        updated.PartnerID,
@@ -169,13 +192,38 @@ func (e *EventPartnerService) UpdateRequest(ctx context.Context, user auth.User,
 		TerminatedAt:     updated.TerminatedAt,
 		CreatedAt:        updated.CreatedAt,
 	})
-	ceBytes, err := events.BuildCloudEvent(events.PartnerCustomerEventType, payload)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.PartnerCustomerEventType, payload)
 	if err != nil {
 		return nil, err
 	}
-	if err := e.outbox.Insert(ctx, events.PartnerCustomerEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.PartnerCustomerEventType, ceBytes); err != nil {
 		return nil, err
 	}
+
+	// Notify the customer when a partner accepted/rejected partnership request
+	decision := "Accepted"
+	if updated.RequestStatus == model.RequestStatusRejected {
+		decision = "Declined"
+	}
+	reason := ""
+	if updated.Reason != nil {
+		reason = *updated.Reason
+	}
+	notificationBytes, err := notification.Build(
+		notification.PartnershipResponseEventType,
+		user.Organization,
+		notification.SeverityImportant,
+		map[string]string{"decision": decision, "reason": reason},
+		nil,
+		notification.Recipient{Users: []string{updated.Username}, IgnoreUserPreferences: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := e.outbox.Insert(ctx, notification.PartnershipResponseEventType, notificationBytes); err != nil {
+		return nil, err
+	}
+
 	return updated, nil
 }
 

--- a/internal/service/eventwrap/event_sizer.go
+++ b/internal/service/eventwrap/event_sizer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kubev2v/migration-planner/internal/service"
 	"github.com/kubev2v/migration-planner/internal/service/mappers"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 )
 
 type EventSizerService struct {
@@ -36,12 +36,12 @@ func (e *EventSizerService) CalculateClusterRequirements(
 		return nil, err
 	}
 
-	payload := events.NewSizingPayload(assessment.Username, assessmentID.String())
-	ceBytes, err := events.BuildCloudEvent(events.SizingEventType, payload)
+	payload := kafka.NewSizingPayload(assessment.Username, assessmentID.String())
+	ceBytes, err := kafka.BuildCloudEvent(kafka.SizingEventType, payload)
 	if err != nil {
 		return nil, err
 	}
-	if err := e.outbox.Insert(ctx, events.SizingEventType, ceBytes); err != nil {
+	if err := e.outbox.Insert(ctx, kafka.SizingEventType, ceBytes); err != nil {
 		return nil, err
 	}
 

--- a/internal/service/eventwrap/outbox_test.go
+++ b/internal/service/eventwrap/outbox_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
-	"github.com/kubev2v/migration-planner/pkg/events"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,22 +24,22 @@ var _ = Describe("OutboxService", func() {
 	})
 
 	It("inserts a valid event into the outbox", func() {
-		err := service.Insert(context.Background(), events.VisitorEventType, []byte(`{"test":"data"}`))
+		err := service.Insert(context.Background(), kafka.VisitorEventType, []byte(`{"test":"data"}`))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(outbox.events).To(HaveLen(1))
-		Expect(outbox.events[0].EventType).To(Equal(events.VisitorEventType))
+		Expect(outbox.events[0].EventType).To(Equal(kafka.VisitorEventType))
 	})
 
 	It("inserts an assessment created event", func() {
-		err := service.Insert(context.Background(), events.AssessmentCreatedEventType, []byte(`{"test":"assessment"}`))
+		err := service.Insert(context.Background(), kafka.AssessmentCreatedEventType, []byte(`{"test":"assessment"}`))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(outbox.events).To(HaveLen(1))
-		Expect(outbox.events[0].EventType).To(Equal(events.AssessmentCreatedEventType))
+		Expect(outbox.events[0].EventType).To(Equal(kafka.AssessmentCreatedEventType))
 	})
 
 	It("returns error when store insert fails", func() {
 		outbox.insertErr = fmt.Errorf("db connection lost")
-		err := service.Insert(context.Background(), events.VisitorEventType, []byte(`{"test":"data"}`))
+		err := service.Insert(context.Background(), kafka.VisitorEventType, []byte(`{"test":"data"}`))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("db connection lost"))
 	})

--- a/internal/store/partner.go
+++ b/internal/store/partner.go
@@ -51,7 +51,7 @@ func (p *PartnerCustomerStore) Create(ctx context.Context, pc model.PartnerCusto
 			}
 			return result.Error
 		}
-		result := tx.Preload("Partner").First(&created, "id = ?", pc.ID)
+		result := tx.Preload("Partner.Members").First(&created, "id = ?", pc.ID)
 		return result.Error
 	})
 	if err != nil {

--- a/pkg/events/kafka/assessment.go
+++ b/pkg/events/kafka/assessment.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 import (
 	"encoding/json"

--- a/pkg/events/kafka/event.go
+++ b/pkg/events/kafka/event.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 import (
 	"encoding/json"

--- a/pkg/events/kafka/kafka_producer.go
+++ b/pkg/events/kafka/kafka_producer.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 import (
 	"context"

--- a/pkg/events/kafka/kafka_suite_test.go
+++ b/pkg/events/kafka/kafka_suite_test.go
@@ -1,4 +1,4 @@
-package events_test
+package kafka_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEvents(t *testing.T) {
+func TestKafkaEvents(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Events Suite")
+	RunSpecs(t, "Kafka Events Suite")
 }

--- a/pkg/events/kafka/partner_customer.go
+++ b/pkg/events/kafka/partner_customer.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 import "time"
 

--- a/pkg/events/kafka/types.go
+++ b/pkg/events/kafka/types.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 const (
 	// GenericTopic is the Kafka topic where all events are produced

--- a/pkg/events/kafka/user_action.go
+++ b/pkg/events/kafka/user_action.go
@@ -1,4 +1,4 @@
-package events
+package kafka
 
 import "time"
 

--- a/pkg/events/notification/notification.go
+++ b/pkg/events/notification/notification.go
@@ -1,0 +1,64 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Notification matches the Console Notifications service message schema.
+type Notification struct {
+	ID          string            `json:"id"`
+	Version     string            `json:"version"`
+	Bundle      string            `json:"bundle"`
+	Application string            `json:"application"`
+	EventType   string            `json:"event_type"`
+	Timestamp   string            `json:"timestamp"`
+	OrgID       string            `json:"org_id"`
+	Severity    string            `json:"severity"`
+	Context     map[string]string `json:"context,omitempty"`
+	Events      []Event           `json:"events"`
+	Recipients  []Recipient       `json:"recipients,omitempty"`
+}
+
+type Event struct {
+	Metadata map[string]string `json:"metadata"`
+	Payload  any               `json:"payload"`
+}
+
+type Recipient struct {
+	OnlyAdmins            bool     `json:"only_admins"`
+	IgnoreUserPreferences bool     `json:"ignore_user_preferences"`
+	Users                 []string `json:"users,omitempty"`
+}
+
+// New builds a Notification for eventType, stamping the fields fixed by the
+// application's registration with the notification service (id, version,
+// bundle, application, timestamp).
+func New(eventType, orgID, severity string, context map[string]string, payload any, recipients ...Recipient) Notification {
+	return Notification{
+		ID:          uuid.New().String(),
+		Version:     schemaVersion,
+		Bundle:      bundle,
+		Application: application,
+		EventType:   eventType,
+		Timestamp:   time.Now().UTC().Format("2006-01-02T15:04:05"),
+		OrgID:       orgID,
+		Severity:    severity,
+		Context:     context,
+		Events:      []Event{{Metadata: map[string]string{}, Payload: payload}},
+		Recipients:  recipients,
+	}
+}
+
+// Build constructs a Notification for eventType and marshals it to JSON,
+// ready to be stored in the outbox and later dispatched by a Writer.
+func Build(eventType, orgID, severity string, context map[string]string, payload any, recipients ...Recipient) ([]byte, error) {
+	data, err := json.Marshal(New(eventType, orgID, severity, context, payload, recipients...))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal notification %s: %w", eventType, err)
+	}
+	return data, nil
+}

--- a/pkg/events/notification/notification_suite_test.go
+++ b/pkg/events/notification/notification_suite_test.go
@@ -1,0 +1,13 @@
+package notification_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNotification(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Notification Suite")
+}

--- a/pkg/events/notification/notification_test.go
+++ b/pkg/events/notification/notification_test.go
@@ -1,0 +1,53 @@
+package notification_test
+
+import (
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("New", func() {
+	It("stamps the fields fixed by the notification service registration", func() {
+		n := notification.New(
+			notification.PartnershipRequestEventType,
+			"org-123",
+			notification.SeverityImportant,
+			map[string]string{"request_id": "req-1"},
+			map[string]bool{"test": true},
+			notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true},
+		)
+
+		Expect(n.ID).NotTo(BeEmpty())
+		Expect(n.Version).To(Equal("v2.0.0"))
+		Expect(n.Bundle).To(Equal("openshift"))
+		Expect(n.Application).To(Equal("migration-advisor"))
+		Expect(n.EventType).To(Equal(notification.PartnershipRequestEventType))
+		Expect(n.OrgID).To(Equal("org-123"))
+		Expect(n.Severity).To(Equal(notification.SeverityImportant))
+		Expect(n.Context).To(HaveKeyWithValue("request_id", "req-1"))
+		Expect(n.Timestamp).NotTo(BeEmpty())
+	})
+
+	It("wraps the payload as a single event with empty metadata", func() {
+		n := notification.New(notification.AssessmentSharedEventType, "org-1", notification.SeverityImportant, nil, map[string]bool{"test": true})
+
+		Expect(n.Events).To(HaveLen(1))
+		Expect(n.Events[0].Metadata).To(BeEmpty())
+		Expect(n.Events[0].Payload).To(Equal(map[string]bool{"test": true}))
+	})
+
+	It("carries through the given recipients", func() {
+		n := notification.New(notification.PartnershipResponseEventType, "org-1", notification.SeverityImportant, nil, nil,
+			notification.Recipient{Users: []string{"alice"}})
+
+		Expect(n.Recipients).To(HaveLen(1))
+		Expect(n.Recipients[0].Users).To(ConsistOf("alice"))
+	})
+
+	It("generates a unique id per call", func() {
+		a := notification.New(notification.AssessmentCreatedEventType, "org", notification.SeverityImportant, nil, nil)
+		b := notification.New(notification.AssessmentCreatedEventType, "org", notification.SeverityImportant, nil, nil)
+
+		Expect(a.ID).NotTo(Equal(b.ID))
+	})
+})

--- a/pkg/events/notification/types.go
+++ b/pkg/events/notification/types.go
@@ -1,0 +1,30 @@
+package notification
+
+const (
+	// bundle is the Console Notifications bundle this application belongs to.
+	bundle = "openshift"
+
+	// application is the technical name registered with the notification service.
+	application = "migration-advisor"
+
+	// schemaVersion is the version of the notification message schema.
+	schemaVersion = "v2.0.0"
+)
+
+const (
+	SeverityImportant = "IMPORTANT"
+)
+
+const (
+	// PartnershipRequestEventType fires when a partner organization receives a request to establish a partnership.
+	PartnershipRequestEventType = "partnership-request"
+
+	// PartnershipResponseEventType fires when a partner organization responds to a partnership request.
+	PartnershipResponseEventType = "partnership-response"
+
+	// AssessmentSharedEventType fires when a migration assessment is shared with a partner organization.
+	AssessmentSharedEventType = "assessment-shared"
+
+	// AssessmentCreatedEventType fires when a new assessment is created on behalf of a customer by a partner organization.
+	AssessmentCreatedEventType = "assessment-created"
+)

--- a/pkg/events/notification/writer.go
+++ b/pkg/events/notification/writer.go
@@ -1,0 +1,102 @@
+// The HTTPWriter was written according to the guide in the link below:
+// https://inscope.corp.redhat.com/docs/default/component/notifications-app/user-guide/send-notification/
+// Email templates can be found here: https://github.com/RedHatInsights/notifications-backend/tree/master/common-template/src/main/resources/templates/email/Oma
+
+package notification
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Writer sends an already-built notification payload (see Build) to the
+// notification service.
+type Writer interface {
+	Write(ctx context.Context, data []byte) error
+}
+
+// HTTPWriter sends notification payloads to the notification service over
+// an mTLS-authenticated HTTPS connection.
+type HTTPWriter struct {
+	url    string
+	client *http.Client
+}
+
+// NewHTTPWriter builds an HTTPWriter that authenticates with the notification
+// service using the given PEM-encoded client certificate and private key.
+func NewHTTPWriter(notificationURL string, certPEM, keyPEM []byte) (*HTTPWriter, error) {
+	parsedURL, err := url.ParseRequestURI(notificationURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing notification URL: %w", err)
+	}
+	if parsedURL.Scheme != "https" {
+		return nil, fmt.Errorf("notification URL must use HTTPS scheme, got %q", parsedURL.Scheme)
+	}
+	if parsedURL.Host == "" {
+		return nil, fmt.Errorf("notification URL must specify a host")
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("loading notification service client certificate: %w", err)
+	}
+
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		},
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &HTTPWriter{
+		url:    notificationURL,
+		client: &http.Client{Transport: transport, Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (w *HTTPWriter) Write(ctx context.Context, data []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("building notification request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending notification: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("notification service returned status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// StdoutWriter prints notifications to stdout. It is used as a fallback
+// when the notification service's mTLS client certificate is not configured.
+type StdoutWriter struct{}
+
+func NewStdoutWriter() *StdoutWriter { return &StdoutWriter{} }
+
+func (w *StdoutWriter) Write(_ context.Context, data []byte) error {
+	fmt.Println(string(data))
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added important notifications for assessment creation and sharing, partnership requests and responses, and customer updates.
  * Notifications can be delivered through a configured service using secure client authentication, with stdout fallback when unavailable.
  * Event publishing now routes Kafka events and notifications through their appropriate delivery channels.
  * Added deployment configuration for notification endpoints, proxies, and credentials.

* **Reliability**
  * Failed or unsupported events remain available for retry instead of being discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->