### PR TITLE
ECOPROJECT-5215 | fix: notification service rejects request without context

### DIFF
--- a/internal/service/eventwrap/event_partner.go
+++ b/internal/service/eventwrap/event_partner.go
@@ -78,7 +78,7 @@ func (e *EventPartnerService) CreateRequest(ctx context.Context, user auth.User,
 			notification.PartnershipRequestEventType,
 			orgID,
 			notification.SeverityImportant,
-			nil,
+			map[string]string{},
 			notification.Recipient{IgnoreUserPreferences: true, Users: users},
 		)
 		if err != nil {

--- a/pkg/events/notification/notification.go
+++ b/pkg/events/notification/notification.go
@@ -19,7 +19,7 @@ type Notification struct {
 	Timestamp   string            `json:"timestamp"`
 	OrgID       string            `json:"org_id"`
 	Severity    string            `json:"severity"`
-	Context     map[string]string `json:"context,omitempty"`
+	Context     map[string]string `json:"context"`
 	Events      []Event           `json:"events"`
 	Recipients  []Recipient       `json:"recipients,omitempty"`
 }
@@ -57,6 +57,11 @@ func New(eventType, orgID, severity string, context map[string]string, payload a
 // Build constructs a Notification for eventType and marshals it to JSON,
 // ready to be stored in the outbox and later dispatched by a Writer.
 func Build(eventType, orgID, severity string, context map[string]string, recipients ...Recipient) ([]byte, error) {
+	// Notification service will reject request (400) with empty context. The minimum is passing an empty context.
+	if context == nil {
+		context = make(map[string]string)
+	}
+
 	notification := New(eventType, orgID, severity, context, make(map[string]string), recipients...)
 
 	if err := notification.validate(); err != nil {


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed partnership request notifications that could fail when no context details were provided.
  - Notifications now send an empty context instead of an invalid empty value, preventing related request errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->