### PR TITLE
ECOPROJECT-5409 | fix: correct FaultToleranceEnabled mapping for vCenter FT states

### DIFF
--- a/pkg/duckdb_parser/ingest_sqlite_test.go
+++ b/pkg/duckdb_parser/ingest_sqlite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kubev2v/migration-planner/pkg/duckdb_parser/models"
 	"github.com/kubev2v/migration-planner/pkg/inventory"
 )
 
@@ -26,12 +27,13 @@ type sqliteCluster struct {
 
 // sqliteVM describes a VM for createTestSQLite.
 type sqliteVM struct {
-	id            string
-	name          string
-	clusterName   string // must match a sqliteCluster.name
-	ipAddress     string // primary IP; defaults to "" when empty
-	nics          string // JSON array; defaults to "[]" when empty
-	guestNetworks string // JSON array; defaults to "[]" when empty
+	id                    string
+	name                  string
+	clusterName           string // must match a sqliteCluster.name
+	ipAddress             string // primary IP; defaults to "" when empty
+	nics                  string // JSON array; defaults to "[]" when empty
+	guestNetworks         string // JSON array; defaults to "[]" when empty
+	faultToleranceEnabled bool
 }
 
 // createTestSQLite builds a minimal forklift SQLite database at a temp path and returns
@@ -146,6 +148,10 @@ func createTestSQLite(t *testing.T, instanceUUID string, clusters []sqliteCluste
 			if guestNetworks == "" {
 				guestNetworks = "[]"
 			}
+			ftEnabled := 0
+			if vm.faultToleranceEnabled {
+				ftEnabled = 1
+			}
 			_, err = db.Exec(fmt.Sprintf(
 				`INSERT INTO dst.VM (
 					ID, Name, Folder, Host, UUID, Firmware, PowerState, ConnectionState,
@@ -156,7 +162,7 @@ func createTestSQLite(t *testing.T, instanceUUID string, clusters []sqliteCluste
 				) VALUES (
 					'%s', '%s', 'folder-1', '%s',
 					'%s', 'bios', 'poweredOn', 'connected',
-					0, 4, 8192, 'rhel', 'rhel', '', '%s',
+					%d, 4, 8192, 'rhel', 'rhel', '', '%s',
 					10737418240, 0, 0, 0, '[]', '%s',
 					0, 0, 2, 0, 0, '[]', '%s'
 				)`,
@@ -164,6 +170,7 @@ func createTestSQLite(t *testing.T, instanceUUID string, clusters []sqliteCluste
 				escapeSQLString(vm.name),
 				escapeSQLString(hostID),
 				escapeSQLString(vm.id+"-uuid"),
+				ftEnabled,
 				escapeSQLString(vm.ipAddress),
 				escapeSQLString(nics),
 				escapeSQLString(guestNetworks),
@@ -475,6 +482,47 @@ func TestIngestSqlite_VHostReadsVMotionFromForklift(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, vmotionSupport, "VMotion support should be true, not hard-coded false")
 	assert.True(t, storageVmotionSupport, "Storage VMotion support should be true, not hard-coded false")
+}
+
+// TestIngestSqlite_FaultToleranceEnabledMapping validates that the agent's
+// FaultToleranceEnabled boolean (0/1) is translated into vCenter FT State
+// vocabulary ('notConfigured'/'enabled') on ingest.
+func TestIngestSqlite_FaultToleranceEnabledMapping(t *testing.T) {
+	ctx := context.Background()
+	parser, db, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	clusters := []sqliteCluster{
+		{id: "domain-c1", name: "cluster1", datacenter: "dc1"},
+	}
+	vms := []sqliteVM{
+		{id: "vm-ft-on", name: "vm-ft-on", clusterName: "cluster1", faultToleranceEnabled: true},
+		{id: "vm-ft-off", name: "vm-ft-off", clusterName: "cluster1", faultToleranceEnabled: false},
+	}
+	sqlitePath := createTestSQLite(t, "vcenter-uuid-ft", clusters, vms)
+
+	result, err := parser.IngestSqlite(ctx, sqlitePath)
+	require.NoError(t, err)
+	require.True(t, result.IsValid())
+
+	var ftState string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT "FT State" FROM vinfo WHERE "VM ID" = 'vm-ft-on'`).Scan(&ftState))
+	assert.Equal(t, "enabled", ftState)
+
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT "FT State" FROM vinfo WHERE "VM ID" = 'vm-ft-off'`).Scan(&ftState))
+	assert.Equal(t, "notConfigured", ftState)
+
+	// End-to-end: predicate must resolve these through the real VMs() query path.
+	vmsOut, err := parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+	vmMap := make(map[string]models.VM)
+	for _, vm := range vmsOut {
+		vmMap[vm.ID] = vm
+	}
+	assert.True(t, vmMap["vm-ft-on"].FaultToleranceEnabled)
+	assert.False(t, vmMap["vm-ft-off"].FaultToleranceEnabled)
 }
 
 func TestIngestSqlite_DatastoreIORMValues(t *testing.T) {

--- a/pkg/duckdb_parser/queries_test.go
+++ b/pkg/duckdb_parser/queries_test.go
@@ -93,3 +93,62 @@ func TestVMs_Labels(t *testing.T) {
 	assert.Equal(t, []string{"test"}, []string(vmMap["vm-002"].Labels), "vm-002 should have one label")
 	assert.Empty(t, vmMap["vm-003"].Labels, "vm-003 should still have empty labels")
 }
+
+// TestVMs_FaultToleranceEnabled validates the FT State → FaultToleranceEnabled predicate.
+// Covers all vCenter FT states: disabled, notConfigured, enabled, running, primary, secondary, starting, needSecondary, and NULL.
+func TestVMs_FaultToleranceEnabled(t *testing.T) {
+	parser, _, cleanup := setupTestParser(t, &testValidator{})
+	defer cleanup()
+
+	vms := []map[string]string{
+		// FT State = 'disabled' (FT was on, now off) → should be false
+		{"VM": "vm-disabled", "VM ID": "vm-001", "VI SDK UUID": "uuid-1", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "disabled"},
+		// FT State = 'notConfigured' (never had FT) → should be false
+		{"VM": "vm-notconfigured", "VM ID": "vm-002", "VI SDK UUID": "uuid-2", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "notConfigured"},
+		// Enabled states (all should be true)
+		{"VM": "vm-enabled", "VM ID": "vm-003", "VI SDK UUID": "uuid-3", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "enabled"},
+		{"VM": "vm-running", "VM ID": "vm-004", "VI SDK UUID": "uuid-4", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "running"},
+		{"VM": "vm-primary", "VM ID": "vm-005", "VI SDK UUID": "uuid-5", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "primary"},
+		{"VM": "vm-secondary", "VM ID": "vm-006", "VI SDK UUID": "uuid-6", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "secondary"},
+		{"VM": "vm-starting", "VM ID": "vm-007", "VI SDK UUID": "uuid-7", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "starting"},
+		{"VM": "vm-needsecondary", "VM ID": "vm-008", "VI SDK UUID": "uuid-8", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": "needSecondary"},
+		// NULL/empty case (no FT State column value) → should be false
+		{"VM": "vm-null", "VM ID": "vm-009", "VI SDK UUID": "uuid-9", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1"},
+		// FT State = '' (empty string value) → should be false
+		{"VM": "vm-empty", "VM ID": "vm-010", "VI SDK UUID": "uuid-10", "Host": "esxi-host-1", "CPUs": "2", "Memory": "4096", "Powerstate": "poweredOn", "Cluster": "cluster1", "Datacenter": "dc1", "FT State": ""},
+	}
+	hosts := []map[string]string{
+		{"Datacenter": "dc1", "Cluster": "cluster1", "# Cores": "8", "# CPU": "2", "Object ID": "host-001", "# Memory": "32768", "Model": "ESXi", "Vendor": "VMware", "Host": "esxi-host-1", "Config status": "green"},
+	}
+
+	tmpFile := createTestExcel(t, defaultStandardSheets(vms, hosts)...)
+
+	ctx := context.Background()
+	_, err := parser.IngestRvTools(ctx, tmpFile)
+	require.NoError(t, err)
+
+	vmsOut, err := parser.VMs(ctx, Filters{}, Options{})
+	require.NoError(t, err)
+	require.Len(t, vmsOut, 10)
+
+	vmMap := make(map[string]models.VM)
+	for _, vm := range vmsOut {
+		vmMap[vm.ID] = vm
+	}
+
+	expected := map[string]bool{
+		"vm-001": false, // disabled → false
+		"vm-002": false, // notConfigured → false
+		"vm-003": true,  // enabled → true
+		"vm-004": true,  // running → true
+		"vm-005": true,  // primary → true
+		"vm-006": true,  // secondary → true
+		"vm-007": true,  // starting → true
+		"vm-008": true,  // needSecondary → true
+		"vm-009": false, // NULL → false
+		"vm-010": false, // empty string → false
+	}
+	for id, want := range expected {
+		assert.Equal(t, want, vmMap[id].FaultToleranceEnabled, "VM %s: FaultToleranceEnabled", id)
+	}
+}

--- a/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
+++ b/pkg/duckdb_parser/templates/ingest_sqlite.go.tmpl
@@ -40,7 +40,7 @@ SELECT
     v.Firmware,
     v.PowerState,
     v.ConnectionState,
-    CASE WHEN v.FaultToleranceEnabled = 1 THEN 'Protected' ELSE 'Not protected' END,
+    CASE WHEN v.FaultToleranceEnabled = 1 THEN 'enabled' ELSE 'notConfigured' END,
     v.CpuCount,
     v.MemoryMB,
     v.GuestName,

--- a/pkg/duckdb_parser/templates/vm_query.go.tmpl
+++ b/pkg/duckdb_parser/templates/vm_query.go.tmpl
@@ -76,7 +76,7 @@ SELECT
     COALESCE(i."Firmware", '') AS "Firmware",
     COALESCE(i."Powerstate", '') AS "PowerState",
     COALESCE(i."Connection state", '') AS "ConnectionState",
-    (i."FT State" IS NOT NULL AND i."FT State" != '' AND i."FT State" != 'notConfigured') AS "FaultToleranceEnabled",
+    COALESCE(i."FT State" IN ('enabled', 'running', 'starting', 'needSecondary', 'primary', 'secondary'), false) AS "FaultToleranceEnabled",
     COALESCE(i."CPUs", 0) AS "CpuCount",
     COALESCE(i."Memory", 0) AS "MemoryMB",
     COALESCE(i."OS according to the configuration file", '') AS "GuestName",


### PR DESCRIPTION
Map only active FT states (enabled, running, starting, needSecondary,
primary, secondary) to true. States disabled and notConfigured, plus
NULL/empty values, now correctly resolve to false. Aligns the SQLite
ingest template to emit vCenter FT state values and adds unit test
coverage for all states.

Signed-off-by: Tal Turjeman <tturjema@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual machine fault-tolerance status reporting with consistent `enabled` and `notConfigured` values.
  - Updated VM queries to recognize only active fault-tolerance states as enabled.
  - Correctly handles disabled, transitional, missing, and unconfigured states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->