### PR TITLE
ci: fix workspace path for release config file

### DIFF
--- a/.tekton/migration-planner-agent-push.yaml
+++ b/.tekton/migration-planner-agent-push.yaml
@@ -170,7 +170,7 @@ spec:
           image: registry.access.redhat.com/ubi9/ubi-minimal:latest
           script: |
             #!/usr/bin/env sh
-            config="$(workspaces.output.path)/.github/release-config.txt"
+            config="$(workspaces.output.path)/source/.github/release-config.txt"
             test -f "$config" || {
               echo "Missing $config"
               find "$(workspaces.output.path)" -maxdepth 3 -type f | sort

--- a/.tekton/migration-planner-api-push.yaml
+++ b/.tekton/migration-planner-api-push.yaml
@@ -170,7 +170,7 @@ spec:
           image: registry.access.redhat.com/ubi9/ubi-minimal:latest
           script: |
             #!/usr/bin/env sh
-            config="$(workspaces.output.path)/.github/release-config.txt"
+            config="$(workspaces.output.path)/source/.github/release-config.txt"
             test -f "$config" || {
               echo "Missing $config"
               find "$(workspaces.output.path)" -maxdepth 3 -type f | sort

--- a/.tekton/migration-planner-rhcos-iso-push.yaml
+++ b/.tekton/migration-planner-rhcos-iso-push.yaml
@@ -177,7 +177,7 @@ spec:
           image: registry.access.redhat.com/ubi9/ubi-minimal:latest
           script: |
             #!/usr/bin/env sh
-            config="$(workspaces.output.path)/.github/release-config.txt"
+            config="$(workspaces.output.path)/source/.github/release-config.txt"
             test -f "$config" || {
               echo "Missing $config"
               find "$(workspaces.output.path)" -maxdepth 3 -type f | sort


### PR DESCRIPTION
The git-clone task writes files to source/ subdirectory within its output workspace. Updated the read-release-branch task to include /source in the path to correctly locate .github/release-config.txt.

This fixes the build failure where the task was looking for the file at /workspace/output/ instead of /workspace/output/source/.