### PR TITLE
ECOPROJECT-5221 | fix: remove FORCE CHECKPOINT from interceptor to prevent deadlock

### DIFF
--- a/pkg/store/interceptor.go
+++ b/pkg/store/interceptor.go
@@ -10,12 +10,9 @@ import (
 // QueryInterceptor provides database query methods with transaction awareness.
 // Implementations route queries through an active transaction if present in context.
 //
-// NOTE: The default implementation (queryInterceptor) is DuckDB-specific. It uses:
-// - Mutex serialization in ExecContext to satisfy DuckDB's single-connection constraint
-// - FORCE CHECKPOINT after non-transactional writes to flush DuckDB's WAL to the main file
-//
-// If supporting other databases, a separate implementation would be needed without
-// these DuckDB-specific behaviors.
+// NOTE: DuckDB durability is handled by the WAL — it replays on startup. Explicit
+// checkpointing is only needed before file-level operations (close, clone) and is
+// available via Store2.Checkpoint().
 type QueryInterceptor interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
@@ -64,19 +61,7 @@ func (q *queryInterceptor) ExecContext(ctx context.Context, query string, args .
 		return tx.ExecContext(ctx, query, args...)
 	}
 
-	result, err := q.db.ExecContext(ctx, query, args...)
-	if err != nil {
-		return result, err
-	}
-
-	// Issue a DuckDB-specific FORCE CHECKPOINT to flush the write-ahead log (WAL) to the main database file.
-	// This ensures durability for non-transactional writes by persisting changes immediately.
-	// FORCE CHECKPOINT is DuckDB-specific SQL and would fail on other databases.
-	// We only checkpoint on the non-transaction path; transactions handle their own durability on commit.
-	if _, cpErr := q.db.ExecContext(ctx, "FORCE CHECKPOINT"); cpErr != nil {
-		q.logger.Warnw("checkpoint failed", "error", cpErr)
-	}
-	return result, nil
+	return q.db.ExecContext(ctx, query, args...)
 }
 
 func (q *queryInterceptor) txFromContext(ctx context.Context) (*sql.Tx, bool) {

--- a/pkg/store/interceptor_test.go
+++ b/pkg/store/interceptor_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"context"
 	"database/sql"
+	"sync"
 	"testing"
+	"time"
 
 	_ "github.com/marcboeker/go-duckdb/v2"
 )
