### PR TITLE
ECOPROJECT-5215 | fix: IgnoreUserPreferences should be false for now

### DIFF
--- a/internal/service/eventwrap/event_assessment.go
+++ b/internal/service/eventwrap/event_assessment.go
@@ -92,7 +92,7 @@ func (e *EventAssessmentService) CreateAssessment(ctx context.Context, createFor
 				assessment.OrgID,
 				notification.SeverityImportant,
 				map[string]string{"assessment_id": assessment.ID.String()},
-				notification.Recipient{Users: []string{assessment.Username}, IgnoreUserPreferences: true},
+				notification.Recipient{Users: []string{assessment.Username}, IgnoreUserPreferences: false},
 			)
 			if err != nil {
 				return nil, err
@@ -201,7 +201,7 @@ func (e *EventAssessmentService) ShareAssessment(ctx context.Context, id uuid.UU
 		"11111111", // Todo: Send the correct console.redhat.com partner org_id if needed
 		notification.SeverityImportant,
 		map[string]string{"assessment_id": id.String()},
-		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
+		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: false, Users: notifiedUsers},
 	)
 	if err != nil {
 		return err

--- a/internal/service/eventwrap/event_partner.go
+++ b/internal/service/eventwrap/event_partner.go
@@ -65,7 +65,7 @@ func (e *EventPartnerService) CreateRequest(ctx context.Context, user auth.User,
 		"11111111", // Todo: Send the correct console.redhat.com partner org_id if needed
 		notification.SeverityImportant,
 		nil,
-		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
+		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: false, Users: notifiedUsers},
 	)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (e *EventPartnerService) UpdateRequest(ctx context.Context, user auth.User,
 		user.Organization,
 		notification.SeverityImportant,
 		map[string]string{"decision": decision, "reason": reason},
-		notification.Recipient{Users: []string{updated.Username}, IgnoreUserPreferences: true},
+		notification.Recipient{Users: []string{updated.Username}, IgnoreUserPreferences: false},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Assessment notifications now respect recipients’ notification preferences.
  - Partnership request and response notifications now honor recipients’ notification preferences.
  - Other notification behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->