### PR TITLE
ECOPROJECT-5215 | fix: include payload for debugging

### DIFF
--- a/internal/service/eventwrap/dispatcher.go
+++ b/internal/service/eventwrap/dispatcher.go
@@ -84,6 +84,7 @@ func (d *OutboxDispatcher) processBatch(ctx context.Context) {
 		if err != nil {
 			zap.S().Errorw("outbox dispatcher: failed to write event, will retry",
 				"id", outboxEvent.ID, "event_type", outboxEvent.EventType, "error", err)
+			zap.S().Debugw("failed payload", "id", outboxEvent.ID, "payload", string(outboxEvent.Payload))
 			continue
 		}
 		published = append(published, outboxEvent.ID)


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging when an event cannot be written to the outbox, while preserving existing retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->