@@ -192,5 +194,231 @@ func TestQueryInterceptor_SerializedExec(t *testing.T) {
 
 	if count != 20 {
 		t.Errorf("expected 20 rows, got %d", count)
+	}
+}
+
+// setupTestDBWithMaxConns creates a file-backed DuckDB (WAL-enabled) with MaxOpenConns(1),
+// matching production configuration.
+func setupTestDBWithMaxConns(t *testing.T, maxConns int) *sql.DB {
+	t.Helper()
+	dbPath := t.TempDir() + "/test.db"
+	db, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	db.SetMaxOpenConns(maxConns)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+	})
+	return db
+}
+
+// TestQueryInterceptor_ConcurrentExecWithSingleConn verifies that concurrent
+// non-transactional writes complete without hanging when MaxOpenConns is 1.
+// This is the scenario that caused ECOPROJECT-5221: with FORCE CHECKPOINT after
+// every ExecContext, concurrent writes would deadlock because the single connection
+// was held by the checkpoint while the next write waited for the same connection.
+func TestQueryInterceptor_ConcurrentExecWithSingleConn(t *testing.T) {
+	db := setupTestDBWithMaxConns(t, 1)
+	qi := NewQueryInterceptor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER, data VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	const (
+		numGoroutines = 10
+		numWrites     = 20
+		timeout       = 30 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines*numWrites)
+
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range numWrites {
+				if _, err := qi.ExecContext(ctx, "INSERT INTO test VALUES (?, ?)", g*numWrites+i, "data"); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("concurrent writes with MaxOpenConns(1) timed out after %v — possible deadlock", timeout)
+	}
+
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("write error: %v", err)
+	}
+
+	row := qi.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM test")
+	var count int
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+	if count != numGoroutines*numWrites {
+		t.Errorf("expected %d rows, got %d", numGoroutines*numWrites, count)
+	}
+}
+
+// TestQueryInterceptor_ConcurrentReadsAndWritesSingleConn verifies that mixed
+// concurrent reads and writes don't deadlock with a single connection. This
+// simulates the production scenario where the console background loop (reads +
+// deletes) runs alongside API write handlers.
+func TestQueryInterceptor_ConcurrentReadsAndWritesSingleConn(t *testing.T) {
+	db := setupTestDBWithMaxConns(t, 1)
+	qi := NewQueryInterceptor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER, data VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	const (
+		numWriters = 5
+		numReaders = 5
+		numOps     = 20
+		timeout    = 30 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	for w := range numWriters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range numOps {
+				if _, err := qi.ExecContext(ctx, "INSERT INTO test VALUES (?, ?)", w*numOps+i, "data"); err != nil {
+					t.Errorf("write error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	for range numReaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range numOps {
+				row := qi.QueryRowContext(ctx, "SELECT COUNT(*) FROM test")
+				var count int
+				if err := row.Scan(&count); err != nil {
+					t.Errorf("read error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("concurrent reads/writes with MaxOpenConns(1) timed out after %v — possible deadlock", timeout)
+	}
+}
+
+// TestQueryInterceptor_ConcurrentTxAndNonTxWritesSingleConn verifies that
+// transactional and non-transactional writes interleaved across goroutines
+// complete without hanging. This simulates API handlers (transactional) running
+// alongside background outbox cleanup (non-transactional deletes).
+func TestQueryInterceptor_ConcurrentTxAndNonTxWritesSingleConn(t *testing.T) {
+	db := setupTestDBWithMaxConns(t, 1)
+	qi := NewQueryInterceptor(db)
+	transactor := NewTransactor(db)
+
+	if _, err := qi.ExecContext(context.Background(), "CREATE TABLE test (id INTEGER, data VARCHAR)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	const (
+		numTxWriters    = 3
+		numNonTxWriters = 3
+		numOps          = 15
+		timeout         = 30 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	for w := range numTxWriters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range numOps {
+				err := transactor.WithTx(ctx, func(txCtx context.Context) error {
+					_, err := qi.ExecContext(txCtx, "INSERT INTO test VALUES (?, ?)", w*1000+i, "tx")
+					return err
+				})
+				if err != nil {
+					t.Errorf("tx write error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	for w := range numNonTxWriters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range numOps {
+				if _, err := qi.ExecContext(ctx, "INSERT INTO test VALUES (?, ?)", (w+numTxWriters)*1000+i, "non-tx"); err != nil {
+					t.Errorf("non-tx write error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("concurrent tx + non-tx writes with MaxOpenConns(1) timed out after %v — possible deadlock", timeout)
+	}
+
+	row := qi.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM test")
+	var count int
+	if err := row.Scan(&count); err != nil {
+		t.Fatalf("failed to count rows: %v", err)
+	}
+	expected := (numTxWriters + numNonTxWriters) * numOps
+	if count != expected {
+		t.Errorf("expected %d rows, got %d", expected, count)
 	}
 }


### PR DESCRIPTION
FORCE CHECKPOINT after every non-transactional ExecContext caused DuckDB's internal WAL locking to stall under concurrent write pressure. With MaxOpenConns(1), a single stuck checkpoint blocked all subsequent DB operations permanently. WAL replay on startup already ensures durability, so explicit checkpointing is only needed before file-level operations (close, clone) via Store2.Checkpoint().

Adds concurrent write tests with MaxOpenConns(1) that reproduce the deadlock scenario and verify the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database write behavior by removing unnecessary checkpoint operations from non-transactional writes.
  * Preserved reliable startup recovery through write-ahead log replay.
  * Improved stability for concurrent reads, writes, and mixed transactional operations.

* **Tests**
  * Added coverage for concurrent database access and single-connection scenarios.
  * Added timeout and row-count validation to detect hangs or incomplete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->