### PR TITLE
ci: skip validations when only non-code files change

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -1,0 +1,32 @@
+# Shared by pull-request.yml and kind.yml.
+# The `code` filter is true when at least one changed file is not excluded.
+# Keep this in the job (dorny/paths-filter), not on on.pull_request.paths —
+# skipping the whole workflow leaves required checks pending.
+code:
+  - '**'
+  - '!**/*.md'
+  - '!**/*.png'
+  - '!**/*.svg'
+  - '!**/*.gif'
+  - '!**/*.jpg'
+  - '!**/*.jpeg'
+  - '!**/*.webp'
+  - '!**/*.html'
+  - '!**/LICENSE'
+  - '!**/LICENSE.txt'
+  - '!OWNERS'
+  - '!CODEOWNERS'
+  - '!.github/CODEOWNERS'
+  - '!.github/ISSUE_TEMPLATE/**'
+  - '!.github/PULL_REQUEST_TEMPLATE/**'
+  - '!.github/release-config.txt'
+  - '!.coderabbit.yaml'
+  - '!renovate.json'
+  - '!.gitlab-ci.yml'
+  - '!.gitignore'
+  - '!.tekton/**'
+  - '!doc/**'
+  - '!skills/**'
+  - '!examples/**'
+  - '!hack/staging-debug-tool/**'
+  - '!build/migration-planner-iso/config'

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -7,8 +7,44 @@ on:
   pull_request:
     branches: [main, stable]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  # Path filtering lives here (not on on.pull_request.paths) so this workflow
+  # always runs and required checks are never left pending.
+  # Branch protection should require the "Required e2e" job.
+  # Skip list is shared with pull-request.yml via .github/path-filters.yml.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run-e2e: ${{ steps.set.outputs.run-e2e }}
+    steps:
+      - name: Check out path filters
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Detect whether e2e is needed
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: .github/path-filters.yml
+          predicate-quantifier: 'every'
+
+      - name: Set run-e2e
+        id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run-e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-e2e=${{ steps.filter.outputs.code }}" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
+    if: needs.changes.outputs.run-e2e == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -83,3 +119,28 @@ jobs:
             kubectl describe ${pod} 2>/dev/null || true
             echo "======================="
           done
+
+  # Always runs so branch protection can require this check on docs-only PRs.
+  required:
+    name: Required e2e
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify e2e job
+        env:
+          RUN_E2E: ${{ needs.changes.outputs.run-e2e }}
+          CHANGES: ${{ needs.changes.result }}
+          TEST: ${{ needs.test.result }}
+        run: |
+          echo "changes=$CHANGES run_e2e=$RUN_E2E test=$TEST"
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          [[ "$CHANGES" == success ]] || fail "changes did not succeed ($CHANGES)"
+
+          if [[ "$RUN_E2E" == true ]]; then
+            [[ "$TEST" == success ]] || fail "e2e did not succeed ($TEST)"
+          else
+            echo "Only skippable files changed; e2e was skipped"
+          fi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,10 @@ permissions:
   contents: read
 
 jobs:
-  # Configuration job - define all shared values once
+  # Configuration job - define all shared values once.
+  # Path filtering lives here (not on on.pull_request.paths) so this workflow
+  # always runs and required checks are never left pending.
+  # Branch protection should require the "Required validations" job.
   config:
     runs-on: ubuntu-latest
     outputs:
@@ -19,6 +22,7 @@ jobs:
       jira-pattern: ${{ steps.set-config.outputs.jira-pattern }}
       jira-required-types: ${{ steps.set-config.outputs.jira-required-types }}
       bot-authors: ${{ steps.set-config.outputs.bot-authors }}
+      run-code-validations: ${{ steps.filter.outputs.code }}
     steps:
       - id: set-config
         run: |
