### PR TITLE
ci: grant PR approval workflow contents permission

### DIFF
--- a/.github/workflows/pr-approval.yml
+++ b/.github/workflows/pr-approval.yml
@@ -17,3 +17,4 @@ jobs:
       APP_PRIVATE_KEY: ${{ secrets.MIGRATION_PLANNER_REVIEWER_PRIVATE_KEY }}
     permissions:
       pull-requests: write
+      contents: read


### PR DESCRIPTION
Allow the reusable PR approval workflow to request contents read access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation permissions to support read-only repository content access while retaining pull request approval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->