### PR TITLE
ECOPROJECT-5215 | feat: must contain users when sending notification to the console service

### DIFF
--- a/internal/service/assessment_test.go
+++ b/internal/service/assessment_test.go
@@ -1063,6 +1063,10 @@ var _ = Describe("assessment service", Ordered, func() {
 			tx := gormdb.Exec(fmt.Sprintf("INSERT INTO partners_customers (id, username, partner_id, request_status, name, contact_name, contact_phone, email, location) VALUES ('%s', 'customer1', '%s', 'accepted', 'Name', 'Contact', '555', 'c@e.com', 'Loc');", uuid.New(), partnerGroupID))
 			Expect(tx.Error).To(BeNil())
 
+			// Partner group has a member to notify
+			tx = gormdb.Exec(fmt.Sprintf("INSERT INTO members (id, username, email, group_id) VALUES ('%s', 'partner-admin', 'admin@partner.com', '%s');", uuid.New(), partnerGroupID))
+			Expect(tx.Error).To(BeNil())
+
 			ctx := ctxWithUser("customer1", "org1")
 			err := svc.ShareAssessment(ctx, assessmentID)
 
@@ -1089,8 +1093,31 @@ var _ = Describe("assessment service", Ordered, func() {
 			Expect(n.EventType).To(Equal(notification.AssessmentSharedEventType))
 			Expect(n.Context["assessment_id"]).To(Equal(assessmentID.String()))
 			Expect(n.Recipients).To(HaveLen(1))
-			Expect(n.Recipients[0].OnlyAdmins).To(BeTrue())
 			Expect(n.Recipients[0].IgnoreUserPreferences).To(BeTrue())
+		})
+
+		It("commits the share but does not emit a notification when the partner group has no members", func() {
+			// Accepted partner customer record, but the partner group has no members to notify
+			tx := gormdb.Exec(fmt.Sprintf("INSERT INTO partners_customers (id, username, partner_id, request_status, name, contact_name, contact_phone, email, location) VALUES ('%s', 'customer1', '%s', 'accepted', 'Name', 'Contact', '555', 'c@e.com', 'Loc');", uuid.New(), partnerGroupID))
+			Expect(tx.Error).To(BeNil())
+
+			ctx := ctxWithUser("customer1", "org1")
+			err := svc.ShareAssessment(ctx, assessmentID)
+			Expect(err).To(BeNil())
+
+			// The share itself is committed: viewer relation is created
+			var count int64
+			gormdb.Raw("SELECT COUNT(*) FROM relations WHERE resource = 'assessment' AND resource_id = ? AND relation = 'viewer' AND subject_namespace = 'org' AND subject_id = ?", assessmentID.String(), partnerGroupID.String()).Scan(&count)
+			Expect(count).To(Equal(int64(1)))
+
+			// The share CloudEvent is committed
+			var outboxCount int64
+			gormdb.Raw(countOutboxByTypeStm, kafka.ShareAssessmentEventType).Scan(&outboxCount)
+			Expect(outboxCount).To(Equal(int64(1)))
+
+			// But no console notification is emitted (would otherwise email the whole org)
+			gormdb.Raw(countOutboxByTypeStm, notification.AssessmentSharedEventType).Scan(&outboxCount)
+			Expect(outboxCount).To(Equal(int64(0)))
 		})
 
 		It("is idempotent — sharing twice does not error", func() {

--- a/internal/service/eventwrap/event_assessment.go
+++ b/internal/service/eventwrap/event_assessment.go
@@ -170,6 +170,15 @@ func (e *EventAssessmentService) ShareAssessment(ctx context.Context, id uuid.UU
 		return err
 	}
 
+	payload := kafka.NewShareAssessmentPayload(user.Username, id.String(), *identity.PartnerID)
+	ceBytes, err := kafka.BuildCloudEvent(kafka.ShareAssessmentEventType, payload)
+	if err != nil {
+		return err
+	}
+	if err := e.outbox.Insert(ctx, kafka.ShareAssessmentEventType, ceBytes); err != nil {
+		return err
+	}
+
 	// Because of ShareAssessment success Must be a consumer with a PartnerID
 	partnerGID, err := uuid.Parse(*identity.PartnerID)
 	if err != nil {
@@ -186,28 +195,21 @@ func (e *EventAssessmentService) ShareAssessment(ctx context.Context, id uuid.UU
 		notifiedUsers = append(notifiedUsers, m.Username)
 	}
 
-	payload := kafka.NewShareAssessmentPayload(user.Username, id.String(), *identity.PartnerID)
-	ceBytes, err := kafka.BuildCloudEvent(kafka.ShareAssessmentEventType, payload)
-	if err != nil {
-		return err
-	}
-	if err := e.outbox.Insert(ctx, kafka.ShareAssessmentEventType, ceBytes); err != nil {
-		return err
-	}
-
-	// Notify a partner when a customer shared an assessment with him
-	notificationBytes, err := notification.Build(
-		notification.AssessmentSharedEventType,
-		"11111111", // Todo: Send the correct console.redhat.com partner org_id if needed
-		notification.SeverityImportant,
-		map[string]string{"assessment_id": id.String()},
-		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
-	)
-	if err != nil {
-		return err
-	}
-	if err := e.outbox.Insert(ctx, notification.AssessmentSharedEventType, notificationBytes); err != nil {
-		return err
+	if len(notifiedUsers) > 0 {
+		// Notify a partner when a customer shared an assessment with him
+		notificationBytes, err := notification.Build(
+			notification.AssessmentSharedEventType,
+			"", // Todo: Send the correct console.redhat.com partner org_id
+			notification.SeverityImportant,
+			map[string]string{"assessment_id": id.String()},
+			notification.Recipient{IgnoreUserPreferences: true, Users: notifiedUsers},
+		)
+		if err != nil {
+			return err
+		}
+		if err := e.outbox.Insert(ctx, notification.AssessmentSharedEventType, notificationBytes); err != nil {
+			return err
+		}
 	}
 
 	if _, err := store.Commit(ctx); err != nil {

--- a/internal/service/eventwrap/event_partner.go
+++ b/internal/service/eventwrap/event_partner.go
@@ -59,19 +59,21 @@ func (e *EventPartnerService) CreateRequest(ctx context.Context, user auth.User,
 		notifiedUsers = append(notifiedUsers, m.Username)
 	}
 
-	// Notify the partner when a customer sent a partnership request
-	notificationBytes, err := notification.Build(
-		notification.PartnershipRequestEventType,
-		"11111111", // Todo: Send the correct console.redhat.com partner org_id if needed
-		notification.SeverityImportant,
-		nil,
-		notification.Recipient{OnlyAdmins: true, IgnoreUserPreferences: true, Users: notifiedUsers},
-	)
-	if err != nil {
-		return nil, err
-	}
-	if err := e.outbox.Insert(ctx, notification.PartnershipRequestEventType, notificationBytes); err != nil {
-		return nil, err
+	if len(notifiedUsers) > 0 {
+		// Notify the partner when a customer sent a partnership request
+		notificationBytes, err := notification.Build(
+			notification.PartnershipRequestEventType,
+			"", // Todo: Send the correct console.redhat.com partner org_id
+			notification.SeverityImportant,
+			nil,
+			notification.Recipient{IgnoreUserPreferences: true, Users: notifiedUsers},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := e.outbox.Insert(ctx, notification.PartnershipRequestEventType, notificationBytes); err != nil {
+			return nil, err
+		}
 	}
 
 	return created, nil

--- a/internal/service/partner_test.go
+++ b/internal/service/partner_test.go
@@ -8,8 +8,11 @@ import (
 	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/service"
+	"github.com/kubev2v/migration-planner/internal/service/eventwrap"
 	"github.com/kubev2v/migration-planner/internal/store"
 	"github.com/kubev2v/migration-planner/internal/store/model"
+	"github.com/kubev2v/migration-planner/pkg/events/kafka"
+	"github.com/kubev2v/migration-planner/pkg/events/notification"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gorm.io/gorm"
@@ -290,6 +293,71 @@ var _ = Describe("partner service", Ordered, func() {
 		})
 
 		AfterEach(func() {
+			gormdb.Exec("DELETE FROM partners_customers;")
+			gormdb.Exec("DELETE FROM members;")
+			gormdb.Exec("DELETE FROM groups;")
+		})
+	})
+
+	Context("CreateRequest notifications", func() {
+		var wrapped service.PartnerServicer
+
+		BeforeEach(func() {
+			wrapped = eventwrap.NewEventPartnerService(service.NewPartnerService(s, service.NewAccountsService(s)), s)
+		})
+
+		It("commits the partner-customer event but does not emit a notification when the partner group has no members", func() {
+			partnerGroupID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertPartnerGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+			Expect(tx.Error).To(BeNil())
+
+			pc := model.PartnerCustomer{
+				Name:         "Name1",
+				ContactName:  "Contact1",
+				ContactPhone: "555-0001",
+				Email:        "user1@example.com",
+				Location:     "Location1",
+			}
+
+			created, err := wrapped.CreateRequest(context.TODO(), auth.User{Username: "user1"}, partnerGroupID.String(), pc)
+			Expect(err).To(BeNil())
+			Expect(created).ToNot(BeNil())
+
+			// The partner-customer CloudEvent is committed
+			var count int64
+			gormdb.Raw("SELECT COUNT(*) FROM outbox_events WHERE event_type = ?;", kafka.PartnerCustomerEventType).Scan(&count)
+			Expect(count).To(Equal(int64(1)))
+
+			// But no console notification is emitted (would otherwise email the whole org)
+			gormdb.Raw("SELECT COUNT(*) FROM outbox_events WHERE event_type = ?;", notification.PartnershipRequestEventType).Scan(&count)
+			Expect(count).To(Equal(int64(0)))
+		})
+
+		It("emits a notification when the partner group has members", func() {
+			partnerGroupID := uuid.New()
+			tx := gormdb.Exec(fmt.Sprintf(insertPartnerGroupStm, partnerGroupID, "Partner Org", "desc", "partner", "icon", "Acme", "NULL"))
+			Expect(tx.Error).To(BeNil())
+			tx = gormdb.Exec(fmt.Sprintf(insertPartnerMemberStm, uuid.New(), "partneruser", "p@acme.com", partnerGroupID))
+			Expect(tx.Error).To(BeNil())
+
+			pc := model.PartnerCustomer{
+				Name:         "Name1",
+				ContactName:  "Contact1",
+				ContactPhone: "555-0001",
+				Email:        "user1@example.com",
+				Location:     "Location1",
+			}
+
+			_, err := wrapped.CreateRequest(context.TODO(), auth.User{Username: "user1"}, partnerGroupID.String(), pc)
+			Expect(err).To(BeNil())
+
+			var count int64
+			gormdb.Raw("SELECT COUNT(*) FROM outbox_events WHERE event_type = ?;", notification.PartnershipRequestEventType).Scan(&count)
+			Expect(count).To(Equal(int64(1)))
+		})
+
+		AfterEach(func() {
+			gormdb.Exec("DELETE FROM outbox_events;")
 			gormdb.Exec("DELETE FROM partners_customers;")
 			gormdb.Exec("DELETE FROM members;")
 			gormdb.Exec("DELETE FROM groups;")

--- a/pkg/events/notification/notification.go
+++ b/pkg/events/notification/notification.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,9 +57,32 @@ func New(eventType, orgID, severity string, context map[string]string, payload a
 // Build constructs a Notification for eventType and marshals it to JSON,
 // ready to be stored in the outbox and later dispatched by a Writer.
 func Build(eventType, orgID, severity string, context map[string]string, recipients ...Recipient) ([]byte, error) {
-	data, err := json.Marshal(New(eventType, orgID, severity, context, make(map[string]string), recipients...))
+	notification := New(eventType, orgID, severity, context, make(map[string]string), recipients...)
+
+	if err := notification.validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate notification %s: %w", eventType, err)
+	}
+
+	data, err := json.Marshal(notification)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal notification %s: %w", eventType, err)
 	}
 	return data, nil
+}
+
+func (n Notification) validate() error {
+	// Firing a notification when the users preferences is on but no users specified may send the email
+	// to the whole organization
+	for _, r := range n.Recipients {
+		if r.IgnoreUserPreferences && len(r.Users) == 0 {
+			return fmt.Errorf("ignore users preferences is on but no users specified")
+		}
+		for _, user := range r.Users {
+			if strings.TrimSpace(user) == "" {
+				return fmt.Errorf("have a user that is an empty string")
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/events/notification/notification_test.go
+++ b/pkg/events/notification/notification_test.go
@@ -51,3 +51,32 @@ var _ = Describe("New", func() {
 		Expect(a.ID).NotTo(Equal(b.ID))
 	})
 })
+
+var _ = Describe("Build", func() {
+	It("rejects an ignore-preferences recipient with no users", func() {
+		// IgnoreUserPreferences with no users would email the whole org.
+		data, err := notification.Build(
+			notification.AssessmentSharedEventType,
+			"org-1",
+			notification.SeverityImportant,
+			nil,
+			notification.Recipient{IgnoreUserPreferences: true},
+		)
+
+		Expect(err).To(HaveOccurred())
+		Expect(data).To(BeNil())
+	})
+
+	It("accepts an ignore-preferences recipient with a named user", func() {
+		data, err := notification.Build(
+			notification.AssessmentSharedEventType,
+			"org-1",
+			notification.SeverityImportant,
+			nil,
+			notification.Recipient{IgnoreUserPreferences: true, Users: []string{"alice"}},
+		)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).ToNot(BeNil())
+	})
+})


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assessment sharing and partnership request processing for groups without members.
  * Prevented unnecessary notifications when no group members are available.
  * Enabled all eligible group members to receive relevant notifications.
  * Corrected organization details associated with notifications.
  * Added validation to prevent invalid notification recipients.
  * Ensured assessment sharing events are recorded promptly, even when no notification is sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->