### PR TITLE
chore: add OMA jira project support to PR validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,7 +27,7 @@ jobs:
       - id: set-config
         run: |
           echo 'allowed-types=["feat","fix","ci","build","chore","docs","refactor","test","style","perf"]' >> $GITHUB_OUTPUT
-          echo 'jira-pattern=ECOPROJECT-[0-9]+' >> $GITHUB_OUTPUT
+          echo 'jira-pattern=(ECOPROJECT|OMA)-[0-9]+' >> $GITHUB_OUTPUT
           echo 'jira-required-types=["feat","fix"]' >> $GITHUB_OUTPUT
           echo 'bot-authors=["red-hat-konflux[bot]","dependabot[bot]","migration-planner-sync[bot]"]' >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

Adds support for the OMA Jira project alongside the existing ECOPROJECT project in PR validation workflows.

## Changes

- Updated `jira-pattern` in `.github/workflows/pull-request.yml` from `ECOPROJECT-[0-9]+` to `(ECOPROJECT|OMA)-[0-9]+`

## Impact

PR and commit validation will now accept both:
- ✅ `ECOPROJECT-XXX` (existing)
- ✅ `OMA-XXX` (new)

## Testing

The reusable workflows already support flexible patterns - this change enables both project formats for this repository.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commit and pull request validation now accepts Jira keys in both `ECOPROJECT-<number>` and `OMA-<number>` formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->