### PR TITLE
ECOPROJECT-5480 | fix: disable iam integration

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -85,7 +85,7 @@ parameters:
     value: "notifications.key"
   - name: IAM_ENABLED
     description: Enable IAM integration to resolve user org_id from Red Hat User Service
-    value: "true"
+    value: "false"
   - name: IAM_URL
     description: URL of the Red Hat User Service used to resolve a user's org_id
   - name: IAM_CERT_SECRET_NAME


### PR DESCRIPTION
IAM integration is enabled by default in the template which makes the deployment crash in prod. It should be enabled along with IAM_URL

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * IAM integration is now disabled by default in newly deployed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->