@@ -26,6 +30,16 @@ jobs:
           echo 'jira-pattern=ECOPROJECT-[0-9]+' >> $GITHUB_OUTPUT
           echo 'jira-required-types=["feat","fix"]' >> $GITHUB_OUTPUT
           echo 'bot-authors=["red-hat-konflux[bot]","dependabot[bot]","migration-planner-sync[bot]"]' >> $GITHUB_OUTPUT
+
+      - name: Check out path filters
+        uses: actions/checkout@v4
+
+      - name: Detect whether code validations are needed
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: .github/path-filters.yml
+          predicate-quantifier: 'every'
 
   # Validate commit messages
   validate-commits:
@@ -49,7 +63,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: [validate-commits, validate-pr-title]
+    needs: [config, validate-commits, validate-pr-title]
+    if: needs.config.outputs.run-code-validations == 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -75,7 +90,8 @@ jobs:
 
   check-generate:
     runs-on: ubuntu-latest
-    needs: [validate-commits, validate-pr-title]
+    needs: [config, validate-commits, validate-pr-title]
+    if: needs.config.outputs.run-code-validations == 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -99,7 +115,8 @@ jobs:
 
   check-format:
     runs-on: ubuntu-latest
-    needs: [validate-commits, validate-pr-title]
+    needs: [config, validate-commits, validate-pr-title]
+    if: needs.config.outputs.run-code-validations == 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -119,7 +136,8 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
-    needs: [validate-commits, validate-pr-title]
+    needs: [config, validate-commits, validate-pr-title]
+    if: needs.config.outputs.run-code-validations == 'true'
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -146,3 +164,51 @@ jobs:
 
     - name: Run the tests
       run: make unit-test
+
+  # Always runs so branch protection can require this single check.
+  # Do not require lint/unit-test directly if you want docs-only PRs to merge:
+  # those jobs are skipped when only documentation/image files change.
+  # Skipped jobs count as success, but a failed commit check would also skip
+  # them — this job fails unless commit/title checks passed and, when code
+  # changed, the code validations passed.
+  required:
+    name: Required validations
+    needs:
+      - config
+      - validate-commits
+      - validate-pr-title
+      - lint
+      - check-generate
+      - check-format
+      - unit-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          RUN_CODE: ${{ needs.config.outputs.run-code-validations }}
+          CONFIG: ${{ needs.config.result }}
+          COMMITS: ${{ needs.validate-commits.result }}
+          TITLE: ${{ needs.validate-pr-title.result }}
+          LINT: ${{ needs.lint.result }}
+          GENERATE: ${{ needs.check-generate.result }}
+          FORMAT: ${{ needs.check-format.result }}
+          TEST: ${{ needs.unit-test.result }}
+        run: |
+          echo "config=$CONFIG commits=$COMMITS title=$TITLE run_code=$RUN_CODE"
+          echo "lint=$LINT generate=$GENERATE format=$FORMAT test=$TEST"
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          [[ "$CONFIG" == success ]] || fail "config did not succeed ($CONFIG)"
+          [[ "$COMMITS" == success ]] || fail "validate-commits did not succeed ($COMMITS)"
+          [[ "$TITLE" == success ]] || fail "validate-pr-title did not succeed ($TITLE)"
+
+          if [[ "$RUN_CODE" == true ]]; then
+            [[ "$LINT" == success ]] || fail "lint did not succeed ($LINT)"
+            [[ "$GENERATE" == success ]] || fail "check-generate did not succeed ($GENERATE)"
+            [[ "$FORMAT" == success ]] || fail "check-format did not succeed ($FORMAT)"
+            [[ "$TEST" == success ]] || fail "unit-test did not succeed ($TEST)"
+          else
+            echo "Only skippable files changed; code validations were skipped"
+          fi


### PR DESCRIPTION
Keep the workflow running and report a required gate job so branch protection still works. Share the skip list with kind e2e.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Code validation and end-to-end tests now run only when relevant code changes are detected.
  * Documentation, media, and other non-code-only changes can bypass unnecessary test runs.
  * Added consolidated required checks that clearly report whether validation succeeded or was appropriately skipped.
  * Updated workflow permissions to use read-only access where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->